### PR TITLE
Agent harness + Claude Code/Codex/skills integrations (and memory_service repair)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,39 @@ Runnable end-to-end demo: [`agentmem/examples/harness_demo.py`](agentmem/example
 
 ---
 
+## Relationship graph — compliance questions that are inherently relational
+
+Some compliance checks *are* graph queries. Lians stores **bitemporal relationship
+edges** alongside facts — same audit chain, same information barriers, no graph
+database — so you can answer them point-in-time:
+
+- **Legal** — conflict-of-interest reachability (ABA 1.7/1.9): is an attorney
+  connected to an adverse party?
+- **Finance** — related-party / beneficial-ownership (SEC, AML/KYC): is a
+  counterparty within N hops of a restricted entity?
+- **Healthcare** — care-network / referral-pattern (anti-kickback) analysis.
+
+```python
+mem.relate("analyst-1", src_entity="Attorney", rel_type="represented",
+           dst_entity="ClientX", event_time=datetime(2026, 1, 1, tzinfo=timezone.utc))
+mem.relate("analyst-1", src_entity="ClientX", rel_type="adverse_to",
+           dst_entity="PartyY", event_time=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+# Conflict-of-interest check — is there a connection, and through what?
+path = mem.path("analyst-1", src_entity="Attorney", dst_entity="PartyY")
+# → {"connected": True, "hops": 2, "path": [...]}
+
+# Point-in-time: who was connected on the day of the trade?
+mem.neighbors("analyst-1", entity="FundA", depth=2, as_of=datetime(2025, 6, 1, tzinfo=timezone.utc))
+
+# Graph-proximity reranking — boost recalls about entities near an anchor
+mem.recall_near("analyst-1", query="earnings", near_entity="FundA", near_key="ticker")
+```
+
+Endpoints: `POST /v1/graph/relate` · `/v1/graph/unrelate` · `GET /v1/graph/neighbors` · `/v1/graph/path` (all `as_of`-capable). Inspired by [Zep/Graphiti](docs/compare-zep.md), built on our compliance spine.
+
+---
+
 ## Agent integrations — Claude Code, Codex, MCP
 
 Give any coding agent persistent, compliance-grade memory:
@@ -204,7 +237,7 @@ Superseded facts are excluded at the database layer. Every write is recorded in 
 | GDPR crypto-shred with audit survival | ✓ | ✗ | ✗ |
 | Information barriers (DB-layer RLS) | ✓ | ✗ | ✗ |
 
-→ Full benchmark numbers: [docs/benchmark.md](docs/benchmark.md) · Feature-by-feature breakdown: [docs/compare-mem0.md](docs/compare-mem0.md)
+→ Full benchmark numbers: [docs/benchmark.md](docs/benchmark.md) · Feature-by-feature breakdown: [vs mem0](docs/compare-mem0.md) · [vs Zep/Graphiti](docs/compare-zep.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,57 @@ Switch to the hosted server with one line: `from lians import LiansClient as Loc
 
 ---
 
+## Agent harness — drop-in memory loop
+
+`LiansMemoryHarness` wraps the two operations every memory-augmented agent needs —
+recall-before and remember-after — into one object, with the compliance scoping
+(subject, source, event-time, information barrier) regulated deployments require.
+Works with any sync client (`LiansClient` or `LocalLiansClient`) and any model.
+
+```python
+from lians import LiansClient, LiansMemoryHarness
+
+harness = LiansMemoryHarness(mem, agent_id="research-desk", domain="finance")
+
+# One call: recall context, run your model, persist the response.
+answer = harness.run_turn(
+    "What is NVDA's current revenue guidance?",
+    generate=lambda context, query: call_model(f"{context}\n\nUser: {query}"),
+)
+
+# Or control each step:
+context = harness.recall_context("NVDA revenue guidance")   # ready to inject
+harness.remember("Desk note: guidance now $40B")            # write after the turn
+```
+
+Regulated scoping ties every write to one data subject and an information barrier:
+
+```python
+harness = LiansMemoryHarness(
+    mem, agent_id="care-team-3",
+    subject_id="MRN-00042",       # per-subject key — the crypto-shred target
+    barrier_group="oncology",     # information-barrier tag
+    domain="healthcare",
+)
+```
+
+Runnable end-to-end demo: [`agentmem/examples/harness_demo.py`](agentmem/examples/harness_demo.py).
+
+---
+
+## Agent integrations — Claude Code, Codex, MCP
+
+Give any coding agent persistent, compliance-grade memory:
+
+| Host | How |
+|------|-----|
+| **Claude Code** | Plugin with slash commands (`/lians-remember`, `/lians-recall`, `/lians-audit`, `/lians-integrate`) and a compliance subagent — [`integrations/lians-plugin`](integrations/lians-plugin) |
+| **Codex** | Drop-in `AGENTS.md` + MCP config — [`integrations/codex`](integrations/codex) |
+| **Skills standard** | `npx skills add https://github.com/Lians-ai/Lians --skill lians` — works in Claude Code, Codex, Cursor — [`skills/`](skills) |
+| **Any MCP host** | One-time config; eight native memory tools — see [MCP section](#mcp--native-tool-in-any-ai-client) above |
+
+---
+
 ## Why Lians
 
 Financial AI agents accumulate facts that **change over time**: rate decisions supersede prior ones, guidance gets revised, price targets change. Systems like mem0 return all versions with equal rank — your LLM gets contaminated context.
@@ -153,7 +204,7 @@ Superseded facts are excluded at the database layer. Every write is recorded in 
 | GDPR crypto-shred with audit survival | ✓ | ✗ | ✗ |
 | Information barriers (DB-layer RLS) | ✓ | ✗ | ✗ |
 
-→ Full benchmark numbers: [docs/benchmark.md](docs/benchmark.md)
+→ Full benchmark numbers: [docs/benchmark.md](docs/benchmark.md) · Feature-by-feature breakdown: [docs/compare-mem0.md](docs/compare-mem0.md)
 
 ---
 

--- a/agentmem/alembic/versions/0012_relationships.py
+++ b/agentmem/alembic/versions/0012_relationships.py
@@ -1,0 +1,79 @@
+"""relationships graph layer (bitemporal edges + RLS barrier isolation)
+
+Revision ID: 0012_relationships
+Revises: 0011_rls_barriers
+Create Date: 2026-06-29
+
+Adds the ``relationships`` table — a bitemporal knowledge-graph edge store that
+mirrors the temporal/audit/barrier columns of ``memories``. Enables compliance
+graph queries (conflict-of-interest, related-party, care-network) without a
+separate graph database: N-hop traversal runs over Postgres.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+
+revision = "0012_relationships"
+down_revision = "0011_rls_barriers"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_pg = bind.dialect.name == "postgresql"
+    json_type = JSONB if is_pg else sa.JSON
+
+    op.create_table(
+        "relationships",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("namespace", sa.String(), nullable=False),
+        sa.Column("agent_id", sa.String(), nullable=False),
+        sa.Column("src_entity", sa.String(), nullable=False),
+        sa.Column("rel_type", sa.String(), nullable=False),
+        sa.Column("dst_entity", sa.String(), nullable=False),
+        sa.Column("event_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ingestion_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("valid_from", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("valid_to", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("invalidated_by", UUID(as_uuid=True),
+                  sa.ForeignKey("relationships.id"), nullable=True),
+        sa.Column("barrier_group", sa.String(), nullable=True),
+        sa.Column("subject_id", sa.String(), nullable=True),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("metadata", json_type, nullable=False, server_default="{}"),
+        sa.Column("content_hash", sa.String(), nullable=False),
+    )
+    op.create_index("ix_relationships_namespace", "relationships", ["namespace"])
+    op.create_index("ix_relationships_agent_id", "relationships", ["agent_id"])
+    op.create_index("ix_relationships_src_entity", "relationships", ["src_entity"])
+    op.create_index("ix_relationships_dst_entity", "relationships", ["dst_entity"])
+    op.create_index("ix_relationships_rel_type", "relationships", ["rel_type"])
+    op.create_index("ix_relationships_barrier_group", "relationships", ["barrier_group"])
+    op.create_index("ix_relationships_subject_id", "relationships", ["subject_id"])
+    op.create_index("ix_relationships_content_hash", "relationships", ["content_hash"])
+    op.create_index("ix_rel_ns_agent_src", "relationships",
+                    ["namespace", "agent_id", "src_entity"])
+    op.create_index("ix_rel_ns_agent_dst", "relationships",
+                    ["namespace", "agent_id", "dst_entity"])
+
+    if is_pg:
+        # Same barrier-isolation policy as memories/live_facts (migration 0011).
+        op.execute("""
+            ALTER TABLE relationships ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE relationships FORCE ROW LEVEL SECURITY;
+            CREATE POLICY barrier_isolation ON relationships
+                USING (
+                    barrier_group IS NULL
+                    OR current_setting('agentmem.barrier_group', true) IS NULL
+                    OR barrier_group = current_setting('agentmem.barrier_group', true)
+                );
+        """)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP POLICY IF EXISTS barrier_isolation ON relationships;")
+    op.drop_table("relationships")

--- a/agentmem/examples/harness_demo.py
+++ b/agentmem/examples/harness_demo.py
@@ -1,0 +1,92 @@
+"""
+Agent memory harness demo — a complete, runnable memory-augmented agent loop.
+
+Run it::
+
+    pip install lians-sdk[local]
+    python examples/harness_demo.py
+
+This uses LocalLiansClient (in-memory SQLite, zero setup, no API key) and a
+trivial rule-based "model" so the example runs offline. Swap ``fake_model`` for
+a real LLM call (Claude, GPT, etc.) and ``LocalLiansClient`` for ``LiansClient``
+pointed at your server to take it to production unchanged.
+
+What it demonstrates
+--------------------
+1. recall-before / remember-after on every turn (``run_turn``)
+2. supersession: a revised guidance figure replaces the stale one in context
+3. point-in-time recall: "what did we know in September?"
+4. backtest-contamination check: proof the agent held no future knowledge
+"""
+from datetime import datetime, timezone
+
+from lians import LocalLiansClient, LiansMemoryHarness
+
+
+def fake_model(context: str, query: str) -> str:
+    """Stand-in for a real LLM. Echoes the recalled context to show injection."""
+    print("\n--- context injected into the model ---")
+    print(context)
+    print("--- end context ---")
+    # A real agent would reason here; we just acknowledge the turn.
+    if "guidance" in query.lower():
+        return "Acknowledged the latest NVDA guidance; updating the desk note."
+    return "Noted."
+
+
+def main() -> None:
+    with LocalLiansClient() as mem:
+        harness = LiansMemoryHarness(
+            mem,
+            agent_id="research-desk",
+            source="analyst-agent",
+            domain="finance",
+        )
+
+        # Seed two facts about the same metric at different business times.
+        harness.remember(
+            "NVDA FY2026 revenue guidance is $36B",
+            event_time=datetime(2025, 8, 1, tzinfo=timezone.utc),
+            metadata={"ticker": "NVDA", "metric": "revenue_guidance"},
+        )
+        harness.remember(
+            "NVDA FY2026 revenue guidance raised to $40B",
+            event_time=datetime(2025, 11, 19, tzinfo=timezone.utc),
+            metadata={"ticker": "NVDA", "metric": "revenue_guidance"},
+        )
+
+        # A full harnessed turn: recall → model → remember.
+        print("\n========== TURN 1 ==========")
+        answer = harness.run_turn(
+            "What is NVDA's current revenue guidance?",
+            generate=fake_model,
+        )
+        print(f"\nmodel -> {answer}")
+
+        # Present recall shows only the current ($40B) figure — the $36B fact was
+        # superseded and is excluded at the database layer.
+        print("\n========== PRESENT RECALL ==========")
+        for m in harness.recall("NVDA revenue guidance"):
+            print(f"  now: {m.content}")
+
+        # Point-in-time recall reconstructs what was true on Sept 1 ($36B).
+        print("\n========== POINT-IN-TIME (Sept 1, 2025) ==========")
+        for m in harness.recall(
+            "NVDA revenue guidance",
+            as_of=datetime(2025, 9, 1, tzinfo=timezone.utc),
+        ):
+            print(f"  then: {m.content}")
+
+        # Backtest-contamination check: if we simulate as of July 2025, both the
+        # August and November facts are "future knowledge" and get flagged.
+        print("\n========== BACKTEST CHECK (sim as of July 1, 2025) ==========")
+        report = harness.backtest_check(
+            simulation_as_of=datetime(2025, 7, 1, tzinfo=timezone.utc)
+        )
+        print(f"  is_clean: {report['is_clean']}  flags: {len(report['flags'])}")
+        for f in report["flags"]:
+            print(f"    [!] {f['contamination_type']}: {f['content_preview']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agentmem/sdk/python/lians/__init__.py
+++ b/agentmem/sdk/python/lians/__init__.py
@@ -47,6 +47,12 @@ Install with extras::
 from .sync_client import LiansClient
 from .client import AsyncLiansClient
 from .local_client import LocalLiansClient
+from .harness import (
+    LiansMemoryHarness,
+    RecalledMemory,
+    TurnResult,
+    MemoryClient,
+)
 
 # Backward-compatibility aliases
 AgentMemClient = LiansClient
@@ -57,6 +63,11 @@ __all__ = [
     "LiansClient",
     "AsyncLiansClient",
     "LocalLiansClient",
+    # Agent harness
+    "LiansMemoryHarness",
+    "RecalledMemory",
+    "TurnResult",
+    "MemoryClient",
     # aliases
     "AgentMemClient",
     "AsyncAgentMemClient",

--- a/agentmem/sdk/python/lians/client.py
+++ b/agentmem/sdk/python/lians/client.py
@@ -421,6 +421,98 @@ class AsyncLiansClient:
             "simulation_as_of": simulation_as_of.isoformat(),
         })
 
+    # ── Relationship graph ──────────────────────────────────────────────────────
+
+    async def relate(
+        self,
+        agent_id: str,
+        src_entity: str,
+        rel_type: str,
+        dst_entity: str,
+        event_time: datetime,
+        exclusive: bool = False,
+        subject_id: Optional[str] = None,
+        source: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        normalize: bool = False,
+    ) -> dict:
+        """Assert a relationship edge ``src_entity --rel_type--> dst_entity``."""
+        return await self._req("POST", "/v1/graph/relate", json={
+            "agent_id": agent_id, "src_entity": src_entity, "rel_type": rel_type,
+            "dst_entity": dst_entity, "event_time": event_time.isoformat(),
+            "exclusive": exclusive, "subject_id": subject_id, "source": source,
+            "metadata": metadata or {}, "normalize": normalize,
+        })
+
+    async def unrelate(
+        self,
+        agent_id: str,
+        src_entity: str,
+        rel_type: str,
+        dst_entity: str,
+        event_time: Optional[datetime] = None,
+        normalize: bool = False,
+    ) -> dict:
+        """Invalidate a live edge (sets ``valid_to``). Returns ``{"invalidated": N}``."""
+        return await self._req("POST", "/v1/graph/unrelate", json={
+            "agent_id": agent_id, "src_entity": src_entity, "rel_type": rel_type,
+            "dst_entity": dst_entity,
+            "event_time": event_time.isoformat() if event_time else None,
+            "normalize": normalize,
+        })
+
+    async def neighbors(
+        self,
+        agent_id: str,
+        entity: str,
+        depth: int = 1,
+        as_of: Optional[datetime] = None,
+        rel_types: Optional[list[str]] = None,
+        direction: str = "any",
+        normalize: bool = False,
+    ) -> dict:
+        """Entities within ``depth`` hops of ``entity`` (optional point-in-time ``as_of``)."""
+        return await self._req("GET", "/v1/graph/neighbors", params={
+            "entity": entity, "agent_id": agent_id, "depth": depth,
+            "direction": direction, "normalize": normalize,
+            "as_of": as_of.isoformat() if as_of else None,
+            "rel_type": rel_types,
+        })
+
+    async def path(
+        self,
+        agent_id: str,
+        src_entity: str,
+        dst_entity: str,
+        max_depth: int = 4,
+        as_of: Optional[datetime] = None,
+        rel_types: Optional[list[str]] = None,
+        normalize: bool = False,
+    ) -> dict:
+        """Shortest connection between two entities — the COI / related-party query."""
+        return await self._req("GET", "/v1/graph/path", params={
+            "src": src_entity, "dst": dst_entity, "agent_id": agent_id,
+            "max_depth": max_depth, "normalize": normalize,
+            "as_of": as_of.isoformat() if as_of else None,
+            "rel_type": rel_types,
+        })
+
+    async def recall_near(
+        self,
+        agent_id: str,
+        query: str,
+        near_entity: str,
+        near_key: str = "ticker",
+        k: int = 5,
+        as_of: Optional[datetime] = None,
+        filters: Optional[dict] = None,
+    ) -> dict:
+        """Recall with graph-proximity reranking around ``near_entity``."""
+        merged = dict(filters or {})
+        merged["_near_entity"] = near_entity
+        merged["_near_key"] = near_key
+        return await self.recall(agent_id=agent_id, query=query, k=k, as_of=as_of, filters=merged)
+
     # ── Conflicts ──────────────────────────────────────────────────────────────
 
     async def list_conflicts(

--- a/agentmem/sdk/python/lians/harness.py
+++ b/agentmem/sdk/python/lians/harness.py
@@ -382,6 +382,77 @@ class LiansMemoryHarness:
             remembered=remembered,
         )
 
+    # ── Relationship graph ────────────────────────────────────────────────────
+
+    def relate(
+        self,
+        src_entity: str,
+        rel_type: str,
+        dst_entity: str,
+        *,
+        event_time: Optional[datetime] = None,
+        exclusive: bool = False,
+        subject_id: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        normalize: Optional[bool] = None,
+    ) -> dict:
+        """
+        Assert a relationship edge for this agent's graph.
+
+        ``normalize`` defaults to True for the finance domain (so company/ISIN/
+        CUSIP forms collapse to one node) and False otherwise.
+        """
+        self._require("relate")
+        return self.client.relate(  # type: ignore[attr-defined]
+            agent_id=self.agent_id,
+            src_entity=src_entity,
+            rel_type=rel_type,
+            dst_entity=dst_entity,
+            event_time=event_time or _now(),
+            exclusive=exclusive,
+            subject_id=subject_id or self.subject_id,
+            source=self.source,
+            metadata=self._scoped_metadata(metadata),
+            normalize=self.domain == "finance" if normalize is None else normalize,
+        )
+
+    def neighbors(self, entity: str, **kwargs: Any) -> dict:
+        """Entities connected to ``entity`` within N hops (see client.neighbors)."""
+        self._require("neighbors")
+        return self.client.neighbors(agent_id=self.agent_id, entity=entity, **kwargs)  # type: ignore[attr-defined]
+
+    def path(self, src_entity: str, dst_entity: str, **kwargs: Any) -> dict:
+        """Shortest connection between two entities (COI / related-party query)."""
+        self._require("path")
+        return self.client.path(  # type: ignore[attr-defined]
+            agent_id=self.agent_id, src_entity=src_entity, dst_entity=dst_entity, **kwargs
+        )
+
+    def recall_near(
+        self,
+        query: str,
+        near_entity: str,
+        *,
+        near_key: str = "ticker",
+        k: Optional[int] = None,
+        as_of: Optional[datetime] = None,
+    ) -> list[RecalledMemory]:
+        """
+        Recall with graph-proximity reranking — facts about entities near
+        ``near_entity`` in the relationship graph are boosted.
+        """
+        self._require("recall_near")
+        result = self.client.recall_near(  # type: ignore[attr-defined]
+            agent_id=self.agent_id,
+            query=query,
+            near_entity=near_entity,
+            near_key=near_key,
+            k=k if k is not None else self.recall_k,
+            as_of=as_of,
+        )
+        memories = result.get("memories", []) if isinstance(result, dict) else []
+        return [RecalledMemory.from_dict(m) for m in memories]
+
     # ── Compliance pass-throughs ──────────────────────────────────────────────
 
     def snapshot(self, as_of: datetime, **kwargs: Any) -> dict:

--- a/agentmem/sdk/python/lians/harness.py
+++ b/agentmem/sdk/python/lians/harness.py
@@ -1,0 +1,448 @@
+"""
+Lians agent memory harness — a drop-in memory loop for any agent framework.
+
+The harness wraps the two operations every memory-augmented agent needs:
+
+    1. **Recall-before** — fetch the current (non-stale) facts relevant to the
+       turn and format them for injection into the model's context.
+    2. **Remember-after** — persist what the agent learned or decided, with the
+       compliance scoping (subject, source, event-time, importance) that
+       regulated deployments require.
+
+Unlike a raw vector store, the harness inherits Lians' bitemporal model:
+superseded facts are excluded at the database layer, so the context you inject
+is never contaminated by stale revisions. Every write lands in the tamper-evident
+audit chain, and per-subject scoping keeps GDPR/HIPAA crypto-shred intact.
+
+It is deliberately framework-agnostic. It works with any Lians client that
+exposes the shared synchronous surface (``add``, ``recall``, ``recall_at``,
+``add_from_messages``, ``snapshot``, ``backtest_check``, ``erase``) — that means
+``LiansClient`` (hosted/self-hosted), ``LocalLiansClient`` (SQLite), and any
+duck-typed stand-in used in tests.
+
+Quick start::
+
+    from datetime import datetime, timezone
+    from lians import LocalLiansClient
+    from lians.harness import LiansMemoryHarness
+
+    mem = LocalLiansClient()
+    harness = LiansMemoryHarness(mem, agent_id="research-desk")
+
+    def my_llm(prompt: str) -> str:
+        ...  # call any model
+
+    # One call: recall context, run the model, persist the response.
+    answer = harness.run_turn(
+        "What is NVDA's current revenue guidance?",
+        generate=lambda ctx, q: my_llm(f"{ctx}\n\nUser: {q}"),
+    )
+
+Manual control::
+
+    context = harness.recall_context("NVDA revenue guidance")
+    response = my_llm(context + "\n\nUser: ...")
+    harness.remember(response, metadata={"ticker": "NVDA"})
+
+Regulated scoping::
+
+    harness = LiansMemoryHarness(
+        mem,
+        agent_id="care-team-3",
+        subject_id="MRN-00042",        # ties every write to one data subject
+        barrier_group="oncology",      # tags writes for the information barrier
+        source="ehr-agent",
+        domain="healthcare",
+    )
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional, Protocol, Sequence, runtime_checkable
+
+
+# ── Client protocol ───────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class MemoryClient(Protocol):
+    """The subset of the Lians client surface the harness depends on."""
+
+    def add(
+        self,
+        agent_id: str,
+        content: str,
+        event_time: datetime,
+        source: Optional[str] = ...,
+        subject_id: Optional[str] = ...,
+        metadata: Optional[dict[str, Any]] = ...,
+        importance: float = ...,
+    ) -> dict: ...
+
+    def recall(
+        self,
+        agent_id: str,
+        query: str,
+        k: int = ...,
+        as_of: Optional[datetime] = ...,
+        filters: Optional[dict[str, Any]] = ...,
+    ) -> dict: ...
+
+
+# ── Result containers ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RecalledMemory:
+    """A single memory returned by recall, normalized to plain attributes."""
+
+    content: Optional[str]
+    event_time: Optional[str]
+    metadata: dict[str, Any] = field(default_factory=dict)
+    importance: float = 0.5
+    source: Optional[str] = None
+    id: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "RecalledMemory":
+        return cls(
+            content=raw.get("content"),
+            event_time=raw.get("event_time"),
+            metadata=raw.get("metadata") or {},
+            importance=raw.get("importance", 0.5),
+            source=raw.get("source"),
+            id=str(raw["id"]) if raw.get("id") is not None else None,
+        )
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    """Everything a single harnessed turn produced — useful for audit/logging."""
+
+    query: str
+    context: str
+    recalled: list[RecalledMemory]
+    response: Any
+    remembered: Optional[dict] = None
+
+
+# ── Harness ───────────────────────────────────────────────────────────────────
+
+
+class LiansMemoryHarness:
+    """
+    Wraps a Lians client with the recall-before / remember-after agent loop.
+
+    Parameters
+    ----------
+    client:
+        Any Lians client exposing ``add`` and ``recall`` (``LiansClient``,
+        ``AsyncLiansClient`` is *not* supported here — use the sync clients).
+    agent_id:
+        The memory namespace for this agent/session. Required.
+    subject_id:
+        Default data-subject identifier applied to every write (e.g. a patient
+        MRN, a client matter ID, a counterparty). Ties writes to one per-subject
+        encryption key so GDPR/HIPAA crypto-shred can erase exactly this subject.
+    barrier_group:
+        Information-barrier label tagged onto every write's metadata under
+        ``_barrier``. DB-layer Row-Level-Security enforcement is provisioned per
+        agent on the server; this tag makes the intended wall auditable and
+        filterable from the client side.
+    source:
+        Default provenance label for writes (e.g. ``"trading-agent"``).
+    domain:
+        Optional vertical hint (``"finance"`` | ``"healthcare"`` | ``"legal"``)
+        recorded on writes under metadata ``_domain`` for downstream adapters.
+    recall_k:
+        Default number of memories to retrieve per recall.
+    default_importance:
+        Importance score applied to writes when not overridden (0.0–1.0).
+    min_recall_score / min_importance:
+        Reserved filters applied client-side to drop low-value recalls.
+    """
+
+    def __init__(
+        self,
+        client: MemoryClient,
+        *,
+        agent_id: str,
+        subject_id: Optional[str] = None,
+        barrier_group: Optional[str] = None,
+        source: Optional[str] = "agent",
+        domain: Optional[str] = None,
+        recall_k: int = 5,
+        default_importance: float = 0.5,
+    ) -> None:
+        if not agent_id:
+            raise ValueError("agent_id is required")
+        if not (hasattr(client, "add") and hasattr(client, "recall")):
+            raise TypeError(
+                "client must expose `add` and `recall` (use LiansClient or "
+                "LocalLiansClient — AsyncLiansClient is not supported by the harness)"
+            )
+        self.client = client
+        self.agent_id = agent_id
+        self.subject_id = subject_id
+        self.barrier_group = barrier_group
+        self.source = source
+        self.domain = domain
+        self.recall_k = recall_k
+        self.default_importance = default_importance
+
+    # ── Recall ────────────────────────────────────────────────────────────────
+
+    def recall(
+        self,
+        query: str,
+        *,
+        k: Optional[int] = None,
+        as_of: Optional[datetime] = None,
+        filters: Optional[dict[str, Any]] = None,
+    ) -> list[RecalledMemory]:
+        """
+        Return the current (non-stale) memories relevant to ``query``.
+
+        Pass ``as_of`` for point-in-time recall — the compliance query that
+        answers "what did this agent know on date X?" without contamination
+        from facts learned later.
+        """
+        result = self.client.recall(
+            agent_id=self.agent_id,
+            query=query,
+            k=k if k is not None else self.recall_k,
+            as_of=as_of,
+            filters=filters or {},
+        )
+        memories = result.get("memories", []) if isinstance(result, dict) else []
+        return [RecalledMemory.from_dict(m) for m in memories]
+
+    def recall_context(
+        self,
+        query: str,
+        *,
+        k: Optional[int] = None,
+        as_of: Optional[datetime] = None,
+        filters: Optional[dict[str, Any]] = None,
+        header: str = "Relevant facts from memory (most recent, non-stale):",
+        empty_message: str = "(no relevant facts in memory yet)",
+    ) -> str:
+        """
+        Recall and render memories as a context block ready to inject into a prompt.
+
+        The block is plain text — drop it into a system message, a RAG context
+        slot, or straight into the user turn. Each line carries the event time
+        and source so the model can reason about recency and provenance.
+        """
+        memories = self.recall(query, k=k, as_of=as_of, filters=filters)
+        if not memories:
+            return f"{header}\n{empty_message}"
+        lines = [header]
+        for m in memories:
+            if not m.content:
+                continue  # erased (crypto-shredded) — content unrecoverable
+            stamp = _short_time(m.event_time)
+            prov = f" [{m.source}]" if m.source else ""
+            lines.append(f"- ({stamp}){prov} {m.content}")
+        return "\n".join(lines)
+
+    # ── Remember ──────────────────────────────────────────────────────────────
+
+    def remember(
+        self,
+        content: str,
+        *,
+        event_time: Optional[datetime] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        importance: Optional[float] = None,
+        subject_id: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> dict:
+        """
+        Persist a single fact/decision the agent produced.
+
+        Supersession, audit-chain append, and per-subject encryption all happen
+        server-side. ``event_time`` defaults to now; set it to the business time
+        the fact refers to when that differs (critical for point-in-time recall
+        and backtest-contamination checks).
+        """
+        return self.client.add(
+            agent_id=self.agent_id,
+            content=content,
+            event_time=event_time or _now(),
+            source=source or self.source,
+            subject_id=subject_id or self.subject_id,
+            metadata=self._scoped_metadata(metadata),
+            importance=importance if importance is not None else self.default_importance,
+        )
+
+    def remember_messages(
+        self,
+        messages: Sequence[dict[str, Any]],
+        *,
+        event_time: Optional[datetime] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        importance: Optional[float] = None,
+        subject_id: Optional[str] = None,
+        source: Optional[str] = None,
+        roles: Optional[list[str]] = None,
+    ) -> dict:
+        """
+        Extract and persist facts from an OpenAI/LangChain-style message list.
+
+        Only writes messages whose role is in ``roles`` (default: assistant).
+        Requires the client to expose ``add_from_messages`` (all sync Lians
+        clients do); raises ``AttributeError`` otherwise.
+        """
+        if not hasattr(self.client, "add_from_messages"):
+            raise AttributeError(
+                "client does not support add_from_messages; use remember() per-fact"
+            )
+        return self.client.add_from_messages(  # type: ignore[attr-defined]
+            agent_id=self.agent_id,
+            messages=list(messages),
+            event_time=event_time or _now(),
+            source=source or self.source,
+            subject_id=subject_id or self.subject_id,
+            metadata=self._scoped_metadata(metadata),
+            importance=importance if importance is not None else self.default_importance,
+            roles=roles,
+        )
+
+    # ── Combined turn ─────────────────────────────────────────────────────────
+
+    def run_turn(
+        self,
+        query: str,
+        generate: Callable[[str, str], Any],
+        *,
+        k: Optional[int] = None,
+        as_of: Optional[datetime] = None,
+        filters: Optional[dict[str, Any]] = None,
+        remember_response: bool = True,
+        response_metadata: Optional[dict[str, Any]] = None,
+        response_importance: Optional[float] = None,
+        event_time: Optional[datetime] = None,
+    ) -> Any:
+        """
+        Run one full memory-augmented turn and return the model's response.
+
+        Steps: recall context → call ``generate(context, query)`` → persist the
+        response (unless ``remember_response=False``). Use :meth:`turn` instead
+        when you need the full :class:`TurnResult` for audit/logging.
+
+        ``generate`` receives ``(context, query)`` and returns the response. The
+        response is stringified before it is remembered.
+        """
+        return self.turn(
+            query,
+            generate,
+            k=k,
+            as_of=as_of,
+            filters=filters,
+            remember_response=remember_response,
+            response_metadata=response_metadata,
+            response_importance=response_importance,
+            event_time=event_time,
+        ).response
+
+    def turn(
+        self,
+        query: str,
+        generate: Callable[[str, str], Any],
+        *,
+        k: Optional[int] = None,
+        as_of: Optional[datetime] = None,
+        filters: Optional[dict[str, Any]] = None,
+        remember_response: bool = True,
+        response_metadata: Optional[dict[str, Any]] = None,
+        response_importance: Optional[float] = None,
+        event_time: Optional[datetime] = None,
+    ) -> TurnResult:
+        """Run one turn and return a :class:`TurnResult` with full provenance."""
+        recalled = self.recall(query, k=k, as_of=as_of, filters=filters)
+        context = self._render(recalled)
+        response = generate(context, query)
+        remembered: Optional[dict] = None
+        if remember_response:
+            text = response if isinstance(response, str) else str(response)
+            if text.strip():
+                remembered = self.remember(
+                    text,
+                    metadata=response_metadata,
+                    importance=response_importance,
+                    event_time=event_time,
+                )
+        return TurnResult(
+            query=query,
+            context=context,
+            recalled=recalled,
+            response=response,
+            remembered=remembered,
+        )
+
+    # ── Compliance pass-throughs ──────────────────────────────────────────────
+
+    def snapshot(self, as_of: datetime, **kwargs: Any) -> dict:
+        """Full knowledge-state reconstruction at ``as_of`` (audit/regulator demo)."""
+        self._require("snapshot")
+        return self.client.snapshot(agent_id=self.agent_id, as_of=as_of, **kwargs)  # type: ignore[attr-defined]
+
+    def backtest_check(self, simulation_as_of: datetime) -> dict:
+        """Detect lookahead bias — facts the agent held that it couldn't have known."""
+        self._require("backtest_check")
+        return self.client.backtest_check(  # type: ignore[attr-defined]
+            agent_id=self.agent_id, simulation_as_of=simulation_as_of
+        )
+
+    def erase(self, subject_id: Optional[str] = None, *, request_ref: str) -> dict:
+        """GDPR/HIPAA crypto-shred a data subject (defaults to the harness subject)."""
+        self._require("erase")
+        sid = subject_id or self.subject_id
+        if not sid:
+            raise ValueError("no subject_id to erase (set one on the harness or pass it)")
+        return self.client.erase(subject_id=sid, request_ref=request_ref)  # type: ignore[attr-defined]
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _scoped_metadata(self, extra: Optional[dict[str, Any]]) -> dict[str, Any]:
+        meta: dict[str, Any] = dict(extra or {})
+        if self.barrier_group and "_barrier" not in meta:
+            meta["_barrier"] = self.barrier_group
+        if self.domain and "_domain" not in meta:
+            meta["_domain"] = self.domain
+        return meta
+
+    def _render(self, memories: list[RecalledMemory]) -> str:
+        header = "Relevant facts from memory (most recent, non-stale):"
+        if not memories:
+            return f"{header}\n(no relevant facts in memory yet)"
+        lines = [header]
+        for m in memories:
+            if not m.content:
+                continue
+            stamp = _short_time(m.event_time)
+            prov = f" [{m.source}]" if m.source else ""
+            lines.append(f"- ({stamp}){prov} {m.content}")
+        return "\n".join(lines)
+
+    def _require(self, attr: str) -> None:
+        if not hasattr(self.client, attr):
+            raise AttributeError(
+                f"client does not support `{attr}` — use a hosted/local Lians client"
+            )
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _short_time(value: Optional[str]) -> str:
+    if not value:
+        return "undated"
+    # event_time is serialized ISO-8601; keep the date (and time if present)
+    return str(value).replace("T", " ")[:16]

--- a/agentmem/sdk/python/lians/local_client.py
+++ b/agentmem/sdk/python/lians/local_client.py
@@ -645,6 +645,128 @@ class LocalLiansClient:
             "Use AgentMemClient (HTTP) instead of LocalAgentMemClient."
         )
 
+    # â”€â”€ Relationship graph â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    def relate(
+        self,
+        agent_id: str,
+        src_entity: str,
+        rel_type: str,
+        dst_entity: str,
+        event_time: datetime,
+        exclusive: bool = False,
+        subject_id: Optional[str] = None,
+        source: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        normalize: bool = False,
+    ) -> dict:
+        """Assert a relationship edge: ``src_entity --rel_type--> dst_entity``."""
+        return self._run(self._async_relate(
+            agent_id=agent_id, src_entity=src_entity, rel_type=rel_type,
+            dst_entity=dst_entity, event_time=event_time, exclusive=exclusive,
+            subject_id=subject_id, source=source, metadata=metadata or {},
+            normalize=normalize,
+        ))
+
+    async def _async_relate(self, **kwargs) -> dict:
+        from src.lians import graph_service
+        async with self._session_factory() as db:
+            edge = await graph_service.relate(db, self._namespace, **kwargs)
+            return {
+                "id": str(edge.id),
+                "src_entity": edge.src_entity,
+                "rel_type": edge.rel_type,
+                "dst_entity": edge.dst_entity,
+                "event_time": edge.event_time.isoformat(),
+                "valid_to": edge.valid_to.isoformat() if edge.valid_to else None,
+            }
+
+    def unrelate(
+        self,
+        agent_id: str,
+        src_entity: str,
+        rel_type: str,
+        dst_entity: str,
+        event_time: Optional[datetime] = None,
+        normalize: bool = False,
+    ) -> dict:
+        """Invalidate a live edge (sets ``valid_to``). Returns ``{"invalidated": N}``."""
+        return self._run(self._async_unrelate(
+            agent_id=agent_id, src_entity=src_entity, rel_type=rel_type,
+            dst_entity=dst_entity, event_time=event_time, normalize=normalize,
+        ))
+
+    async def _async_unrelate(self, **kwargs) -> dict:
+        from src.lians import graph_service
+        async with self._session_factory() as db:
+            count = await graph_service.unrelate(db, self._namespace, **kwargs)
+            return {"invalidated": count}
+
+    def neighbors(
+        self,
+        agent_id: str,
+        entity: str,
+        depth: int = 1,
+        as_of: Optional[datetime] = None,
+        rel_types: Optional[list[str]] = None,
+        direction: str = "any",
+        normalize: bool = False,
+    ) -> dict:
+        """Entities within ``depth`` hops of ``entity`` (optional point-in-time ``as_of``)."""
+        return self._run(self._async_neighbors(
+            agent_id=agent_id, entity=entity, depth=depth, as_of=as_of,
+            rel_types=rel_types, direction=direction, normalize=normalize,
+        ))
+
+    async def _async_neighbors(self, **kwargs) -> dict:
+        from src.lians import graph_service
+        async with self._session_factory() as db:
+            return await graph_service.neighbors(db, self._namespace, **kwargs)
+
+    def path(
+        self,
+        agent_id: str,
+        src_entity: str,
+        dst_entity: str,
+        max_depth: int = 4,
+        as_of: Optional[datetime] = None,
+        rel_types: Optional[list[str]] = None,
+        normalize: bool = False,
+    ) -> dict:
+        """
+        Shortest connection between two entities â€” the conflict-of-interest /
+        related-party reachability query. ``{"connected": False}`` is the clean result.
+        """
+        return self._run(self._async_path(
+            agent_id=agent_id, src_entity=src_entity, dst_entity=dst_entity,
+            max_depth=max_depth, as_of=as_of, rel_types=rel_types, normalize=normalize,
+        ))
+
+    async def _async_path(self, **kwargs) -> dict:
+        from src.lians import graph_service
+        async with self._session_factory() as db:
+            return await graph_service.path(db, self._namespace, **kwargs)
+
+    def recall_near(
+        self,
+        agent_id: str,
+        query: str,
+        near_entity: str,
+        near_key: str = "ticker",
+        k: int = 5,
+        as_of: Optional[datetime] = None,
+        filters: Optional[dict[str, Any]] = None,
+    ) -> dict:
+        """
+        Recall with graph-proximity reranking: results about entities near
+        ``near_entity`` in the relationship graph are boosted. ``near_key`` is the
+        metadata field holding each memory's entity (default ``ticker``).
+        """
+        merged = dict(filters or {})
+        merged["_near_entity"] = near_entity
+        merged["_near_key"] = near_key
+        return self.recall(agent_id=agent_id, query=query, k=k, as_of=as_of, filters=merged)
+
     def register_webhook(self, *args: Any, **kwargs: Any) -> dict:  # noqa: ARG002
         """Not available in local mode â€” webhooks require an HTTP server."""
         raise NotImplementedError(

--- a/agentmem/sdk/python/lians/local_client.py
+++ b/agentmem/sdk/python/lians/local_client.py
@@ -518,9 +518,33 @@ class LocalLiansClient:
 
     async def _async_backtest_check(self, agent_id: str, simulation_as_of: datetime) -> dict:
         from src.lians.backtest import check_contamination
+        from src.lians.schemas import ContaminationFlagOut, ContaminationReportOut
         async with self._session_factory() as db:
             report = await check_contamination(db, self._namespace, agent_id, simulation_as_of)
-        return report.model_dump(mode="json")
+        # check_contamination returns a plain dataclass; project it onto the
+        # pydantic schema so the dict shape matches the HTTP API exactly.
+        out = ContaminationReportOut(
+            agent_id=report.agent_id,
+            namespace=report.namespace,
+            simulation_as_of=report.simulation_as_of,
+            memories_checked=report.memories_checked,
+            flags=[
+                ContaminationFlagOut(
+                    memory_id=f.memory_id,
+                    event_time=f.event_time,
+                    ingestion_time=f.ingestion_time,
+                    contamination_type=f.contamination_type,
+                    delta_days=f.delta_days,
+                    content_preview=f.content_preview,
+                    source=f.source,
+                    metadata=f.metadata,
+                )
+                for f in report.flags
+            ],
+            contamination_rate=report.contamination_rate,
+            is_clean=report.is_clean,
+        )
+        return out.model_dump(mode="json")
 
     def list_conflicts(
         self,

--- a/agentmem/sdk/python/lians/sync_client.py
+++ b/agentmem/sdk/python/lians/sync_client.py
@@ -317,6 +317,50 @@ class LiansClient:
             self._async.backtest_check(agent_id=agent_id, simulation_as_of=simulation_as_of)
         )
 
+    # ── Relationship graph ──────────────────────────────────────────────────────
+
+    def relate(self, agent_id, src_entity, rel_type, dst_entity, event_time,
+               exclusive=False, subject_id=None, source=None, metadata=None,
+               normalize=False) -> dict:
+        """Assert a relationship edge ``src_entity --rel_type--> dst_entity``."""
+        return self._loop.run_until_complete(self._async.relate(
+            agent_id=agent_id, src_entity=src_entity, rel_type=rel_type,
+            dst_entity=dst_entity, event_time=event_time, exclusive=exclusive,
+            subject_id=subject_id, source=source, metadata=metadata, normalize=normalize,
+        ))
+
+    def unrelate(self, agent_id, src_entity, rel_type, dst_entity,
+                 event_time=None, normalize=False) -> dict:
+        """Invalidate a live edge (sets ``valid_to``)."""
+        return self._loop.run_until_complete(self._async.unrelate(
+            agent_id=agent_id, src_entity=src_entity, rel_type=rel_type,
+            dst_entity=dst_entity, event_time=event_time, normalize=normalize,
+        ))
+
+    def neighbors(self, agent_id, entity, depth=1, as_of=None, rel_types=None,
+                  direction="any", normalize=False) -> dict:
+        """Entities within ``depth`` hops of ``entity`` (optional ``as_of``)."""
+        return self._loop.run_until_complete(self._async.neighbors(
+            agent_id=agent_id, entity=entity, depth=depth, as_of=as_of,
+            rel_types=rel_types, direction=direction, normalize=normalize,
+        ))
+
+    def path(self, agent_id, src_entity, dst_entity, max_depth=4, as_of=None,
+             rel_types=None, normalize=False) -> dict:
+        """Shortest connection between two entities — the COI / related-party query."""
+        return self._loop.run_until_complete(self._async.path(
+            agent_id=agent_id, src_entity=src_entity, dst_entity=dst_entity,
+            max_depth=max_depth, as_of=as_of, rel_types=rel_types, normalize=normalize,
+        ))
+
+    def recall_near(self, agent_id, query, near_entity, near_key="ticker",
+                    k=5, as_of=None, filters=None) -> dict:
+        """Recall with graph-proximity reranking around ``near_entity``."""
+        return self._loop.run_until_complete(self._async.recall_near(
+            agent_id=agent_id, query=query, near_entity=near_entity,
+            near_key=near_key, k=k, as_of=as_of, filters=filters,
+        ))
+
     # ── Conflicts ──────────────────────────────────────────────────────────────
 
     def list_conflicts(

--- a/agentmem/src/lians/api/routes_graph.py
+++ b/agentmem/src/lians/api/routes_graph.py
@@ -1,0 +1,122 @@
+"""
+Relationship-graph routes — the knowledge-graph layer.
+
+    POST /v1/graph/relate      — assert an edge (src --rel_type--> dst)
+    POST /v1/graph/unrelate    — invalidate a live edge (sets valid_to)
+    GET  /v1/graph/neighbors   — entities within N hops (optional as_of)
+    GET  /v1/graph/path        — shortest connection between two entities
+
+The path query is the conflict-of-interest / related-party / referral-reachability
+question; every read accepts ``as_of`` for point-in-time traversal. Edges live in
+the same audit chain and information barrier as memories.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_db
+from ..schemas import (
+    RelateRequest, UnrelateRequest, RelateResult, NeighborsResult, PathResult,
+)
+from .. import graph_service
+from .deps import get_auth, AuthContext
+
+router = APIRouter(prefix="/v1/graph", tags=["graph"])
+
+
+@router.post("/relate", response_model=RelateResult)
+async def relate(
+    req: RelateRequest,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    auth.require("write")
+    edge = await graph_service.relate(
+        db, auth.namespace,
+        agent_id=req.agent_id,
+        src_entity=req.src_entity,
+        rel_type=req.rel_type,
+        dst_entity=req.dst_entity,
+        event_time=req.event_time,
+        exclusive=req.exclusive,
+        subject_id=req.subject_id,
+        source=req.source,
+        metadata=req.metadata,
+        normalize=req.normalize,
+    )
+    return RelateResult(
+        id=edge.id,
+        src_entity=edge.src_entity,
+        rel_type=edge.rel_type,
+        dst_entity=edge.dst_entity,
+        event_time=edge.event_time,
+        valid_to=edge.valid_to,
+    )
+
+
+@router.post("/unrelate")
+async def unrelate(
+    req: UnrelateRequest,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    auth.require("write")
+    count = await graph_service.unrelate(
+        db, auth.namespace,
+        agent_id=req.agent_id,
+        src_entity=req.src_entity,
+        rel_type=req.rel_type,
+        dst_entity=req.dst_entity,
+        event_time=req.event_time,
+        normalize=req.normalize,
+    )
+    return {"invalidated": count}
+
+
+@router.get("/neighbors", response_model=NeighborsResult)
+async def neighbors(
+    entity: str = Query(..., description="Entity to expand from"),
+    agent_id: str = Query(...),
+    depth: int = Query(1, ge=1, le=6),
+    direction: str = Query("any", pattern="^(any|in|out)$"),
+    as_of: Optional[datetime] = Query(None, description="Point-in-time traversal"),
+    rel_type: Optional[list[str]] = Query(None, description="Restrict to these relationship types"),
+    normalize: bool = Query(False),
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    auth.require("read")
+    result = await graph_service.neighbors(
+        db, auth.namespace, agent_id, entity,
+        depth=depth, as_of=as_of, rel_types=rel_type,
+        direction=direction, normalize=normalize,
+    )
+    return NeighborsResult(**result)
+
+
+@router.get("/path", response_model=PathResult)
+async def path(
+    src: str = Query(..., description="Source entity"),
+    dst: str = Query(..., description="Destination entity"),
+    agent_id: str = Query(...),
+    max_depth: int = Query(4, ge=1, le=8),
+    as_of: Optional[datetime] = Query(None),
+    rel_type: Optional[list[str]] = Query(None),
+    normalize: bool = Query(False),
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Shortest connection between two entities — the conflict-of-interest /
+    related-party reachability query. ``connected: false`` is the clean result.
+    """
+    auth.require("read")
+    result = await graph_service.path(
+        db, auth.namespace, agent_id, src, dst,
+        max_depth=max_depth, as_of=as_of, rel_types=rel_type, normalize=normalize,
+    )
+    return PathResult(**result)

--- a/agentmem/src/lians/backtest.py
+++ b/agentmem/src/lians/backtest.py
@@ -35,7 +35,8 @@ from sqlalchemy import select, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import Memory
-from .memory_service import _memory_to_out, _decrypt_memory_content, _resolve_subject_key
+from .memory_service import _memory_to_out, _resolve_subject_key
+from .ranking import _decrypt as _decrypt_memory_content
 
 
 FUTURE_EVENT = "future_event"

--- a/agentmem/src/lians/graph_service.py
+++ b/agentmem/src/lians/graph_service.py
@@ -1,0 +1,424 @@
+"""
+Relationship graph service — the bitemporal knowledge-graph layer.
+
+Stores directed ``src --rel_type--> dst`` edges with the same temporal, audit, and
+information-barrier guarantees as memories, and answers the relational compliance
+questions atomic facts can't:
+
+    neighbors(entity)      — who/what is connected to this entity (N hops)
+    path(src, dst)         — is there a connection, and through what? (COI /
+                             related-party / referral reachability)
+
+All reads accept ``as_of`` for point-in-time traversal — "who was connected on the
+day of the trade?" — the same temporal guarantee Lians gives for facts, now for
+relationships. Traversal runs in-process over the namespace's edges (no graph DB);
+for very large graphs this can move to recursive SQL later without an API change.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import deque
+from datetime import datetime, timezone
+from typing import Any, Optional
+from uuid import UUID
+
+from sqlalchemy import select, and_, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import Relationship
+from .audit_chain import chain_log
+from .entity_normalizer import cached_normalize
+
+
+# ── Canonicalization ────────────────────────────────────────────────────────────
+
+
+def canon_entity(value: str, *, normalize: bool = False) -> str:
+    """
+    Canonical form of an entity label used for dedup and traversal.
+
+    Always collapses surrounding/internal whitespace. When ``normalize`` is set,
+    routes through the domain entity normalizer so 'Apple Inc.', 'AAPL', and ISIN
+    'US0378331005' resolve to one graph node (finance). Off by default so person /
+    party / matter names are preserved verbatim.
+    """
+    collapsed = " ".join(str(value).split())
+    if normalize:
+        return cached_normalize("entity", collapsed)
+    return collapsed
+
+
+def _rel_hash(src: str, rel_type: str, dst: str, event_time: datetime) -> str:
+    raw = f"{src}|{rel_type}|{dst}|{event_time.isoformat()}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _aware(dt: Optional[datetime]) -> Optional[datetime]:
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _is_valid_at(edge: Relationship, as_of: Optional[datetime]) -> bool:
+    """True if the edge was live at ``as_of`` (or currently live when as_of is None)."""
+    if as_of is None:
+        return edge.valid_to is None
+    vf = _aware(edge.valid_from)
+    vt = _aware(edge.valid_to)
+    aso = _aware(as_of)
+    return vf <= aso and (vt is None or vt > aso)
+
+
+# ── Write ───────────────────────────────────────────────────────────────────────
+
+
+async def relate(
+    db: AsyncSession,
+    namespace: str,
+    *,
+    agent_id: str,
+    src_entity: str,
+    rel_type: str,
+    dst_entity: str,
+    event_time: datetime,
+    exclusive: bool = False,
+    subject_id: Optional[str] = None,
+    source: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    normalize: bool = False,
+) -> Relationship:
+    """
+    Assert a relationship edge.
+
+    Idempotent: re-asserting an identical live triplet returns the existing edge.
+    When ``exclusive`` is set, asserting ``src --rel_type--> X`` invalidates any
+    other live ``src --rel_type--> Y`` (Y != X) — the deterministic equivalent of
+    Graphiti's contradiction-driven invalidation, e.g. a person's current employer.
+    """
+    from .memory_service import _get_barrier_group
+
+    src = canon_entity(src_entity, normalize=normalize)
+    dst = canon_entity(dst_entity, normalize=normalize)
+    rel = rel_type.strip()
+
+    # Idempotent: identical live edge already exists.
+    existing = (await db.execute(
+        select(Relationship).where(and_(
+            Relationship.namespace == namespace,
+            Relationship.agent_id == agent_id,
+            Relationship.src_entity == src,
+            Relationship.rel_type == rel,
+            Relationship.dst_entity == dst,
+            Relationship.valid_to.is_(None),
+        ))
+    )).scalars().first()
+    if existing is not None:
+        return existing
+
+    barrier_group = await _get_barrier_group(db, namespace, agent_id)
+    now = datetime.now(timezone.utc)
+
+    edge = Relationship(
+        namespace=namespace,
+        agent_id=agent_id,
+        src_entity=src,
+        rel_type=rel,
+        dst_entity=dst,
+        event_time=event_time,
+        ingestion_time=now,
+        valid_from=event_time,
+        valid_to=None,
+        barrier_group=barrier_group,
+        subject_id=subject_id,
+        source=source,
+        metadata_=metadata or {},
+        content_hash=_rel_hash(src, rel, dst, event_time),
+    )
+    db.add(edge)
+    await db.flush()
+
+    if exclusive:
+        superseded = (await db.execute(
+            select(Relationship).where(and_(
+                Relationship.namespace == namespace,
+                Relationship.agent_id == agent_id,
+                Relationship.src_entity == src,
+                Relationship.rel_type == rel,
+                Relationship.dst_entity != dst,
+                Relationship.valid_to.is_(None),
+            ))
+        )).scalars().all()
+        for old in superseded:
+            old.valid_to = event_time
+            old.invalidated_by = edge.id
+            await _log_invalidation(db, namespace, old, reason="exclusive_supersede")
+
+    await chain_log(
+        db, namespace=namespace, agent_id=agent_id,
+        op="relate", memory_id=edge.id, content_hash=edge.content_hash,
+        payload={"src": src, "rel_type": rel, "dst": dst,
+                 "event_time": event_time.isoformat(), "exclusive": exclusive},
+    )
+    await db.commit()
+    await db.refresh(edge)
+    return edge
+
+
+async def unrelate(
+    db: AsyncSession,
+    namespace: str,
+    *,
+    agent_id: str,
+    src_entity: str,
+    rel_type: str,
+    dst_entity: str,
+    event_time: Optional[datetime] = None,
+    normalize: bool = False,
+) -> int:
+    """
+    Invalidate a live edge (set ``valid_to``) — Graphiti's ``invalid_at``.
+
+    The edge is preserved for point-in-time traversal and audit; it simply drops
+    out of present-time queries. Returns the number of edges invalidated (0 or 1).
+    """
+    src = canon_entity(src_entity, normalize=normalize)
+    dst = canon_entity(dst_entity, normalize=normalize)
+    rel = rel_type.strip()
+    when = event_time or datetime.now(timezone.utc)
+
+    edge = (await db.execute(
+        select(Relationship).where(and_(
+            Relationship.namespace == namespace,
+            Relationship.agent_id == agent_id,
+            Relationship.src_entity == src,
+            Relationship.rel_type == rel,
+            Relationship.dst_entity == dst,
+            Relationship.valid_to.is_(None),
+        ))
+    )).scalars().first()
+    if edge is None:
+        return 0
+
+    edge.valid_to = when
+    await _log_invalidation(db, namespace, edge, reason="unrelate")
+    await db.commit()
+    return 1
+
+
+async def _log_invalidation(db: AsyncSession, namespace: str, edge: Relationship, *, reason: str) -> None:
+    await chain_log(
+        db, namespace=namespace, agent_id=edge.agent_id,
+        op="unrelate", memory_id=edge.id, content_hash=edge.content_hash,
+        payload={"src": edge.src_entity, "rel_type": edge.rel_type,
+                 "dst": edge.dst_entity, "reason": reason},
+    )
+    from .webhook_service import dispatch_event, RELATIONSHIP_INVALIDATED
+    await dispatch_event(db, namespace, RELATIONSHIP_INVALIDATED, {
+        "agent_id": edge.agent_id,
+        "edge_id": str(edge.id),
+        "src": edge.src_entity,
+        "rel_type": edge.rel_type,
+        "dst": edge.dst_entity,
+        "reason": reason,
+    })
+
+
+# ── Read / traversal ────────────────────────────────────────────────────────────
+
+
+async def _live_edges(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    as_of: Optional[datetime],
+    rel_types: Optional[list[str]] = None,
+) -> list[Relationship]:
+    conds = [Relationship.namespace == namespace, Relationship.agent_id == agent_id]
+    if as_of is None:
+        conds.append(Relationship.valid_to.is_(None))
+    if rel_types:
+        conds.append(Relationship.rel_type.in_(rel_types))
+    rows = (await db.execute(select(Relationship).where(and_(*conds)))).scalars().all()
+    if as_of is None:
+        return list(rows)
+    # Point-in-time validity is compared in Python to dodge SQLite naive-datetime
+    # pitfalls; the namespace+agent edge set is bounded.
+    return [e for e in rows if _is_valid_at(e, as_of)]
+
+
+def _adjacency(edges: list[Relationship], direction: str) -> dict[str, list[Relationship]]:
+    """Map each entity to the edges leaving it under the chosen direction semantics."""
+    adj: dict[str, list[Relationship]] = {}
+    for e in edges:
+        if direction in ("out", "any"):
+            adj.setdefault(e.src_entity, []).append(e)
+        if direction in ("in", "any"):
+            adj.setdefault(e.dst_entity, []).append(e)
+    return adj
+
+
+def _other_end(edge: Relationship, current: str) -> str:
+    return edge.dst_entity if edge.src_entity == current else edge.src_entity
+
+
+async def neighbors(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    entity: str,
+    *,
+    depth: int = 1,
+    as_of: Optional[datetime] = None,
+    rel_types: Optional[list[str]] = None,
+    direction: str = "any",
+    normalize: bool = False,
+) -> dict[str, Any]:
+    """
+    Return entities reachable from ``entity`` within ``depth`` hops.
+
+    ``direction``: ``out`` follows src→dst, ``in`` follows dst→src, ``any`` (default)
+    treats edges as undirected — the right default for COI / related-party reach.
+    Each neighbor is returned with its shortest hop distance; the edges traversed
+    at the first hop are included for context.
+    """
+    start = canon_entity(entity, normalize=normalize)
+    edges = await _live_edges(db, namespace, agent_id, as_of, rel_types)
+    adj = _adjacency(edges, direction)
+
+    dist: dict[str, int] = {start: 0}
+    q: deque[str] = deque([start])
+    while q:
+        node = q.popleft()
+        if dist[node] >= depth:
+            continue
+        for edge in adj.get(node, []):
+            nxt = _other_end(edge, node)
+            if nxt not in dist:
+                dist[nxt] = dist[node] + 1
+                q.append(nxt)
+
+    neighbor_list = [
+        {"entity": e, "depth": d}
+        for e, d in sorted(dist.items(), key=lambda kv: (kv[1], kv[0]))
+        if e != start
+    ]
+    direct = [_edge_dict(e) for e in adj.get(start, [])]
+    return {
+        "entity": start,
+        "depth": depth,
+        "as_of": as_of.isoformat() if as_of else None,
+        "neighbors": neighbor_list,
+        "direct_edges": direct,
+    }
+
+
+async def path(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    src_entity: str,
+    dst_entity: str,
+    *,
+    max_depth: int = 4,
+    as_of: Optional[datetime] = None,
+    rel_types: Optional[list[str]] = None,
+    normalize: bool = False,
+) -> dict[str, Any]:
+    """
+    Shortest connection between two entities — the conflict-of-interest /
+    related-party query. Returns the chain of edges linking ``src`` to ``dst``
+    (empty when unconnected within ``max_depth``). Treats edges as undirected.
+    """
+    src = canon_entity(src_entity, normalize=normalize)
+    dst = canon_entity(dst_entity, normalize=normalize)
+    edges = await _live_edges(db, namespace, agent_id, as_of, rel_types)
+    adj = _adjacency(edges, "any")
+
+    # BFS tracking the edge used to reach each node, to reconstruct the trail.
+    prev: dict[str, tuple[str, Relationship]] = {}
+    seen = {src}
+    q: deque[tuple[str, int]] = deque([(src, 0)])
+    found = src == dst
+    while q and not found:
+        node, d = q.popleft()
+        if d >= max_depth:
+            continue
+        for edge in adj.get(node, []):
+            nxt = _other_end(edge, node)
+            if nxt not in seen:
+                seen.add(nxt)
+                prev[nxt] = (node, edge)
+                if nxt == dst:
+                    found = True
+                    break
+                q.append((nxt, d + 1))
+
+    trail: list[dict] = []
+    if found and src != dst:
+        cur = dst
+        while cur != src:
+            node, edge = prev[cur]
+            trail.append(_edge_dict(edge))
+            cur = node
+        trail.reverse()
+
+    return {
+        "src": src,
+        "dst": dst,
+        "connected": found,
+        "hops": len(trail),
+        "as_of": as_of.isoformat() if as_of else None,
+        "path": trail,
+    }
+
+
+async def entity_distances(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    anchor: str,
+    candidates: set[str],
+    *,
+    max_depth: int = 3,
+    as_of: Optional[datetime] = None,
+    normalize: bool = False,
+) -> dict[str, int]:
+    """
+    Graph hop-distance from ``anchor`` to each candidate entity (BFS, undirected).
+
+    Unreachable candidates are omitted. Used by graph-proximity reranking to boost
+    facts about entities near the query's anchor entity.
+    """
+    start = canon_entity(anchor, normalize=normalize)
+    wanted = {canon_entity(c, normalize=normalize) for c in candidates}
+    edges = await _live_edges(db, namespace, agent_id, as_of)
+    adj = _adjacency(edges, "any")
+
+    dist: dict[str, int] = {start: 0}
+    q: deque[str] = deque([start])
+    out: dict[str, int] = {}
+    while q:
+        node = q.popleft()
+        if node in wanted:
+            out[node] = dist[node]
+        if dist[node] >= max_depth:
+            continue
+        for edge in adj.get(node, []):
+            nxt = _other_end(edge, node)
+            if nxt not in dist:
+                dist[nxt] = dist[node] + 1
+                q.append(nxt)
+    return out
+
+
+def _edge_dict(e: Relationship) -> dict[str, Any]:
+    return {
+        "id": str(e.id),
+        "src": e.src_entity,
+        "rel_type": e.rel_type,
+        "dst": e.dst_entity,
+        "event_time": e.event_time.isoformat() if e.event_time else None,
+        "valid_to": e.valid_to.isoformat() if e.valid_to else None,
+        "source": e.source,
+        "metadata": dict(e.metadata_ or {}),
+    }

--- a/agentmem/src/lians/main.py
+++ b/agentmem/src/lians/main.py
@@ -21,6 +21,7 @@ from .api.routes_webhooks import router as webhooks_router
 from .api.routes_compliance import router as compliance_router
 from .api.routes_backtest import router as backtest_router
 from .api.routes_snapshot import router as snapshot_router
+from .api.routes_graph import router as graph_router
 from .telemetry import instrument_fastapi, instrument_sqlalchemy
 from .middleware import (
     setup_logging,
@@ -222,6 +223,7 @@ app.include_router(webhooks_router)
 app.include_router(compliance_router)
 app.include_router(backtest_router)
 app.include_router(snapshot_router)
+app.include_router(graph_router)
 app.include_router(metrics_router)
 
 

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -349,8 +349,17 @@ async def recall_memories(
 
         settings = get_settings()
 
+        # Graph-proximity reranking (opt-in via filters). Pull the anchor params
+        # out of `filters` BEFORE they reach the metadata matcher, and bypass the
+        # recall cache when present (results depend on the live graph).
+        near_entity: Optional[str] = None
+        near_key = "ticker"
+        if req.filters:
+            near_entity = req.filters.pop("_near_entity", None)
+            near_key = req.filters.pop("_near_key", "ticker")
+
         # Hot cache (Redis)
-        if settings.recall_cache_enabled and not req.as_of:
+        if settings.recall_cache_enabled and not req.as_of and not near_entity:
             cached = await get_cached_recall(
                 namespace, req.agent_id, req.query, req.as_of, req.k, req.filters
             )
@@ -433,6 +442,14 @@ async def recall_memories(
 
         span.set_attribute("result_count", len(results))
 
+        # Graph-proximity reranking: boost results whose entity sits near the
+        # anchor entity in the relationship graph (Graphiti-style node-distance).
+        if near_entity and results:
+            results = await _rerank_by_proximity(
+                db, namespace, req.agent_id, near_entity, near_key, results, req.as_of
+            )
+            span.set_attribute("graph_rerank", True)
+
         # hybrid_recall always returns Memory objects (Change 1 fetch-back ensures this)
         with tracer.start_as_current_span("recall.assemble"):
             memories_out: list[MemoryOut] = [
@@ -466,7 +483,7 @@ async def recall_memories(
                 customer_id, 1, f"r:{recall_log.id}",
             )
 
-        if settings.recall_cache_enabled and not req.as_of:
+        if settings.recall_cache_enabled and not req.as_of and not near_entity:
             await set_cached_recall(
                 namespace, req.agent_id, req.query, req.as_of, req.k, req.filters,
                 result.model_dump_json(),
@@ -476,6 +493,47 @@ async def recall_memories(
         record_recall(namespace, router="semantic", cache_hit=False)
         observe_recall(namespace, _time.perf_counter() - _recall_t0)
         return result
+
+
+async def _rerank_by_proximity(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    anchor: str,
+    near_key: str,
+    results: list,
+    as_of: Optional[datetime],
+) -> list:
+    """
+    Reorder recall results by graph proximity to ``anchor``.
+
+    Each result's entity is read from metadata[``near_key``]; its hop-distance to
+    the anchor in the relationship graph yields an additive proximity bonus
+    (1/(1+distance)), so closely-connected facts rise without displacing strong
+    semantic matches. Unreachable entities get no bonus — pure semantic order.
+    """
+    from .graph_service import entity_distances, canon_entity
+
+    candidates: set[str] = set()
+    for mem, _score, _content in results:
+        val = (mem.metadata_ or {}).get(near_key)
+        if val:
+            candidates.add(str(val))
+    if not candidates:
+        return results
+
+    distances = await entity_distances(
+        db, namespace, agent_id, anchor, candidates, as_of=as_of
+    )
+
+    def _key(item):
+        mem, score, _content = item
+        val = (mem.metadata_ or {}).get(near_key)
+        dist = distances.get(canon_entity(str(val))) if val else None
+        bonus = 1.0 / (1.0 + dist) if dist is not None else 0.0
+        return score + bonus
+
+    return sorted(results, key=_key, reverse=True)
 
 
 def _fire_recall_audit(db: AsyncSession, namespace: str, req: RecallRequest, memories: list) -> None:

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -18,12 +18,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 from uuid import UUID
 
-from sqlalchemy import select, and_, update, text, cast, Float
+from sqlalchemy import select, and_, or_, update, text, cast, Float
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import time as _time
 
-from .models import Memory, EventLog, SubjectKey, AgentBarrierGroup, NamespacePolicy
+from .models import Memory, EventLog, SubjectKey, AgentBarrierGroup, NamespacePolicy, ConflictFlag
 from .audit_chain import chain_log
 from .telemetry import tracer
 from .metrics import record_write, observe_add, record_recall, observe_recall, record_erase
@@ -34,6 +34,7 @@ from .schemas import (
     SupersessionAction, SupersessionActionResult,
     RetentionPolicyIn, RetentionPolicyOut, RetentionPruneResult,
     LineageNode, LineageEdge, MemoryLineageResult,
+    ConflictFlagOut, ConflictListResult, ConflictResolveRequest, ConflictResolveResult,
 )
 from .embeddings import get_embedding_provider
 from .crypto import encrypt_content, decrypt_content, unwrap_subject_key
@@ -250,6 +251,30 @@ async def add_memory(
                         },
                     )
 
+            # Same-time contradiction: persist a ConflictFlag for human review.
+            # Both memories stay live (neither superseded) until someone resolves it.
+            for conflict_old_id in supersession.conflict_ids:
+                flag = ConflictFlag(
+                    namespace=namespace,
+                    agent_id=req.agent_id,
+                    memory_a_id=conflict_old_id,   # pre-existing memory
+                    memory_b_id=mem.id,            # newly ingested memory
+                    confidence=supersession.confidence,
+                    status="open",
+                )
+                db.add(flag)
+                await chain_log(
+                    db, namespace=namespace, agent_id=req.agent_id,
+                    op="conflict_detected", memory_id=mem.id,
+                    content_hash=mem.content_hash,
+                    payload={
+                        "memory_a_id": str(conflict_old_id),
+                        "memory_b_id": str(mem.id),
+                        "confidence": supersession.confidence,
+                        "relation": supersession.relation,
+                    },
+                )
+
             # Change 1: maintain live_facts projection
             await remove_live_facts(db, supersession.superseded_ids)
             await upsert_live_fact(db, mem, predicate_key)
@@ -266,6 +291,25 @@ async def add_memory(
                     "supersession_confidence": supersession.confidence,
                 },
             )
+
+            # Fan out webhook events for the write outcome. dispatch_event is a
+            # no-op when no endpoint subscribes, so this is safe on every write.
+            from .webhook_service import dispatch_event, MEMORY_SUPERSEDED, MEMORY_CONFLICT
+            if supersession.superseded_ids:
+                await dispatch_event(db, namespace, MEMORY_SUPERSEDED, {
+                    "agent_id": req.agent_id,
+                    "new_memory_id": str(mem.id),
+                    "superseded_ids": [str(i) for i in supersession.superseded_ids],
+                    "relation": supersession.relation,
+                    "confidence": supersession.confidence,
+                })
+            if supersession.conflict_ids:
+                await dispatch_event(db, namespace, MEMORY_CONFLICT, {
+                    "agent_id": req.agent_id,
+                    "new_memory_id": str(mem.id),
+                    "conflict_ids": [str(i) for i in supersession.conflict_ids],
+                    "confidence": supersession.confidence,
+                })
 
             await db.commit()
 
@@ -669,6 +713,15 @@ async def erase_subject(
         )
 
     await destroy_subject_key(db, subject_id)
+
+    if memories:
+        from .webhook_service import dispatch_event, MEMORY_ERASED
+        await dispatch_event(db, namespace, MEMORY_ERASED, {
+            "subject_id": subject_id,
+            "request_ref": request_ref,
+            "memories_erased": len(memories),
+        })
+
     await db.commit()
 
     # Change 6: evict destroyed key from DEK cache
@@ -679,3 +732,424 @@ async def erase_subject(
 
     record_erase(namespace, len(memories))
     return len(memories)
+
+
+async def get_knowledge_snapshot(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    as_of: datetime,
+    limit: int = 1000,
+) -> list[MemoryOut]:
+    """
+    Exhaustive point-in-time knowledge state — every memory valid at *as_of*.
+
+    Unlike :func:`recall_memories` (vector search → top-k), this returns *all*
+    memories whose validity window contains ``as_of``
+    (``valid_from <= as_of < valid_to``) and whose ``event_time <= as_of``,
+    ordered by ``event_time`` ascending. No relevance filter is applied —
+    regulators want the complete state, not the most relevant slice.
+
+    Content is decrypted where the per-subject key is still live; memories whose
+    subject key was crypto-shredded return ``content=None`` (existence and
+    metadata preserved, content unrecoverable). This is the read side of the
+    GDPR/HIPAA erasure guarantee.
+    """
+    stmt = (
+        select(Memory)
+        .where(
+            and_(
+                Memory.namespace == namespace,
+                Memory.agent_id == agent_id,
+                Memory.valid_from <= as_of,
+                or_(Memory.valid_to.is_(None), Memory.valid_to > as_of),
+                Memory.event_time <= as_of,
+                Memory.erased_at.is_(None),
+            )
+        )
+        .order_by(Memory.event_time.asc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    mems = result.scalars().all()
+
+    # Decrypt content using the namespace's live subject keys.
+    from .ranking import _decrypt
+
+    subject_keys = await _load_namespace_subject_keys(db, namespace)
+    return [_memory_to_out(m, _decrypt(m, subject_keys)) for m in mems]
+
+
+def _lineage_node(mem: Memory, content: Optional[str]) -> LineageNode:
+    return LineageNode(
+        id=mem.id,
+        content=content,
+        content_hash=mem.content_hash,
+        event_time=mem.event_time,
+        ingestion_time=mem.ingestion_time,
+        valid_from=mem.valid_from,
+        valid_to=mem.valid_to,
+        source=mem.source,
+        importance=mem.importance,
+        supersession_confidence=mem.supersession_confidence,
+        erased_at=mem.erased_at,
+        metadata=dict(mem.metadata_ or {}),
+        # The live tip of the chain: nothing supersedes it and it is still valid.
+        is_current=(mem.superseded_by is None and mem.valid_to is None),
+    )
+
+
+async def get_memory_lineage(
+    db: AsyncSession,
+    namespace: str,
+    memory_id: UUID,
+) -> MemoryLineageResult:
+    """
+    Reconstruct the full belief-provenance chain a memory belongs to.
+
+    Walks the ``superseded_by`` pointers forward (to the current tip) and backward
+    (to the oldest ancestor), then returns every version oldest-first with the
+    supersession edges connecting them. The queried memory may sit anywhere in the
+    chain — root, tip, or middle.
+
+    Edge metadata (relation, confidence, rationale, adjudication stage) is read
+    from the tamper-evident ``supersede`` event-log rows, so the lineage is
+    backed by the same audit trail an examiner would inspect.
+    """
+    from fastapi import HTTPException
+
+    queried = await db.get(Memory, memory_id)
+    if queried is None or queried.namespace != namespace:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    # Walk forward: follow superseded_by until the live tip (superseded_by IS NULL).
+    forward: list[Memory] = []
+    cursor: Optional[Memory] = queried
+    seen: set = set()
+    while cursor is not None and cursor.id not in seen:
+        forward.append(cursor)
+        seen.add(cursor.id)
+        if cursor.superseded_by is None:
+            break
+        cursor = await db.get(Memory, cursor.superseded_by)
+
+    # Walk backward: find the memory whose superseded_by points AT the current root.
+    backward: list[Memory] = []
+    current_root = queried
+    while True:
+        stmt = select(Memory).where(
+            and_(
+                Memory.namespace == namespace,
+                Memory.superseded_by == current_root.id,
+            )
+        )
+        older = (await db.execute(stmt)).scalars().first()
+        if older is None or older.id in seen:
+            break
+        backward.append(older)
+        seen.add(older.id)
+        current_root = older
+
+    # Oldest-first: reversed backward ancestors, then the forward chain.
+    ordered = list(reversed(backward)) + forward
+
+    # Decrypt content for every node in one pass.
+    subject_keys = await _load_namespace_subject_keys(db, namespace)
+    from .ranking import _decrypt
+    nodes = [_lineage_node(m, _decrypt(m, subject_keys)) for m in ordered]
+
+    # Build edges from the supersede event-log rows (older -> newer).
+    edges: list[LineageEdge] = []
+    for older, newer in zip(ordered, ordered[1:]):
+        log_stmt = (
+            select(EventLog)
+            .where(
+                and_(
+                    EventLog.namespace == namespace,
+                    EventLog.op == "supersede",
+                    EventLog.memory_id == older.id,
+                )
+            )
+            .order_by(EventLog.created_at.desc())
+        )
+        row = (await db.execute(log_stmt)).scalars().first()
+        payload = dict(row.payload) if row and row.payload else {}
+        edges.append(LineageEdge(
+            from_id=older.id,
+            to_id=newer.id,
+            relation=payload.get("relation", "SUPERSEDES"),
+            confidence=float(
+                payload.get("confidence", older.supersession_confidence or 1.0)
+            ),
+            rationale=payload.get("rationale"),
+            adjudication_stage=int(payload.get("adjudication_stage", 2)),
+            superseded_at=row.created_at if row else older.valid_to or older.ingestion_time,
+        ))
+
+    root = ordered[0]
+    tip = ordered[-1]
+    return MemoryLineageResult(
+        agent_id=queried.agent_id,
+        namespace=namespace,
+        queried_id=memory_id,
+        root_id=root.id,
+        tip_id=tip.id,
+        depth=len(nodes),
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+async def get_structured_fact_history(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    key_values: dict[str, str],
+    adapter,
+    limit: int = 100,
+) -> list[MemoryOut]:
+    """
+    Return every recorded version of a structured fact, ordered by event_time asc.
+
+    ``key_values`` is an already-normalized structured-key map (e.g.
+    ``{"ticker": "AAPL", "metric": "eps"}`` for finance, ``{"patient_id": ...,
+    "condition": ...}`` for healthcare, ``{"matter_id": ..., "claim_type": ...}``
+    for legal). Superseded versions are included so analysts can see how the fact
+    evolved. Entity normalization is applied through the domain ``adapter`` so
+    'Apple Inc.', 'AAPL', and ISIN 'US0378331005' all collapse to one series.
+    """
+    stmt = (
+        select(Memory)
+        .where(
+            and_(
+                Memory.namespace == namespace,
+                Memory.agent_id == agent_id,
+                Memory.erased_at.is_(None),
+            )
+        )
+        .order_by(Memory.event_time.asc())
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    # For each requested (canonical) key, accept any of its metadata aliases.
+    # e.g. for finance, 'ticker' is satisfied by metadata 'ticker' | 'entity' |
+    # 'isin' | 'cusip' — all normalized to the same canonical value.
+    alias_map = {c: adapter.key_aliases(c) for c in key_values}
+
+    matched: list[Memory] = []
+    for mem in rows:
+        meta = dict(mem.metadata_ or {})
+        ok = True
+        for canonical, want in key_values.items():
+            found = None
+            for alias in alias_map[canonical]:
+                if alias in meta:
+                    found = adapter.normalize(canonical, str(meta[alias]))
+                    break
+            if found != want:
+                ok = False
+                break
+        if ok:
+            matched.append(mem)
+            if len(matched) >= limit:
+                break
+
+    subject_keys = await _load_namespace_subject_keys(db, namespace)
+    from .ranking import _decrypt
+    return [_memory_to_out(m, _decrypt(m, subject_keys)) for m in matched]
+
+
+# ── Conflicts ──────────────────────────────────────────────────────────────────
+
+
+async def list_conflicts(
+    db: AsyncSession,
+    namespace: str,
+    status: Optional[str] = "open",
+    limit: int = 50,
+) -> ConflictListResult:
+    """
+    List conflict flags for a namespace, newest first.
+
+    Each conflict carries the decrypted content, source, and event-time of *both*
+    disagreeing memories so a reviewer can decide which source to trust. Pass
+    ``status`` to filter (``open`` | ``accept_a`` | ``accept_b`` | ``dismissed``),
+    or ``None`` for all statuses.
+    """
+    conds = [ConflictFlag.namespace == namespace]
+    if status:
+        conds.append(ConflictFlag.status == status)
+    stmt = (
+        select(ConflictFlag)
+        .where(and_(*conds))
+        .order_by(ConflictFlag.detected_at.desc())
+        .limit(limit)
+    )
+    flags = (await db.execute(stmt)).scalars().all()
+
+    subject_keys = await _load_namespace_subject_keys(db, namespace)
+    from .ranking import _decrypt
+
+    conflicts: list[ConflictFlagOut] = []
+    for flag in flags:
+        mem_a = await db.get(Memory, flag.memory_a_id)
+        mem_b = await db.get(Memory, flag.memory_b_id)
+        conflicts.append(ConflictFlagOut(
+            id=flag.id,
+            namespace=flag.namespace,
+            agent_id=flag.agent_id,
+            memory_a_id=flag.memory_a_id,
+            memory_b_id=flag.memory_b_id,
+            memory_a_content=_decrypt(mem_a, subject_keys) if mem_a else None,
+            memory_b_content=_decrypt(mem_b, subject_keys) if mem_b else None,
+            memory_a_source=mem_a.source if mem_a else None,
+            memory_b_source=mem_b.source if mem_b else None,
+            memory_a_event_time=mem_a.event_time if mem_a else flag.detected_at,
+            memory_b_event_time=mem_b.event_time if mem_b else flag.detected_at,
+            confidence=flag.confidence,
+            detected_at=flag.detected_at,
+            status=flag.status,
+            resolved_at=flag.resolved_at,
+            resolver_note=flag.resolver_note,
+        ))
+
+    return ConflictListResult(
+        conflicts=conflicts,
+        total=len(conflicts),
+        status_filter=status,
+    )
+
+
+async def resolve_conflict(
+    db: AsyncSession,
+    namespace: str,
+    conflict_id: UUID,
+    req: ConflictResolveRequest,
+) -> ConflictResolveResult:
+    """
+    Resolve a conflict flag and append a tamper-evident ``conflict_resolved`` event.
+
+    ``accept_a`` invalidates memory_b; ``accept_b`` invalidates memory_a;
+    ``dismiss`` leaves both live. Resolving a non-existent / cross-namespace
+    conflict raises 404; resolving an already-resolved one raises 409; an unknown
+    resolution raises 422.
+    """
+    from fastapi import HTTPException
+
+    if req.resolution not in ("accept_a", "accept_b", "dismiss"):
+        raise HTTPException(status_code=422, detail="resolution must be accept_a, accept_b, or dismiss")
+
+    flag = await db.get(ConflictFlag, conflict_id)
+    if flag is None or flag.namespace != namespace:
+        raise HTTPException(status_code=404, detail="Conflict not found")
+    if flag.status != "open":
+        raise HTTPException(status_code=409, detail="Conflict already resolved")
+
+    now = datetime.now(timezone.utc)
+    invalidated: Optional[UUID] = None
+
+    if req.resolution == "accept_a":
+        invalidated = flag.memory_b_id
+    elif req.resolution == "accept_b":
+        invalidated = flag.memory_a_id
+
+    if invalidated is not None:
+        loser = await db.get(Memory, invalidated)
+        if loser is not None:
+            loser.valid_to = now
+            await remove_live_facts(db, [invalidated])
+
+    flag.status = "dismissed" if req.resolution == "dismiss" else req.resolution
+    flag.resolved_at = now
+    flag.resolver_note = req.note
+
+    await chain_log(
+        db, namespace=namespace, agent_id=flag.agent_id,
+        op="conflict_resolved", memory_id=flag.memory_b_id,
+        content_hash=None,
+        payload={
+            "conflict_id": str(conflict_id),
+            "resolution": req.resolution,
+            "memory_invalidated": str(invalidated) if invalidated else None,
+            "note": req.note,
+            "resolved_at": now.isoformat(),
+        },
+    )
+    await db.commit()
+    invalidate_working_set(namespace, flag.agent_id)
+    await invalidate_agent(namespace, flag.agent_id)
+
+    return ConflictResolveResult(
+        conflict_id=conflict_id,
+        resolution=req.resolution,
+        resolved_at=now,
+        memory_invalidated=invalidated,
+    )
+
+
+# ── Erasure certificate ────────────────────────────────────────────────────────
+
+
+async def get_erasure_certificate(
+    db: AsyncSession,
+    namespace: str,
+    subject_id: str,
+) -> Optional[dict]:
+    """
+    Build a proof-of-erasure certificate for a crypto-shredded data subject.
+
+    Reads the ``erase`` event-log rows for the subject — their content was
+    destroyed but the SHA-256 ``content_hash`` of each survives — and reports the
+    preserved hashes plus the current audit-chain status. Returns ``None`` when no
+    erasure has been recorded for the subject (the route turns that into a 404).
+    """
+    import uuid as _uuid
+
+    stmt = (
+        select(EventLog)
+        .where(
+            and_(
+                EventLog.namespace == namespace,
+                EventLog.op == "erase",
+            )
+        )
+        .order_by(EventLog.created_at.asc())
+    )
+    rows = [
+        r for r in (await db.execute(stmt)).scalars().all()
+        if dict(r.payload or {}).get("subject_id") == subject_id
+    ]
+    if not rows:
+        return None
+
+    content_hashes = [r.content_hash for r in rows if r.content_hash]
+    erased_at = max(r.created_at for r in rows)
+    request_ref = next(
+        (dict(r.payload or {}).get("request_ref") for r in rows
+         if dict(r.payload or {}).get("request_ref")),
+        None,
+    )
+
+    from .audit_chain import verify_chain as _verify_chain
+    try:
+        chain = await _verify_chain(db, namespace=namespace)
+        chain_status = chain.get("status", "unchecked")
+    except Exception:
+        chain_status = "unchecked"
+
+    certificate_id = str(_uuid.uuid5(
+        _uuid.NAMESPACE_URL,
+        f"lians-erasure:{namespace}:{subject_id}:{erased_at.isoformat()}",
+    ))
+
+    return {
+        "certificate_id": certificate_id,
+        "subject_id": subject_id,
+        "namespace": namespace,
+        "request_ref": request_ref,
+        "erased_at": erased_at,
+        "memories_erased": len(rows),
+        "content_hashes": content_hashes,
+        "chain_status": chain_status,
+        "generated_at": datetime.now(timezone.utc),
+    }

--- a/agentmem/src/lians/models.py
+++ b/agentmem/src/lians/models.py
@@ -340,3 +340,51 @@ class NamespacePolicy(Base):
     legal_hold = Column(Boolean, nullable=False, default=False)
     stripe_customer_id = Column(String, nullable=True)
     updated_at = Column(DateTime(timezone=True), nullable=False, default=_now, onupdate=_now)
+
+
+class Relationship(Base):
+    """
+    Bitemporal relationship edge between two entities — the knowledge-graph layer.
+
+    A directed triplet ``src_entity --rel_type--> dst_entity`` that inherits the
+    same temporal, audit, and information-barrier machinery as ``memories``:
+
+      valid_from / valid_to   — system-time window the edge was believed (Graphiti's
+                                valid_at / invalid_at). NULL valid_to = currently live.
+      event_time              — business time the relationship became true.
+      invalidated_by          — the edge that superseded this one (exclusive rels).
+      barrier_group           — RLS information-barrier tag, identical semantics to
+                                memories: an edge in another barrier is invisible.
+      subject_id              — optional data-subject link so crypto-shred reaches edges.
+
+    Powers compliance graph queries that are inherently relational:
+      legal      — conflict-of-interest reachability (ABA 1.7/1.9)
+      finance    — related-party / beneficial-ownership within N hops (SEC, AML/KYC)
+      healthcare — care-network and referral-pattern traversal (anti-kickback)
+    """
+    __tablename__ = "relationships"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    namespace = Column(String, nullable=False, index=True)
+    agent_id = Column(String, nullable=False, index=True)
+
+    src_entity = Column(String, nullable=False, index=True)
+    rel_type = Column(String, nullable=False, index=True)
+    dst_entity = Column(String, nullable=False, index=True)
+
+    event_time = Column(DateTime(timezone=True), nullable=False)
+    ingestion_time = Column(DateTime(timezone=True), nullable=False, default=_now)
+    valid_from = Column(DateTime(timezone=True), nullable=False)
+    valid_to = Column(DateTime(timezone=True), nullable=True)
+    invalidated_by = Column(UUID(as_uuid=True), ForeignKey("relationships.id"), nullable=True)
+
+    barrier_group = Column(String, nullable=True, index=True)
+    subject_id = Column(String, nullable=True, index=True)
+    source = Column(String, nullable=True)
+    metadata_ = Column("metadata", JSON, nullable=False, server_default="{}")
+    content_hash = Column(String, nullable=False, index=True)
+
+    __table_args__ = (
+        Index("ix_rel_ns_agent_src", "namespace", "agent_id", "src_entity"),
+        Index("ix_rel_ns_agent_dst", "namespace", "agent_id", "dst_entity"),
+    )

--- a/agentmem/src/lians/schemas.py
+++ b/agentmem/src/lians/schemas.py
@@ -398,3 +398,71 @@ class AuditExportResult(BaseModel):
     chain_status: Optional[str] = None   # "ok" | "tampered" | None (not verified)
     chain_violations: Optional[list[AuditChainViolation]] = None
     events: list[AuditExportRow]
+
+
+# ── Relationship graph ──────────────────────────────────────────────────────────
+
+
+class RelateRequest(BaseModel):
+    """Assert a relationship edge: src_entity --rel_type--> dst_entity."""
+    agent_id: str
+    src_entity: str
+    rel_type: str
+    dst_entity: str
+    event_time: datetime
+    exclusive: bool = False              # invalidate other live src--rel_type--> edges
+    subject_id: Optional[str] = None
+    source: Optional[str] = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    normalize: bool = False              # collapse company/ISIN/CUSIP to canonical ticker
+
+
+class UnrelateRequest(BaseModel):
+    agent_id: str
+    src_entity: str
+    rel_type: str
+    dst_entity: str
+    event_time: Optional[datetime] = None
+    normalize: bool = False
+
+
+class EdgeOut(BaseModel):
+    id: str
+    src: str
+    rel_type: str
+    dst: str
+    event_time: Optional[str]
+    valid_to: Optional[str]
+    source: Optional[str]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RelateResult(BaseModel):
+    id: UUID
+    src_entity: str
+    rel_type: str
+    dst_entity: str
+    event_time: datetime
+    valid_to: Optional[datetime]
+
+
+class NeighborOut(BaseModel):
+    entity: str
+    depth: int
+
+
+class NeighborsResult(BaseModel):
+    entity: str
+    depth: int
+    as_of: Optional[str]
+    neighbors: list[NeighborOut]
+    direct_edges: list[EdgeOut]
+
+
+class PathResult(BaseModel):
+    src: str
+    dst: str
+    connected: bool
+    hops: int
+    as_of: Optional[str]
+    path: list[EdgeOut]

--- a/agentmem/src/lians/webhook_service.py
+++ b/agentmem/src/lians/webhook_service.py
@@ -49,8 +49,12 @@ MEMORY_SUPERSEDED   = "memory.superseded"
 MEMORY_CONFLICT     = "memory.conflict"
 MEMORY_ERASED       = "memory.erased"
 SUPERSESSION_REJECTED = "supersession.rejected"
+RELATIONSHIP_INVALIDATED = "relationship.invalidated"
 
-ALL_EVENTS = {MEMORY_SUPERSEDED, MEMORY_CONFLICT, MEMORY_ERASED, SUPERSESSION_REJECTED}
+ALL_EVENTS = {
+    MEMORY_SUPERSEDED, MEMORY_CONFLICT, MEMORY_ERASED, SUPERSESSION_REJECTED,
+    RELATIONSHIP_INVALIDATED,
+}
 
 
 # ── HMAC signing ──────────────────────────────────────────────────────────────

--- a/agentmem/tests/test_airgap.py
+++ b/agentmem/tests/test_airgap.py
@@ -24,9 +24,9 @@ class TestSentenceTransformerProvider:
 
     def _make_provider(self, model_name: str = "BAAI/bge-large-en-v1.5"):
         """Build a provider with a mocked ST model that returns 1024-dim vectors."""
-        from agentmem.embeddings import SentenceTransformerProvider
+        from src.lians.embeddings import SentenceTransformerProvider
 
-        with patch("agentmem.config.get_settings") as mock_settings:
+        with patch("src.lians.config.get_settings") as mock_settings:
             mock_settings.return_value = MagicMock(
                 sentence_transformer_model=model_name,
                 embedding_dim=1024,
@@ -61,9 +61,9 @@ class TestSentenceTransformerProvider:
 
     def test_model_loaded_lazily(self):
         """Provider must not load the model at construction time."""
-        from agentmem.embeddings import SentenceTransformerProvider
+        from src.lians.embeddings import SentenceTransformerProvider
 
-        with patch("agentmem.config.get_settings") as mock_settings:
+        with patch("src.lians.config.get_settings") as mock_settings:
             mock_settings.return_value = MagicMock(
                 sentence_transformer_model="BAAI/bge-large-en-v1.5",
                 embedding_dim=1024,
@@ -75,9 +75,9 @@ class TestSentenceTransformerProvider:
 
     def test_dim_mismatch_raises_at_load(self):
         """If the model produces wrong-dim vectors, ValueError at load time."""
-        from agentmem.embeddings import SentenceTransformerProvider
+        from src.lians.embeddings import SentenceTransformerProvider
 
-        with patch("agentmem.config.get_settings") as mock_settings:
+        with patch("src.lians.config.get_settings") as mock_settings:
             mock_settings.return_value = MagicMock(
                 sentence_transformer_model="some-384-dim-model",
                 embedding_dim=1024,
@@ -98,14 +98,14 @@ class TestSentenceTransformerProvider:
 
     def test_provider_registered_in_get_provider(self):
         """get_provider() must return SentenceTransformerProvider for the right key."""
-        from agentmem.embeddings import SentenceTransformerProvider
+        from src.lians.embeddings import SentenceTransformerProvider
 
-        with patch("agentmem.embeddings.get_settings") as mock_settings:
+        with patch("src.lians.embeddings.get_settings") as mock_settings:
             mock_settings.return_value = MagicMock(
                 embedding_provider="sentence-transformers",
                 sentence_transformer_model="BAAI/bge-large-en-v1.5",
             )
-            from agentmem.embeddings import get_provider
+            from src.lians.embeddings import get_provider
             provider = get_provider()
 
         assert isinstance(provider, SentenceTransformerProvider)
@@ -128,32 +128,32 @@ class TestAirgapValidation:
         return MagicMock(**defaults)
 
     def test_valid_airgap_config_passes(self):
-        from agentmem.main import _validate_airgap
+        from src.lians.main import _validate_airgap
         # Should not raise
         _validate_airgap(self._settings())
 
     def test_local_provider_is_also_safe(self):
-        from agentmem.main import _validate_airgap
+        from src.lians.main import _validate_airgap
         _validate_airgap(self._settings(embedding_provider="local"))
 
     def test_voyage_provider_raises(self):
-        from agentmem.main import _validate_airgap
+        from src.lians.main import _validate_airgap
         with pytest.raises(RuntimeError, match="EMBEDDING_PROVIDER"):
             _validate_airgap(self._settings(embedding_provider="voyage"))
 
     def test_openai_provider_raises(self):
-        from agentmem.main import _validate_airgap
+        from src.lians.main import _validate_airgap
         with pytest.raises(RuntimeError, match="EMBEDDING_PROVIDER"):
             _validate_airgap(self._settings(embedding_provider="openai"))
 
     def test_llm_stage_enabled_raises(self):
-        from agentmem.main import _validate_airgap
+        from src.lians.main import _validate_airgap
         with pytest.raises(RuntimeError, match="SUPERSESSION_LLM_STAGE"):
             _validate_airgap(self._settings(supersession_llm_stage=True))
 
     def test_both_violations_reported_together(self):
         """RuntimeError message should list all violations, not just the first."""
-        from agentmem.main import _validate_airgap
+        from src.lians.main import _validate_airgap
         with pytest.raises(RuntimeError) as exc_info:
             _validate_airgap(self._settings(
                 embedding_provider="voyage",
@@ -165,7 +165,7 @@ class TestAirgapValidation:
 
     def test_airgap_false_skips_validation(self):
         """When AIRGAP_MODE=false, bad providers must not raise."""
-        from agentmem.main import _validate_airgap
+        from src.lians.main import _validate_airgap
         # _validate_airgap is only called when airgap_mode=True, so this
         # just ensures it doesn't silently run when called with bad config
         # that would otherwise be fine in non-airgap mode.

--- a/agentmem/tests/test_graph.py
+++ b/agentmem/tests/test_graph.py
@@ -1,0 +1,141 @@
+"""
+Relationship-graph layer tests — bitemporal edges, traversal, point-in-time,
+and graph-proximity reranking. Exercised against the real LocalLiansClient.
+"""
+import sys
+import pytest
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk" / "python"))
+
+from lians import LocalLiansClient, LiansMemoryHarness
+
+AG = "graph-agent"
+
+
+def _dt(y, m, d):
+    return datetime(y, m, d, tzinfo=timezone.utc)
+
+
+class TestRelateAndNeighbors:
+    def test_relate_creates_edge(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "FundA", "owns", "IssuerX", event_time=_dt(2026, 1, 1))
+            res = mem.neighbors(AG, "FundA", depth=1)
+            assert "IssuerX" in {n["entity"] for n in res["neighbors"]}
+
+    def test_relate_is_idempotent(self):
+        with LocalLiansClient() as mem:
+            e1 = mem.relate(AG, "A", "knows", "B", event_time=_dt(2026, 1, 1))
+            e2 = mem.relate(AG, "A", "knows", "B", event_time=_dt(2026, 2, 1))
+            assert e1["id"] == e2["id"]  # same live edge returned
+            assert len(mem.neighbors(AG, "A")["direct_edges"]) == 1
+
+    def test_undirected_neighbors_both_ways(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "A", "controls", "B", event_time=_dt(2026, 1, 1))
+            res = mem.neighbors(AG, "B", direction="any")
+            assert "A" in {n["entity"] for n in res["neighbors"]}
+
+    def test_multi_hop(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "A", "r", "B", event_time=_dt(2026, 1, 1))
+            mem.relate(AG, "B", "r", "C", event_time=_dt(2026, 1, 1))
+            d1 = {n["entity"]: n["depth"] for n in mem.neighbors(AG, "A", depth=1)["neighbors"]}
+            d2 = {n["entity"]: n["depth"] for n in mem.neighbors(AG, "A", depth=2)["neighbors"]}
+            assert "C" not in d1
+            assert d2["C"] == 2
+
+
+class TestExclusiveAndUnrelate:
+    def test_exclusive_supersedes_prior(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "Alice", "works_at", "Acme", event_time=_dt(2025, 1, 1), exclusive=True)
+            mem.relate(AG, "Alice", "works_at", "Globex", event_time=_dt(2026, 1, 1), exclusive=True)
+            cur = {n["entity"] for n in mem.neighbors(AG, "Alice")["neighbors"]}
+            assert "Globex" in cur
+            assert "Acme" not in cur
+
+    def test_unrelate_invalidates(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "A", "r", "B", event_time=_dt(2026, 1, 1))
+            assert mem.unrelate(AG, "A", "r", "B")["invalidated"] == 1
+            assert mem.neighbors(AG, "A")["neighbors"] == []
+
+    def test_unrelate_missing_is_zero(self):
+        with LocalLiansClient() as mem:
+            assert mem.unrelate(AG, "A", "r", "B")["invalidated"] == 0
+
+
+class TestPath:
+    def test_path_finds_connection(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "Attorney", "represented", "ClientX", event_time=_dt(2026, 1, 1))
+            mem.relate(AG, "ClientX", "adverse_to", "PartyY", event_time=_dt(2026, 1, 1))
+            res = mem.path(AG, "Attorney", "PartyY", max_depth=4)
+            assert res["connected"] is True
+            assert res["hops"] == 2
+            assert len(res["path"]) == 2
+
+    def test_path_unconnected(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "A", "r", "B", event_time=_dt(2026, 1, 1))
+            res = mem.path(AG, "A", "Z")
+            assert res["connected"] is False
+            assert res["path"] == []
+
+    def test_path_respects_max_depth(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "A", "r", "B", event_time=_dt(2026, 1, 1))
+            mem.relate(AG, "B", "r", "C", event_time=_dt(2026, 1, 1))
+            mem.relate(AG, "C", "r", "D", event_time=_dt(2026, 1, 1))
+            assert mem.path(AG, "A", "D", max_depth=2)["connected"] is False
+            assert mem.path(AG, "A", "D", max_depth=3)["connected"] is True
+
+
+class TestPointInTime:
+    def test_as_of_sees_historical_edge(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "A", "works_at", "Acme", event_time=_dt(2025, 1, 1), exclusive=True)
+            mem.relate(AG, "A", "works_at", "Globex", event_time=_dt(2026, 1, 1), exclusive=True)
+            now = {n["entity"] for n in mem.neighbors(AG, "A")["neighbors"]}
+            assert now == {"Globex"}
+            past = {n["entity"] for n in mem.neighbors(AG, "A", as_of=_dt(2025, 6, 1))["neighbors"]}
+            assert "Acme" in past
+
+    def test_path_as_of(self):
+        with LocalLiansClient() as mem:
+            mem.relate(AG, "A", "r", "B", event_time=_dt(2025, 1, 1))
+            mem.unrelate(AG, "A", "r", "B", event_time=_dt(2025, 12, 1))
+            assert mem.path(AG, "A", "B")["connected"] is False
+            assert mem.path(AG, "A", "B", as_of=_dt(2025, 6, 1))["connected"] is True
+
+
+class TestProximityRerank:
+    def test_recall_near_boosts_connected_entity(self):
+        with LocalLiansClient() as mem:
+            # Identical content, different tickers → equal semantic score, both live.
+            mem.add(AG, "quarterly earnings update", _dt(2026, 1, 1), metadata={"ticker": "AAA", "metric": "eps"})
+            mem.add(AG, "quarterly earnings update", _dt(2026, 1, 1), metadata={"ticker": "BBB", "metric": "eps"})
+            mem.relate(AG, "ANCHOR", "covers", "AAA", event_time=_dt(2026, 1, 1))
+
+            res = mem.recall_near(AG, "earnings", near_entity="ANCHOR", near_key="ticker", k=5)
+            tickers = [m["metadata"].get("ticker") for m in res["memories"]]
+            assert tickers[0] == "AAA"  # proximity broke the tie in AAA's favor
+
+    def test_plain_recall_unaffected(self):
+        with LocalLiansClient() as mem:
+            mem.add(AG, "AAPL guidance raised", _dt(2026, 1, 1), metadata={"ticker": "AAPL", "metric": "g"})
+            out = mem.recall(AG, "AAPL guidance")
+            assert any("AAPL" in m["content"] for m in out["memories"])
+
+
+class TestHarnessGraph:
+    def test_harness_relate_and_path(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="local", domain="legal")
+            h.relate("Attorney", "prior_rep", "ClientX")
+            h.relate("ClientX", "adverse_to", "PartyY")
+            res = h.path("Attorney", "PartyY")
+            assert res["connected"] is True

--- a/agentmem/tests/test_graph_api.py
+++ b/agentmem/tests/test_graph_api.py
@@ -1,0 +1,107 @@
+"""
+HTTP-level tests for the relationship-graph routes (/v1/graph/*).
+
+Confirms the endpoints, auth scoping, and namespace isolation work end-to-end
+through the FastAPI app — complementing the service-level tests in test_graph.py.
+"""
+from __future__ import annotations
+
+import hashlib
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+
+from httpx import AsyncClient, ASGITransport
+
+from src.lians.main import app
+from src.lians.db import get_db
+from src.lians.models import ApiKey
+
+NS = "graph-ns"
+KEY = "graph-key"
+OTHER_NS = "graph-other-ns"
+OTHER_KEY = "graph-other-key"
+AGENT = "ga"
+T = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    for raw, ns in [(KEY, NS), (OTHER_KEY, OTHER_NS)]:
+        db.add(ApiKey(hashed_key=hashlib.sha256(raw.encode()).hexdigest(),
+                      namespace=ns, scopes=["read", "write", "admin"]))
+    await db.commit()
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _h(key=KEY):
+    return {"X-API-Key": key}
+
+
+async def _relate(client, src, rel, dst, key=KEY, exclusive=False):
+    return await client.post("/v1/graph/relate", headers=_h(key), json={
+        "agent_id": AGENT, "src_entity": src, "rel_type": rel, "dst_entity": dst,
+        "event_time": T.isoformat(), "exclusive": exclusive,
+    })
+
+
+@pytest.mark.asyncio
+async def test_relate_and_neighbors(client):
+    r = await _relate(client, "FundA", "owns", "IssuerX")
+    assert r.status_code == 200, r.text
+
+    n = await client.get("/v1/graph/neighbors", headers=_h(),
+                         params={"entity": "FundA", "agent_id": AGENT, "depth": 1})
+    assert n.status_code == 200
+    assert "IssuerX" in {x["entity"] for x in n.json()["neighbors"]}
+
+
+@pytest.mark.asyncio
+async def test_path_conflict_of_interest(client):
+    await _relate(client, "Attorney", "represented", "ClientX")
+    await _relate(client, "ClientX", "adverse_to", "PartyY")
+
+    p = await client.get("/v1/graph/path", headers=_h(),
+                        params={"src": "Attorney", "dst": "PartyY", "agent_id": AGENT})
+    assert p.status_code == 200
+    body = p.json()
+    assert body["connected"] is True
+    assert body["hops"] == 2
+
+
+@pytest.mark.asyncio
+async def test_unrelate(client):
+    await _relate(client, "A", "r", "B")
+    u = await client.post("/v1/graph/unrelate", headers=_h(), json={
+        "agent_id": AGENT, "src_entity": "A", "rel_type": "r", "dst_entity": "B",
+    })
+    assert u.status_code == 200
+    assert u.json()["invalidated"] == 1
+
+
+@pytest.mark.asyncio
+async def test_namespace_isolation(client):
+    # Edge created in OTHER_NS must be invisible to NS.
+    await _relate(client, "Secret", "links", "Hidden", key=OTHER_KEY)
+    n = await client.get("/v1/graph/neighbors", headers=_h(KEY),
+                        params={"entity": "Secret", "agent_id": AGENT})
+    assert n.status_code == 200
+    assert n.json()["neighbors"] == []
+
+
+@pytest.mark.asyncio
+async def test_relate_requires_write_scope(client, db):
+    db.add(ApiKey(hashed_key=hashlib.sha256(b"ro-key").hexdigest(),
+                  namespace=NS, scopes=["read"]))
+    await db.commit()
+    r = await _relate(client, "A", "r", "B", key="ro-key")
+    assert r.status_code == 403

--- a/agentmem/tests/test_harness.py
+++ b/agentmem/tests/test_harness.py
@@ -1,0 +1,173 @@
+"""
+Tests for the Lians agent memory harness.
+
+Covers the recall-before / remember-after loop, compliance scoping, point-in-time
+recall, and the combined turn helpers — exercised against the real
+LocalLiansClient (in-memory SQLite) so the full service path runs.
+"""
+import sys
+import pytest
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+# Make the SDK importable from the test runner's working directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk" / "python"))
+
+from lians import LocalLiansClient, LiansMemoryHarness, RecalledMemory, TurnResult
+from lians.harness import MemoryClient
+
+
+def _dt(y, m, d):
+    return datetime(y, m, d, tzinfo=timezone.utc)
+
+
+class TestConstruction:
+    def test_requires_agent_id(self):
+        with LocalLiansClient() as mem:
+            with pytest.raises(ValueError):
+                LiansMemoryHarness(mem, agent_id="")
+
+    def test_rejects_client_without_surface(self):
+        class Bad:
+            pass
+        with pytest.raises(TypeError):
+            LiansMemoryHarness(Bad(), agent_id="a")
+
+    def test_local_client_satisfies_protocol(self):
+        with LocalLiansClient() as mem:
+            assert isinstance(mem, MemoryClient)
+
+
+class TestRecall:
+    def test_recall_returns_normalized_memories(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            h.remember("NVDA FY26 revenue guidance is $40B", event_time=_dt(2025, 11, 19))
+            out = h.recall("NVDA revenue guidance")
+            assert out and isinstance(out[0], RecalledMemory)
+            assert "NVDA" in out[0].content
+
+    def test_recall_context_renders_block(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            h.remember("AAPL Q1 EPS was $1.52", event_time=_dt(2026, 1, 28))
+            ctx = h.recall_context("Apple earnings")
+            assert "AAPL Q1 EPS" in ctx
+            assert ctx.startswith("Relevant facts")
+
+    def test_recall_context_empty(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            ctx = h.recall_context("nothing stored")
+            assert "no relevant facts" in ctx
+
+    def test_point_in_time_recall(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            h.remember("NVDA guidance $36B", event_time=_dt(2025, 8, 1),
+                       metadata={"ticker": "NVDA", "metric": "guidance"})
+            h.remember("NVDA guidance raised to $40B", event_time=_dt(2025, 11, 19),
+                       metadata={"ticker": "NVDA", "metric": "guidance"})
+            # Present recall: only the current (superseding) fact
+            now = h.recall("NVDA guidance")
+            assert any("$40B" in m.content for m in now)
+            # As of September: the old figure was current then
+            past = h.recall("NVDA guidance", as_of=_dt(2025, 9, 1))
+            assert any("$36B" in m.content for m in past)
+
+
+class TestRemember:
+    def test_remember_applies_scoping(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(
+                mem, agent_id="care", subject_id="MRN-1",
+                barrier_group="oncology", domain="healthcare", source="ehr",
+            )
+            out = h.remember("Patient started metformin 500mg", event_time=_dt(2026, 3, 1))
+            assert out["subject_id"] == "MRN-1"
+            assert out["source"] == "ehr"
+            assert out["metadata"]["_barrier"] == "oncology"
+            assert out["metadata"]["_domain"] == "healthcare"
+
+    def test_remember_messages(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            res = h.remember_messages([
+                {"role": "user", "content": "What about TSLA?"},
+                {"role": "assistant", "content": "TSLA deliveries hit 495k in Q4"},
+            ])
+            assert res["added"] >= 1
+            out = h.recall("TSLA deliveries")
+            assert any("495k" in m.content for m in out)
+
+
+class TestTurn:
+    def test_run_turn_recalls_and_remembers(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            h.remember("MSFT FY25 cloud revenue $110B", event_time=_dt(2025, 7, 1))
+
+            seen = {}
+
+            def generate(context, query):
+                seen["context"] = context
+                return "Recorded: MSFT cloud revenue is on track."
+
+            answer = h.run_turn("How is MSFT cloud doing?", generate)
+            assert "MSFT FY25 cloud revenue" in seen["context"]
+            assert answer.startswith("Recorded")
+            # The response was persisted and is now recallable
+            out = h.recall("MSFT cloud on track")
+            assert any("on track" in m.content for m in out)
+
+    def test_turn_returns_full_result(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            res = h.turn("hello?", lambda ctx, q: "world")
+            assert isinstance(res, TurnResult)
+            assert res.response == "world"
+            assert res.remembered is not None
+
+    def test_turn_can_skip_remember(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            res = h.turn("q", lambda ctx, q: "answer", remember_response=False)
+            assert res.remembered is None
+
+    def test_turn_skips_empty_response(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            res = h.turn("q", lambda ctx, q: "   ")
+            assert res.remembered is None
+
+
+class TestCompliancePassthroughs:
+    def test_backtest_check(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            h.remember("Future leak: earnings beat", event_time=_dt(2026, 6, 1))
+            report = h.backtest_check(simulation_as_of=_dt(2026, 1, 1))
+            assert len(report["flags"]) >= 1   # the June fact is unknowable on Jan 1
+            assert report["is_clean"] is False
+
+    def test_snapshot(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            h.remember("Fact A", event_time=_dt(2026, 1, 1))
+            snap = h.snapshot(as_of=_dt(2026, 2, 1))
+            assert snap["total"] == 1
+            assert snap["items"][0]["content"] == "Fact A"
+
+    def test_erase_uses_default_subject(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk", subject_id="user-9")
+            h.remember("PII fact", event_time=_dt(2026, 1, 1))
+            res = h.erase(request_ref="GDPR-1")
+            assert res["subject_id"] == "user-9"
+            assert res["memories_erased"] >= 1
+
+    def test_erase_requires_subject(self):
+        with LocalLiansClient() as mem:
+            h = LiansMemoryHarness(mem, agent_id="desk")
+            with pytest.raises(ValueError):
+                h.erase(request_ref="GDPR-1")

--- a/docs/compare-mem0.md
+++ b/docs/compare-mem0.md
@@ -1,0 +1,189 @@
+# Lians vs mem0 — quality & access for regulated work
+
+mem0 is a strong, popular general-purpose memory layer for AI agents. Lians is
+built for a narrower, harder problem: memory in **regulated environments** —
+financial institutions, healthcare, and legal firms — where a stale fact is not a
+UX papercut but a compliance event, and where "what did the agent know, and when"
+must be answerable to a regulator.
+
+This document compares the two honestly on the two axes that matter for that
+audience: **quality** (does the memory return correct, current, defensible facts?)
+and **access** (who can read what, and is it provably controlled?).
+
+> Scope note: mem0's surface evolves quickly. Claims below reflect mem0's public
+> README/docs as of June 2026 (Apache-2.0 OSS core; v3 single-pass extraction;
+> hosted platform at app.mem0.ai). Where mem0's managed platform adds a feature
+> the OSS core lacks, we say so. Corrections welcome via PR.
+
+---
+
+## TL;DR
+
+| Dimension | mem0 | Lians |
+|---|---|---|
+| Stale-fact handling | ADD-only accumulation (v3) — versions coexist | Bitemporal supersession — stale versions excluded at the DB layer |
+| "What did we know on date X?" | No temporal reconstruction | `recall_at` / `snapshot` — exhaustive point-in-time state |
+| Tamper-evidence | Not documented | SHA-256 hash chain (SEC 17a-4), `verify_chain()` |
+| Right-to-erasure | Delete API; no audit-preserving proof | Per-subject AES-256-GCM crypto-shred; audit trail survives; erasure certificate |
+| Access control | `user_id` filtering | Scoped API keys + PostgreSQL Row-Level Security information barriers |
+| Lookahead-bias proof | None | `backtest_check` contamination report |
+| Regulatory export | None documented | `compliance_report`, audit export (SEC/FINRA/CFTC) |
+| Domain modeling | Generic | Finance / healthcare / legal adapters (entity normalization) |
+
+Where mem0 leads: breadth of out-of-the-box framework integrations, a polished
+hosted onboarding, a browser extension, and strong general-chat benchmark scores
+(LoCoMo / LongMemEval). If you are building a consumer assistant, that breadth is
+real value. If you are building for a bank, hospital, or law firm, the rows above
+are the ones that get you through procurement and audit.
+
+---
+
+## 1. Quality — correctness of recalled context
+
+### 1.1 The stale-fact problem
+
+mem0 v3 uses an **ADD-only** accumulation model: new observations are appended,
+and prior observations are not overwritten or deleted. This is excellent for
+preserving conversational nuance, but in a domain where facts *revise* — earnings
+guidance, a Fed rate decision, a medication dose, a damages estimate — it means
+the store holds every version, and semantic recall can surface an outdated one
+ranked alongside the current one. The LLM then reasons over contaminated context.
+
+Lians models the revision explicitly. Each fact carries:
+
+- `event_time` — when the fact became true (business time)
+- `valid_from` / `valid_to` — the window during which the system believed it
+
+When a new fact supersedes an old one (same keyed entity + metric), the old fact's
+`valid_to` is closed. Present-time `recall` filters on `valid_to IS NULL`, so the
+**stale version never reaches the model**. The benchmark in
+[`benchmark.md`](./benchmark.md) measures this directly: across a 5-revision chain,
+Lians returned **0 stale facts in the top-5**; an ADD-only baseline returned 4/4.
+
+### 1.2 Point-in-time reconstruction
+
+Because mem0 has no validity interval per fact, it cannot answer "what did the
+agent know on 2025-03-14, ignoring everything learned since?" Lians answers it two
+ways:
+
+- `recall_at(query, as_of=T)` — ranked, point-in-time relevant recall
+- `snapshot(agent_id, as_of=T)` — **exhaustive**: every fact valid at T, no
+  relevance filter, ordered by event time. This is what an examiner actually asks
+  for — the complete state, not the top 5.
+
+### 1.3 Conflicts as first-class objects
+
+When two sources disagree at the same event time (an ISIN-tagged fact vs a
+ticker-tagged fact; two clinicians' notes), Lians does not silently pick one. It
+raises a **conflict** that can be listed and resolved by a human, and emits a
+`memory.conflict` webhook. mem0's accumulation model has no equivalent
+adjudication surface.
+
+### 1.4 Domain-aware normalization
+
+Lians ships finance/healthcare/legal adapters so supersession keys on the *same
+real-world entity* even when the surface form differs:
+
+- finance — `Apple Inc.`, ISIN `US0378331005`, CUSIP `037833100`, and `AAPL` all
+  resolve to one series
+- healthcare — ICD-10, NPI, and medication-name normalization
+- legal — matter-ID, jurisdiction, and claim-type normalization
+
+A generic embedding store treats these as different strings and fails to supersede.
+
+---
+
+## 2. Access — who can read what, provably
+
+### 2.1 Multi-tenancy vs. information barriers
+
+mem0 separates data by `user_id` (and session/agent ids) — a filter applied in the
+query path. That is fine for "keep Alice's memories out of Bob's chat." It is not
+an **information barrier**: a Chinese wall between a bank's M&A and trading desks,
+a hospital's care teams, or a law firm's matter teams, where the requirement is
+that one side *cannot* read the other's data even by mistake or by a bug in the
+application layer.
+
+Lians enforces isolation at **PostgreSQL Row-Level Security**. Each request sets a
+transaction-scoped `app.current_namespace`, and the `barrier_group` policy is
+evaluated by the database, not the application. A coding error in the API layer
+cannot leak across the wall, because the wall is below the API layer. This maps
+directly to:
+
+- **Finance** — SEC/FINRA information-barrier requirements between desks
+- **Legal** — ABA Model Rules 1.7 / 1.9 conflict walls per matter
+- **Healthcare** — HIPAA §164.312(a)(1) access control per care team
+
+### 2.2 Scoped credentials
+
+Lians API keys carry explicit scopes (`read`, `write`, admin) checked on every
+request (`AuthContext.require(scope)`), and keys are stored only as SHA-256 hashes
+and individually revocable. mem0's OSS auth is comparatively coarse (API key /
+session) without documented per-scope enforcement or RLS-backed tenancy.
+
+### 2.3 Encryption and erasure as access controls
+
+The strongest access control is cryptographic. Lians encrypts PII content with a
+**per-subject AES-256-GCM key**. "Erasing" a data subject destroys that one key —
+the content becomes unrecoverable for everyone, instantly, while the SHA-256
+content hashes remain in the audit chain so the erasure itself is provable. The
+SDK returns an **erasure certificate** (stable id + preserved hashes) you can file
+with a supervisory authority.
+
+mem0 documents deletion of memories but not encryption at rest, per-subject keys,
+or an audit-preserving erasure proof. "We deleted the row" and "we can prove the
+content is cryptographically unrecoverable while the audit trail is intact" are
+different assurances, and only the second survives a GDPR/HIPAA review.
+
+---
+
+## 3. By vertical
+
+### Finance
+- **Need:** SEC 17a-4 tamper-evident records, FINRA 4511 retention, MiFID II
+  point-in-time, desk-level information barriers, backtests provably free of
+  lookahead bias.
+- **Lians:** hash chain + `verify_chain`, append-only `event_log`, `recall_at`,
+  RLS barriers, `backtest_check`. Ticker/ISIN/CUSIP normalization.
+- **mem0 gap:** no temporal model, no tamper-evidence, no barrier enforcement, no
+  contamination check.
+
+### Healthcare
+- **Need:** HIPAA §164.312 safeguards — encryption, integrity, access control,
+  transmission security; subject-level erasure; care-team segregation.
+- **Lians:** per-subject AES-256-GCM, hash-chain integrity, RLS care-team
+  barriers, crypto-shred keyed on `patient_id`, air-gap mode. ICD-10/NPI
+  normalization. (A BAA is required before processing real PHI.)
+- **mem0 gap:** no documented encryption-at-rest, no per-subject key model, no
+  HIPAA safeguard mapping.
+
+### Legal
+- **Need:** FRCP Rule 34 eDiscovery (reproduce knowledge before a privilege
+  cutoff), ABA conflict walls, chain-of-custody, client-matter destruction.
+- **Lians:** `recall_at(as_of=privilege_date)`, RLS matter-team walls, hash-chain
+  custody, crypto-shred keyed on `matter_id`, expert-witness contamination check.
+- **mem0 gap:** no privilege-cutoff reconstruction, no matter-level walls, no
+  custody proof.
+
+---
+
+## 4. Where mem0 is the better choice
+
+Be fair about it. Pick mem0 if you want the widest set of turnkey framework
+integrations and a browser extension today, you are optimizing general-assistant
+recall quality on conversational benchmarks, your data is not regulated, and you
+value a zero-ops hosted platform with a large community over compliance depth.
+
+Pick Lians if a wrong-because-stale answer is a compliance event, an auditor or
+examiner will ask "what did the agent know on date X," you must prove records
+weren't altered and that erased data is unrecoverable, or you need barriers
+enforced below the application layer.
+
+---
+
+## 5. Migrating
+
+If you are already on mem0, see [migrate-from-mem0.md](./migrate-from-mem0.md).
+The mental model shift is small: keep calling `add` / `recall`, but start passing
+`event_time` (the business time a fact became true) so the bitemporal guarantees
+switch on. Everything in §1–§2 follows from that one field.

--- a/docs/compare-zep.md
+++ b/docs/compare-zep.md
@@ -1,0 +1,156 @@
+# Lians vs Zep / Graphiti — what to learn from a temporal knowledge graph
+
+[Zep](https://www.getzep.com) is a managed agent-memory platform; its open-source
+engine is [Graphiti](https://github.com/getzep/graphiti), a **bitemporal knowledge
+graph**. Graphiti and Lians independently arrived at the same core insight —
+*facts change over time, so memory must be temporal* — but took different routes:
+Graphiti models the world as **entities and relationships** (a graph) and leans on
+LLM extraction; Lians models **atomic facts** with deterministic supersession and a
+compliance spine (audit chain, crypto-shred, information barriers).
+
+This document compares the two honestly and extracts the parts of Graphiti's
+design worth adopting — on our terms, for regulated work.
+
+> Scope note: reflects Graphiti's public repo/docs and Zep's positioning as of
+> June 2026. Zep CE (the self-hostable graph) is deprecated; production Zep is
+> cloud-only. Graphiti remains Apache-2.0 and self-hostable.
+
+---
+
+## TL;DR
+
+| Dimension | Zep / Graphiti | Lians |
+|---|---|---|
+| Temporal model | Bitemporal **edges** (`valid_at`/`invalid_at`) | Bitemporal **facts** (`event_time` + `valid_from/valid_to`) |
+| Data shape | Entity–relationship **graph** (triplets) | Atomic facts + structured metadata |
+| Retrieval | Semantic + BM25 + **graph traversal** + node-distance rerank | Semantic + BM25 + recency + validity gate + **graph traversal + node-distance rerank** (shipped) |
+| Fact updates | **LLM-extracted**, dedup, contradiction → invalidate edge | **Deterministic** keyed supersession; LLM only as optional adjudicator |
+| Entity model | LLM entity nodes + evolving summaries + communities | Entity *normalization* (ISIN/CUSIP/ICD-10) — no node graph |
+| Ontology | Custom entity/edge **types** (Pydantic) | Domain adapters (key normalization only) |
+| Tamper-evidence | Episode provenance only | SHA-256 hash chain (SEC 17a-4), `verify_chain` |
+| Right-to-erasure | Not a feature | Per-subject crypto-shred + erasure certificate |
+| Access control | None in Graphiti; Zep Cloud only | Scoped keys + PostgreSQL RLS information barriers |
+| Backend | Neo4j / FalkorDB / Neptune (graph DB) | Postgres 16 + pgvector (no extra infra) |
+| Determinism | Extraction-quality dependent | Reproducible; same input → same supersession |
+
+**Where Zep/Graphiti leads:** the graph itself. Relationship triplets unlock
+queries Lians can't answer today — "who is connected to this entity, and how?",
+N-hop traversal, community structure, and graph-proximity reranking. Their LLM
+extraction also ingests messy unstructured text with less caller effort.
+
+**Where Lians leads:** everything a regulator asks about — tamper-evident audit,
+provable erasure, DB-layer barriers, deterministic and reproducible updates, and
+zero extra infrastructure (no graph DB to run, secure, and certify).
+
+---
+
+## 1. The idea worth stealing: a relationship graph
+
+Lians stores facts as rows. That's perfect for "what is AAPL's current EPS" but
+weak for the questions that are *inherently relational* — and several of those are
+core compliance requirements, not nice-to-haves:
+
+- **Legal — conflict-of-interest checks.** "Does any attorney on this matter have
+  a relationship (prior representation, financial interest, family) to an adverse
+  party?" is a graph reachability question. ABA Rules 1.7/1.9 *are* a graph query.
+- **Finance — related-party & beneficial-ownership.** "Is this counterparty
+  connected, within N hops of ownership or control, to a restricted entity?" drives
+  related-party-transaction disclosure (SEC) and AML/KYC beneficial-ownership rules.
+- **Healthcare — care networks & referral loops.** "Which providers and facilities
+  are in this patient's care graph?" and anti-kickback referral-pattern analysis.
+
+Graphiti answers these natively because it stores **Entity → relationship → Entity**
+edges. Lians should too — but built on our existing strengths rather than bolting
+on a graph database.
+
+### How we adopt it without a graph DB
+
+We already have the hard parts Graphiti needs and Postgres can express:
+
+- **Bitemporality** — Graphiti's edge `valid_at`/`invalid_at` is exactly our
+  `valid_from`/`valid_to`. A `relationships` table inherits our temporal model for
+  free, so point-in-time graph queries (`as_of`) and the audit chain extend to edges.
+- **N-hop traversal** — PostgreSQL **recursive CTEs** do bounded traversal without
+  Neo4j. We avoid running, securing, and compliance-certifying a second datastore.
+- **Determinism** — edges can be written *explicitly* (structured ingestion:
+  ownership filings, care-team rosters, matter-party lists) so the graph is
+  reproducible and audit-grade, with LLM extraction as an *optional* enrichment
+  path — the same posture we already take for supersession.
+- **Barriers & erasure** — edges carry `namespace` + `barrier_group` and reference
+  subjects, so RLS isolation and crypto-shred apply unchanged.
+
+This neutralizes Zep's main differentiator while keeping our compliance posture and
+single-datastore simplicity.
+
+---
+
+## 2. Smaller inspirations, ranked
+
+1. **Bitemporal relationship edges (graph layer).** Highest value; see §1. A
+   `relationships` table + `/v1/graph/*` endpoints + recursive-CTE traversal +
+   point-in-time edge queries. Verticals: COI (legal), related-party (finance),
+   care network (healthcare).
+2. **Graph-proximity reranking.** Once edges exist, boost recall for facts about
+   entities near the query entity in the graph — Graphiti's node-distance rerank.
+   Cheap to add to our existing ranker; improves precision on connected topics.
+3. **Custom ontology / entity & relationship types.** Extend domain adapters to
+   declare *entity types* and *allowed relationship types* (e.g. finance:
+   `Issuer`, `Fund`, `Person` with `owns`, `controls`, `advises`). Keeps extraction
+   constrained and auditable — closer to Graphiti's "prescribed ontology" than its
+   "learned" one, which suits regulated determinism.
+4. **Episode grouping with shared provenance.** Graphiti's "episode" = one
+   ingestion unit that every derived fact/edge points back to. We have `event_log`;
+   adding an `episode_id` that groups the facts/edges from one document or message
+   batch strengthens lineage ("which filing produced this ownership edge?").
+5. **Evolving entity summaries.** Graphiti keeps a rolling per-entity summary.
+   Useful but LLM-dependent and non-deterministic — lower priority for us; if
+   added, mark summaries clearly as *derived, non-authoritative* so they never
+   contaminate the audit-grade fact store.
+
+Deliberately **not** adopting: a mandatory graph database, fully *learned*
+ontology (non-reproducible), and LLM extraction as the *only* write path. These
+trade away the determinism and infra-simplicity that make Lians defensible.
+
+---
+
+## 3. What we should keep that Graphiti lacks
+
+Graphiti is an engine, not a product — by its own docs it has **no access control,
+no multi-tenancy, no audit logs, and no compliance features** beyond episode
+provenance; Zep Cloud supplies those. Lians' differentiators are exactly that gap:
+the SEC 17a-4 hash chain, crypto-shred erasure with surviving audit, DB-layer
+information barriers, conflict-review queue, backtest-contamination proof, and
+deterministic supersession. A graph layer should extend these, never dilute them —
+every edge belongs in the audit chain and inside the barrier, just like every fact.
+
+---
+
+## 4. What we shipped (items 1 & 2)
+
+The **bitemporal relationship graph** and **graph-proximity reranking** are now in
+the codebase as an additive layer — no new datastore, full compliance spine:
+
+- `relationships` table — same temporal (`valid_from`/`valid_to`/`event_time`),
+  audit, barrier, and subject columns as `memories`. Migration `0012_relationships`
+  enables the same RLS barrier policy on edges.
+- Writes go through the audit hash chain (`op="relate"` / `op="unrelate"`) and fire
+  the `relationship.invalidated` webhook. `exclusive=True` gives deterministic
+  contradiction-style invalidation (e.g. a person's current employer).
+- `POST /v1/graph/relate` · `POST /v1/graph/unrelate` · `GET /v1/graph/neighbors`
+  (N-hop) · `GET /v1/graph/path` (the COI / related-party reachability query) —
+  **all point-in-time capable via `as_of`**. Traversal runs in-process over the
+  namespace's edges (recursive SQL is a later optimization, not an API change).
+- **Graph-proximity reranking** (`recall_near` / `_near_entity` filter): recall
+  results about entities near the query's anchor entity get a node-distance boost,
+  Graphiti-style — without displacing strong semantic matches.
+- SDK (`relate`/`unrelate`/`neighbors`/`path`/`recall_near` on all three clients) +
+  harness helpers + `entity normalization` reuse so `Apple Inc.`/`AAPL`/ISIN
+  collapse to one node when `normalize=True`.
+
+This gives Lians graph reasoning **and** keeps the compliance spine — the one thing
+neither Graphiti nor Zep Cloud offers in the open.
+
+### Still open (lower priority)
+Items 3–5 from §2 — custom entity/relationship *ontology* types, episode grouping
+with shared provenance, and (clearly-marked, non-authoritative) evolving entity
+summaries — remain future work.

--- a/integrations/codex/AGENTS.md
+++ b/integrations/codex/AGENTS.md
@@ -1,0 +1,102 @@
+# Lians Memory — Codex Agent Instructions
+
+This repository (or session) uses **Lians**, a financial-grade memory layer, to
+give the agent persistent, compliance-safe memory across runs. When working here,
+treat Lians as the source of truth for facts that change over time — guidance
+revisions, dosage changes, matter status, prior decisions.
+
+Use it in regulated contexts: **financial institutions, healthcare, and legal
+firms**. Lians' bitemporal model means stale facts are excluded automatically, so
+the context you reason over is never contaminated by outdated revisions.
+
+## When to use memory
+
+- **Before answering** a question that depends on prior facts, *recall* first.
+- **After establishing** a new fact or making a decision, *remember* it with the
+  business event-time (when it became true), not the current time.
+- **For audit questions** ("what did we know on/before <date>"), use point-in-time
+  recall — never present-state recall.
+
+## Setup
+
+```bash
+pip install lians-sdk            # hosted/self-hosted client
+# or
+pip install lians-sdk[local]     # zero-setup local SQLite, no server/API key
+```
+
+Environment (hosted/self-hosted mode):
+
+```
+LIANS_URL=https://api.lians.dev          # or your self-hosted server
+LIANS_API_KEY=lians_...                  # free key at api.lians.dev
+LIANS_AGENT_ID=codex-session             # memory namespace for this agent
+```
+
+## Core operations
+
+```python
+from lians import LiansClient            # or LocalLiansClient (no env vars)
+from datetime import datetime, timezone
+import os
+
+mem = LiansClient(base_url=os.environ["LIANS_URL"], api_key=os.environ["LIANS_API_KEY"])
+agent = os.environ.get("LIANS_AGENT_ID", "codex-session")
+
+# Remember — event_time is the BUSINESS time the fact became true
+mem.add(agent_id=agent,
+        content="NVDA FY2026 revenue guidance raised to $40B",
+        event_time=datetime(2025, 11, 19, tzinfo=timezone.utc),
+        metadata={"ticker": "NVDA", "metric": "revenue_guidance"})
+
+# Recall — current (non-stale) facts only
+for m in mem.recall(agent_id=agent, query="NVDA revenue guidance")["memories"]:
+    print(m["event_time"], m["content"])
+
+# Point-in-time — what did we know on a past date?
+mem.recall_at(agent_id=agent, query="NVDA revenue guidance",
+              as_of=datetime(2025, 9, 1, tzinfo=timezone.utc))
+```
+
+## Drop-in agent loop (recommended)
+
+The harness wraps recall-before / remember-after in one object so you don't have
+to hand-wire it into the turn loop:
+
+```python
+from lians import LiansClient, LiansMemoryHarness
+
+harness = LiansMemoryHarness(
+    LiansClient(base_url=os.environ["LIANS_URL"], api_key=os.environ["LIANS_API_KEY"]),
+    agent_id=agent,
+    domain="finance",          # or "healthcare" / "legal"
+)
+
+def call_model(context: str, query: str) -> str:
+    ...  # your model call; inject `context` into the prompt
+
+answer = harness.run_turn(user_query, generate=call_model)   # recall → model → remember
+```
+
+## Compliance surfaces (use, don't fake)
+
+| Need | Call |
+|------|------|
+| Reconstruct full state at date T | `mem.snapshot(agent_id, as_of=T)` |
+| Verify audit chain integrity | `mem.verify_chain()` |
+| Detect lookahead bias in a backtest | `mem.backtest_check(agent_id, simulation_as_of=T)` |
+| GDPR/HIPAA crypto-shred a subject | `mem.erase(subject_id, request_ref)` |
+
+## Rules
+
+- Never invent an `event_time` you weren't given — store the precision you have.
+- Never paraphrase audit/snapshot output — report it literally.
+- If a recalled fact's `content` is `null`, it was crypto-shredded; say so.
+- `erase()` is irreversible and requires a request reference — confirm first.
+
+## MCP alternative
+
+If you prefer native tools over the SDK, run Lians as an MCP server and Codex gets
+eight memory tools automatically (`remember`, `recall`, `recall_at`, `reconstruct`,
+`list_conflicts`, `memory_lineage`, `fact_history`, `backtest_check`). See
+`config.example.toml` in this folder.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,49 @@
+# Lians for Codex
+
+Persistent, financial-grade memory for the [Codex](https://github.com/openai/codex)
+agent — with the compliance guarantees regulated teams need (bitemporal recall,
+SEC 17a-4 audit chain, GDPR/HIPAA crypto-shred, information barriers).
+
+## Two ways to wire it in
+
+### 1. AGENTS.md (recommended)
+
+Copy [`AGENTS.md`](./AGENTS.md) to your project root (or merge it into an existing
+`AGENTS.md`). Codex reads it automatically and learns when and how to recall and
+remember through the Lians SDK / harness.
+
+```bash
+cp integrations/codex/AGENTS.md ./AGENTS.md
+pip install lians-sdk          # or lians-sdk[local] for zero-setup SQLite
+```
+
+Set `LIANS_URL`, `LIANS_API_KEY`, and `LIANS_AGENT_ID` in your environment (free
+key at [api.lians.dev](https://api.lians.dev)). Local mode needs no env vars.
+
+### 2. MCP server (native tools)
+
+Add the block from [`config.example.toml`](./config.example.toml) to
+`~/.codex/config.toml`. Codex gains eight native memory tools (`remember`,
+`recall`, `recall_at`, `reconstruct`, `list_conflicts`, `memory_lineage`,
+`fact_history`, `backtest_check`) with no SDK code in your project.
+
+## Install via the skills standard
+
+Lians ships cross-tool skills installable with `npx skills add` (works for Codex,
+Claude Code, Cursor, and other skills-standard hosts):
+
+```bash
+npx skills add https://github.com/Lians-ai/Lians --skill lians
+npx skills add https://github.com/Lians-ai/Lians --skill lians-integrate
+```
+
+See [`../../skills/`](../../skills) for the skill definitions.
+
+## Why Lians over a plain vector store
+
+Codex agents that touch financial, clinical, or legal facts accumulate data that
+**changes over time** — guidance revisions, dosage changes, matter status. A plain
+vector store returns every version with equal rank and contaminates your context.
+Lians excludes superseded facts at the database layer and can reconstruct exactly
+what the agent knew at any past date. See the
+[mem0 comparison](../../docs/compare-mem0.md).

--- a/integrations/codex/config.example.toml
+++ b/integrations/codex/config.example.toml
@@ -1,0 +1,31 @@
+# Lians MCP server for Codex CLI
+#
+# Add this block to your Codex config (~/.codex/config.toml) to expose Lians as a
+# native MCP tool server. Codex will gain the eight Lians memory tools without any
+# SDK code in your project.
+#
+# Requires `uvx` (ships with `uv`): https://docs.astral.sh/uv/
+# Install uv, then Codex launches the server on demand via the command below.
+
+[mcp_servers.lians]
+command = "uvx"
+args = ["--from", "lians-sdk[mcp]", "lians-mcp"]
+
+[mcp_servers.lians.env]
+# Point at the managed cloud (free tier) or your self-hosted server.
+LIANS_URL = "https://api.lians.dev"
+# Get a free key at api.lians.dev, or use your self-hosted key.
+LIANS_API_KEY = "lians_..."
+# Memory namespace for this agent/session.
+LIANS_AGENT_ID = "codex-session"
+
+# ── Local mode (no server, no API key) ─────────────────────────────────────────
+# For prototyping you can omit LIANS_URL / LIANS_API_KEY and run the local SQLite
+# backend instead:
+#
+#   [mcp_servers.lians]
+#   command = "uvx"
+#   args = ["--from", "lians-sdk[mcp,local]", "lians-mcp"]
+#   [mcp_servers.lians.env]
+#   LIANS_LOCAL = "1"
+#   LIANS_AGENT_ID = "codex-session"

--- a/integrations/lians-plugin/.claude-plugin/plugin.json
+++ b/integrations/lians-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "lians",
+  "description": "Financial-grade agent memory for Claude Code — bitemporal recall, SEC 17a-4 audit chain, GDPR/HIPAA crypto-shred, and information barriers. Built for finance, healthcare, and legal teams.",
+  "version": "0.2.0",
+  "author": {
+    "name": "Lians",
+    "email": "support@lians.dev",
+    "url": "https://github.com/Lians-ai/Lians"
+  },
+  "homepage": "https://github.com/Lians-ai/Lians",
+  "repository": "https://github.com/Lians-ai/Lians",
+  "license": "Apache-2.0",
+  "keywords": [
+    "memory",
+    "agent-memory",
+    "compliance",
+    "bitemporal",
+    "audit",
+    "finance",
+    "healthcare",
+    "legal",
+    "gdpr",
+    "hipaa"
+  ]
+}

--- a/integrations/lians-plugin/agents/lians-compliance.md
+++ b/integrations/lians-plugin/agents/lians-compliance.md
@@ -1,0 +1,43 @@
+---
+name: lians-compliance
+description: Compliance-focused memory agent for regulated work. Use when a task involves point-in-time reconstruction, audit-chain verification, lookahead-bias checks, or data-subject erasure against a Lians memory store — in finance, healthcare, or legal contexts.
+tools: Bash, Read, Grep, Glob
+---
+
+You are a compliance memory specialist operating a Lians financial-grade memory
+store. Your job is to produce **evidentiary** answers — the kind a SEC/FINRA
+examiner, a HIPAA auditor, or opposing counsel would accept — never best-effort
+guesses.
+
+## Operating rules
+
+- **Point-in-time is mandatory** for any "what did we know on/before <date>"
+  question. Use `recall_at(..., as_of=<date>)` or `snapshot(agent_id, as_of=<date>)`.
+  Never answer an as-of question with present-state recall.
+- **Quote, don't paraphrase.** Report each fact with its `event_time`, `source`,
+  and (for snapshots) the total count. If `content` is `null`, the record was
+  crypto-shredded — state that explicitly; do not reconstruct erased content.
+- **Verify before asserting integrity.** When asked whether records are intact,
+  run `verify_chain()` and report the literal result, including any violations.
+- **Erasure is irreversible and gated.** Never run `erase()` without an explicit
+  request reference and user confirmation. Always note the audit chain survives.
+- **Backtests need proof.** Before trusting any historical simulation, run
+  `backtest_check(agent_id, simulation_as_of=<date>)` and report `is_clean` and
+  every flag.
+
+## Vertical context
+
+- **Finance** — SEC 17a-4 / FINRA 4511 recordkeeping, MiFID II point-in-time,
+  information barriers between desks. Key facts: `ticker` + `metric`.
+- **Healthcare** — HIPAA §164.312 safeguards; per-subject erasure keyed on
+  `patient_id`; care-team barriers. Requires a BAA before real PHI.
+- **Legal** — FRCP Rule 34 eDiscovery (privilege-cutoff reconstruction), ABA
+  conflict walls per matter, chain-of-custody via the hash chain. Key facts:
+  `matter_id` + `claim_type`.
+
+## How to access memory
+
+Use the Python SDK (`from lians import LiansClient`) with `LIANS_URL` and
+`LIANS_API_KEY` from the environment, or `LocalLiansClient` for a local store.
+If neither is configured, say so and ask for the connection details rather than
+fabricating results.

--- a/integrations/lians-plugin/commands/lians-audit.md
+++ b/integrations/lians-plugin/commands/lians-audit.md
@@ -1,0 +1,47 @@
+---
+description: Run a Lians compliance/audit operation — snapshot, chain verify, backtest, or erasure
+argument-hint: snapshot <agent> <date> | verify | backtest <agent> <date> | erase <subject> <ref>
+---
+
+# /lians-audit
+
+Run the compliance surfaces that make Lians defensible to a regulator, examiner,
+or opposing counsel. Parse the operation from **$ARGUMENTS** and execute the
+matching call. Always print exactly what was returned — these are evidentiary
+outputs; do not paraphrase or soften them.
+
+## Operations
+
+### `snapshot <agent_id> <YYYY-MM-DD>`
+Exhaustive knowledge-state reconstruction — *every* fact valid at that instant,
+not a ranked top-k. The one-call demo for "show me everything the agent knew on
+2025-03-14."
+```python
+snap = mem.snapshot(agent_id="<agent>", as_of=datetime(...))
+print(snap["total"], "facts valid at", snap["as_of"])
+```
+
+### `verify`
+Verify the SEC 17a-4 tamper-evident SHA-256 hash chain. A broken link means the
+audit log was altered.
+```python
+print(mem.verify_chain())   # {"status": "ok", "rows_checked": N, "violations": []}
+```
+
+### `backtest <agent_id> <YYYY-MM-DD>`
+Lookahead-bias detection — flags any fact the agent held that it could not have
+known at the simulation date. A clean report is the proof a risk committee needs.
+```python
+r = mem.backtest_check(agent_id="<agent>", simulation_as_of=datetime(...))
+print("clean" if r["is_clean"] else f"{len(r['flags'])} contamination flags")
+```
+
+### `erase <subject_id> <request_ref>`
+GDPR Art. 17 / HIPAA crypto-shred. Destroys the subject's per-subject key so all
+their content becomes unreadable — **the audit hash chain survives**. This is
+irreversible. Confirm with the user before running, and record the `request_ref`.
+```python
+print(mem.erase(subject_id="<subject>", request_ref="<ref>"))
+```
+
+If the operation isn't recognized, list these four and ask which one.

--- a/integrations/lians-plugin/commands/lians-integrate.md
+++ b/integrations/lians-plugin/commands/lians-integrate.md
@@ -1,0 +1,48 @@
+---
+description: Wire Lians memory into the current repository with a test-driven, minimal-diff integration
+argument-hint: [framework: langchain | langgraph | crewai | openai-agents | autogen | raw]
+---
+
+# /lians-integrate
+
+Integrate Lians as the memory layer for the agent in **this** repository. Work
+test-first and keep the diff minimal — you are adding a memory layer, not
+rewriting the app.
+
+## Procedure
+
+1. **Survey.** Identify the agent loop: where the model is called, where context
+   is assembled, and where turns complete. Detect the framework (or honor the one
+   named in **$ARGUMENTS**). If none, use the raw harness.
+
+2. **Branch.** Create a feature branch `lians-integration` before editing.
+
+3. **Add the dependency.** Choose the matching extra:
+   - `pip install lians-sdk[langchain]` / `[langgraph]` / `[crewai]` /
+     `[openai-agents]` / `[autogen]`
+   - raw / unknown framework → `pip install lians-sdk` and use the harness.
+
+4. **Wire it.** Prefer the harness for raw loops:
+   ```python
+   from lians import LiansClient, LiansMemoryHarness
+   harness = LiansMemoryHarness(
+       LiansClient(base_url=os.environ["LIANS_URL"], api_key=os.environ["LIANS_API_KEY"]),
+       agent_id="<this-agent>",
+       domain="finance",          # or healthcare / legal
+   )
+   # before model call:  context = harness.recall_context(user_query)
+   # after model call:    harness.remember(response)
+   # or both at once:     answer = harness.run_turn(user_query, generate=call_model)
+   ```
+   For a framework, import its integration module instead
+   (`from lians.langchain_integration import build_tools`, etc.).
+
+5. **Test.** Add a test that proves recall-before/remember-after works and that
+   a superseding write hides the stale fact. Use `LocalLiansClient` so the test
+   needs no server or API key. Run the suite.
+
+6. **Report.** Summarize the diff, the env vars required
+   (`LIANS_URL`, `LIANS_API_KEY`, `LIANS_AGENT_ID`), and how to verify locally.
+
+Do not commit. Leave the branch for the user to review. If tests fail, stop and
+report — do not mark the integration done.

--- a/integrations/lians-plugin/commands/lians-recall.md
+++ b/integrations/lians-plugin/commands/lians-recall.md
@@ -1,0 +1,40 @@
+---
+description: Recall current (non-stale) facts from Lians memory, optionally as-of a past date
+argument-hint: <what to recall> [as of YYYY-MM-DD]
+---
+
+# /lians-recall
+
+Retrieve the facts Lians holds that are relevant to **$ARGUMENTS**. By default you
+get the *current* state — superseded/stale revisions are excluded at the database
+layer, so you never reason over contaminated context.
+
+## What to do
+
+1. Parse the query and any "as of <date>" clause from **$ARGUMENTS**.
+2. Recall:
+
+```python
+from lians import LiansClient  # or LocalLiansClient
+mem = LiansClient(base_url=os.environ["LIANS_URL"], api_key=os.environ["LIANS_API_KEY"])
+
+# Present state (default)
+res = mem.recall(agent_id=os.environ.get("LIANS_AGENT_ID", "claude-session"),
+                 query="<query>", k=5)
+
+# Point-in-time — "what did we know on that date?"
+res = mem.recall_at(agent_id=..., query="<query>",
+                    as_of=datetime(YYYY, M, D, tzinfo=timezone.utc))
+
+for m in res["memories"]:
+    print(m["event_time"], m["content"])
+```
+
+3. Present the facts with their **event_time** and source so the user can judge
+   recency and provenance. If a fact's `content` is `null`, it was crypto-shredded
+   (GDPR/HIPAA erasure) — say so rather than guessing.
+4. If nothing is found, say so plainly. Do not fabricate recalled facts.
+
+When the user asks an audit-style question ("what did we know on X", "before the
+trade", "before the privilege cutoff"), always use `recall_at` with that date —
+this is the point-in-time guarantee mem0 and Zep cannot provide.

--- a/integrations/lians-plugin/commands/lians-remember.md
+++ b/integrations/lians-plugin/commands/lians-remember.md
@@ -1,0 +1,43 @@
+---
+description: Store a fact in Lians memory with its business event-time and metadata
+argument-hint: <fact to remember> [as of YYYY-MM-DD]
+---
+
+# /lians-remember
+
+Persist a fact to Lians memory so it survives across this and future sessions.
+Lians applies supersession automatically: if the new fact contradicts an existing
+one (same ticker+metric, same patient+condition, same matter+claim), the older
+fact is marked superseded and disappears from future recall — but stays auditable
+via point-in-time queries.
+
+## What to do
+
+1. Parse the fact from: **$ARGUMENTS**
+2. Determine the **event_time** — *when the fact became true* (business time), not
+   now. If the user wrote "as of <date>", use it. Otherwise default to today and
+   say so.
+3. Infer structured metadata where obvious, so supersession can key on it:
+   - finance → `{"ticker": "...", "metric": "..."}`
+   - healthcare → `{"patient_id": "...", "condition": "..."}`
+   - legal → `{"matter_id": "...", "claim_type": "..."}`
+4. Write it. Prefer the Python SDK if `lians` is importable; otherwise call the
+   REST API with the env vars `LIANS_URL` / `LIANS_API_KEY`.
+
+```python
+from lians import LiansClient  # or LocalLiansClient for local SQLite
+from datetime import datetime, timezone
+
+mem = LiansClient(base_url=os.environ["LIANS_URL"], api_key=os.environ["LIANS_API_KEY"])
+mem.add(
+    agent_id=os.environ.get("LIANS_AGENT_ID", "claude-session"),
+    content="<the fact>",
+    event_time=datetime(YYYY, M, D, tzinfo=timezone.utc),
+    metadata={...},
+)
+```
+
+5. Confirm what was stored, the event_time used, and any metadata inferred.
+
+Never invent an event_time precision you don't have — if the user only gave a
+date, store the date, not a fabricated timestamp.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[build-system]
+[build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Self-hosted embeddings â€” no external API calls, suitable for air-gapped deployments.
+# Self-hosted embeddings — no external API calls, suitable for air-gapped deployments.
 # Default model BAAI/bge-large-en-v1.5 requires ~1.3 GB disk; downloaded on first use.
 # For fully offline use, pre-download the model and set SENTENCE_TRANSFORMER_MODEL=/path.
 local = [

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,34 @@
+# Lians Skills
+
+Cross-tool agent skills for [Lians](https://github.com/Lians-ai/Lians), the
+financial-grade memory layer. These follow the **skills standard**, so they work
+in Claude Code, Codex, Cursor, and any compatible host.
+
+| Skill | Type | What it does |
+|-------|------|--------------|
+| [`lians`](./lians/SKILL.md) | reference | Teaches the agent to store and recall facts correctly through the Lians SDK and harness — bitemporal, compliance-safe. |
+| [`lians-integrate`](./lians-integrate/SKILL.md) | pipeline | Wires Lians into an existing agent codebase, test-first and minimal-diff. |
+
+## Install
+
+```bash
+npx skills add https://github.com/Lians-ai/Lians --skill lians
+npx skills add https://github.com/Lians-ai/Lians --skill lians-integrate
+```
+
+## Tool-specific packaging
+
+- **Claude Code** — a full plugin (commands + compliance subagent) lives in
+  [`../integrations/lians-plugin`](../integrations/lians-plugin), registered via
+  the root [`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json).
+- **Codex** — drop-in `AGENTS.md` and MCP config in
+  [`../integrations/codex`](../integrations/codex).
+- **Any MCP host** — Lians is on the
+  [official MCP Registry](https://registry.modelcontextprotocol.io/servers/io.github.ebeirne/lians).
+
+## Why these exist
+
+Agents in finance, healthcare, and legal accumulate facts that change over time.
+A plain vector store returns every stale revision with equal rank. Lians excludes
+superseded facts at the database layer and reconstructs exactly what the agent
+knew at any past date — see the [mem0 comparison](../docs/compare-mem0.md).

--- a/skills/lians-integrate/SKILL.md
+++ b/skills/lians-integrate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lians-integrate
+description: Wire Lians memory into an existing agent codebase, test-first and minimal-diff. Use when the user asks to add persistent/compliance memory to their agent, integrate Lians, or replace a vector store with bitemporal memory.
+---
+
+# Integrate Lians into this repository
+
+A pipeline skill: add Lians as the memory layer for the agent in **this** repo.
+Add a memory layer; don't rewrite the app. Work test-first.
+
+## Procedure
+
+1. **Survey the agent loop.** Find where the model is called, where context is
+   assembled, and where a turn completes. Detect the framework in use.
+
+2. **Branch.** `git checkout -b lians-integration` before editing.
+
+3. **Install** the matching package:
+   - LangChain → `pip install lians-sdk[langchain]`
+   - LangGraph → `pip install lians-sdk[langgraph]`
+   - CrewAI → `pip install lians-sdk[crewai]`
+   - OpenAI Agents SDK → `pip install lians-sdk[openai-agents]`
+   - AutoGen → `pip install lians-sdk[autogen]`
+   - raw / unknown → `pip install lians-sdk` (use the harness)
+
+4. **Wire memory in.**
+
+   Raw loop — use the harness:
+   ```python
+   from lians import LiansClient, LiansMemoryHarness
+   harness = LiansMemoryHarness(
+       LiansClient(base_url=os.environ["LIANS_URL"], api_key=os.environ["LIANS_API_KEY"]),
+       agent_id="<this-agent>",
+       domain="finance",   # or healthcare / legal
+   )
+   # before model call: context = harness.recall_context(user_query)
+   # after model call:  harness.remember(response)
+   # or both:           answer = harness.run_turn(user_query, generate=call_model)
+   ```
+
+   Framework — import its integration module:
+   ```python
+   from lians.langchain_integration import LiansChatHistory, build_tools
+   from lians.langgraph_integration import create_recall_node, create_remember_node
+   from lians.crewai_integration import build_crewai_tools
+   from lians.openai_agents_integration import build_openai_agent_tools
+   from lians.autogen_integration import build_autogen_tools
+   ```
+
+5. **Test (required).** Add a test using `LocalLiansClient` (no server/API key)
+   that proves: (a) a remembered fact is recalled, and (b) a superseding write
+   hides the stale fact from `recall` but `recall_at(as_of=...)` still sees it.
+   Run the suite.
+
+6. **Report.** Summarize the diff, the env vars required (`LIANS_URL`,
+   `LIANS_API_KEY`, `LIANS_AGENT_ID`), and how to verify locally. **Do not
+   commit** — leave the branch for review.
+
+## Guardrails
+
+- Keep the diff small and reversible.
+- Store `event_time` as the business time of each fact, not `datetime.now()`,
+  wherever the source provides it — point-in-time recall and backtest checks
+  depend on it.
+- If tests fail, stop and report. Do not declare the integration complete.

--- a/skills/lians/SKILL.md
+++ b/skills/lians/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: lians
+description: Use Lians financial-grade agent memory — store and recall facts with a bitemporal model so stale revisions never contaminate context. Use whenever an agent needs persistent memory in finance, healthcare, or legal work, or when a task asks "what did we know on/before <date>", needs an audit trail, or must erase a data subject.
+---
+
+# Lians Memory
+
+Lians is a memory layer for AI agents built for regulated environments. Unlike a
+plain vector store, it uses a **bitemporal** model: every fact carries the
+business time it became true (`event_time`) and the system time it was known
+(`valid_from`/`valid_to`). When a new fact supersedes an old one, the old one is
+excluded from recall automatically — but remains reconstructable for any past date.
+
+Use Lians when the agent works with facts that **change over time**: guidance
+revisions, dosage changes, matter status, prior decisions — and when those changes
+must be auditable.
+
+## Setup
+
+```bash
+pip install lians-sdk          # hosted / self-hosted
+pip install lians-sdk[local]   # zero-setup local SQLite (no server, no API key)
+```
+
+Environment (hosted/self-hosted): `LIANS_URL`, `LIANS_API_KEY`, `LIANS_AGENT_ID`.
+Get a free key at api.lians.dev. Local mode needs none.
+
+## Clients (same API surface)
+
+```python
+from lians import LiansClient        # sync HTTP — scripts, CLIs
+from lians import AsyncLiansClient   # async HTTP — FastAPI, async frameworks
+from lians import LocalLiansClient   # local SQLite — prototyping, CI, notebooks
+```
+
+## Core operations
+
+```python
+from datetime import datetime, timezone
+mem = LiansClient(base_url=os.environ["LIANS_URL"], api_key=os.environ["LIANS_API_KEY"])
+
+# Store — event_time is the BUSINESS time the fact became true, not now
+mem.add(agent_id="desk", content="NVDA guidance raised to $40B",
+        event_time=datetime(2025, 11, 19, tzinfo=timezone.utc),
+        metadata={"ticker": "NVDA", "metric": "revenue_guidance"})
+
+# Recall — current, non-stale facts only
+res = mem.recall(agent_id="desk", query="NVDA guidance", k=5)
+for m in res["memories"]:
+    print(m["event_time"], m["content"])
+
+# Point-in-time — what did we know on a past date?
+mem.recall_at(agent_id="desk", query="NVDA guidance",
+              as_of=datetime(2025, 9, 1, tzinfo=timezone.utc))
+
+# From a conversation
+mem.add_from_messages(agent_id="desk",
+    messages=[{"role": "assistant", "content": "TSLA Q4 deliveries hit 495k"}])
+```
+
+## Drop-in agent loop — the harness
+
+For a turn-based agent, the harness handles recall-before / remember-after for you:
+
+```python
+from lians import LiansClient, LiansMemoryHarness
+
+harness = LiansMemoryHarness(mem, agent_id="desk", domain="finance")  # finance|healthcare|legal
+
+context = harness.recall_context("NVDA guidance")    # ready to inject into a prompt
+harness.remember("Desk note: guidance now $40B")     # write after the turn
+# or both in one call:
+answer = harness.run_turn(user_query, generate=lambda ctx, q: call_model(ctx, q))
+```
+
+Scope writes to a data subject and information barrier when needed:
+
+```python
+harness = LiansMemoryHarness(mem, agent_id="care-3",
+                             subject_id="MRN-00042",   # per-subject key → crypto-shred target
+                             barrier_group="oncology", # information-barrier tag
+                             domain="healthcare")
+```
+
+## Compliance surfaces
+
+| Need | Call |
+|------|------|
+| Full knowledge state at date T | `mem.snapshot(agent_id, as_of=T)` |
+| Verify SEC 17a-4 audit chain | `mem.verify_chain()` |
+| Detect lookahead bias in a backtest | `mem.backtest_check(agent_id, simulation_as_of=T)` |
+| GDPR/HIPAA crypto-shred a subject | `mem.erase(subject_id, request_ref)` |
+
+## Rules
+
+- `event_time` = when the fact became true (business time), **not** now. Store the
+  precision you were given; never fabricate a timestamp.
+- For any "what did we know on/before <date>" question, use `recall_at` /
+  `snapshot` — never present-state `recall`.
+- Report audit/snapshot output literally; do not paraphrase evidentiary results.
+- If a recalled fact's `content` is `null`, it was crypto-shredded — say so.
+- `erase()` is irreversible and needs a request reference — confirm before running.
+
+## Domain metadata (enables keyed supersession)
+
+- finance → `{"ticker": "...", "metric": "..."}`
+- healthcare → `{"patient_id": "...", "condition": "..."}`
+- legal → `{"matter_id": "...", "claim_type": "..."}`


### PR DESCRIPTION
## What this adds

Agent-facing integrations for Lians, built for the regulated verticals (finance, healthcare, legal), plus repairs that make the API actually importable again.

### Integrations
- **Agent harness** (`LiansMemoryHarness`) — a drop-in recall-before / remember-after loop with compliance scoping (`subject_id`, `barrier_group`, `domain`) and `snapshot` / `backtest_check` / `erase` pass-throughs. Works with any sync client. Exported from the SDK; 17 tests; runnable `agentmem/examples/harness_demo.py`.
- **Claude Code plugin** (`integrations/lians-plugin`) — `plugin.json`, slash commands (`/lians-remember`, `/lians-recall`, `/lians-audit`, `/lians-integrate`), and a `lians-compliance` subagent.
- **Codex plugin** (`integrations/codex`) — drop-in `AGENTS.md`, MCP `config.example.toml`, README.
- **Cross-tool skills** (`skills/`) — `lians` (reference) + `lians-integrate` (pipeline), installable via `npx skills add`.
- **`docs/compare-mem0.md`** — honest quality & access comparison vs mem0, framed per vertical.

### Quality fixes (the package was unimportable — the server would not start)
- UTF-8 BOM in root `pyproject.toml` broke pytest's config parsing.
- `backtest.py` imported a renamed helper (`_decrypt` now lives in `ranking`).
- `local_client.backtest_check` projected the dataclass onto `ContaminationReportOut`.
- Restored six service functions that routes/SDK imported but never existed: `get_knowledge_snapshot`, `get_memory_lineage`, `get_structured_fact_history` (alias-aware), `list_conflicts`, `resolve_conflict`, `get_erasure_certificate`.
- **Conflict persistence**: `add_memory` now writes `ConflictFlag` rows + `conflict_detected` audit events, so the human-review queue actually functions.
- **Webhook dispatch**: `memory.superseded` / `memory.conflict` / `memory.erased` are now fired from the write/erase path (previously documented but never wired).
- Fixed stale `agentmem.*` import paths in `test_airgap.py` after the `lians` rename.

## Testing
All previously-erroring suites now pass: harness (17), webhooks (23), conflicts (22), lineage, fact_history (18), snapshot, erasure + erasure-certificate, airgap (13), backtest, api, audit_chain, compliance_report, metrics, middleware, supersession_real_world — plus SDK (33). The 162-test verification batch was green except the one webhook gap, now fixed (58/58 in the follow-up run). pgvector tests remain skipped (no Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)