### PR TITLE
Add Java and C SDKs (languages no competitor offers)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,3 +103,50 @@ jobs:
       - name: Run Jest tests
         run: npm test
         working-directory: agentmem/sdk/typescript
+
+  # ── Java SDK tests ──────────────────────────────────────────────────────────
+  java:
+    name: Java SDK (Temurin ${{ matrix.java-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ["11", "17", "21"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java-version }}
+          cache: maven
+
+      - name: Build & test
+        run: mvn -B --no-transfer-progress verify
+        working-directory: agentmem/sdk/java
+
+  # ── C SDK tests ─────────────────────────────────────────────────────────────
+  c:
+    name: C SDK (CMake)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libcurl dev headers
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+        working-directory: agentmem/sdk/c
+
+      - name: Build
+        run: cmake --build build
+        working-directory: agentmem/sdk/c
+
+      - name: Test (pure helpers)
+        run: ctest --test-dir build --output-on-failure
+        working-directory: agentmem/sdk/c

--- a/README.md
+++ b/README.md
@@ -265,6 +265,27 @@ closed cloud. Lians keeps the graph **and** the open compliance spine.
 
 ---
 
+## Language SDKs
+
+Lians ships native SDKs across four languages — including **Java and C, which no
+other open agent-memory layer offers** (mem0 is Python/TypeScript; Zep adds Go).
+That puts the full compliance memory layer where regulated systems actually run:
+JVM risk platforms, and native/low-latency C in trading, market-data, and on-prem
+healthcare/legal stacks.
+
+| Language | Install | Client | Docs |
+|----------|---------|--------|------|
+| **Python** | `pip install lians-sdk` | `from lians import LiansClient` | [sdk/python](agentmem/sdk/python) |
+| **TypeScript / Node** | `npm install @ebeirne/lians` | `import { LiansClient } from "@ebeirne/lians"` | [sdk/typescript](agentmem/sdk/typescript) |
+| **Java** (JVM 11+) | `dev.lians:lians-sdk:0.2.0` (Maven) | `new LiansClient(opts)` | [sdk/java](agentmem/sdk/java) |
+| **C** (C99 + libcurl) | `cmake --build build` | `lians_client_new(...)` | [sdk/c](agentmem/sdk/c) |
+
+All four cover the same REST API: recall, point-in-time `recall_at`, snapshot,
+backtest, crypto-shred erasure, audit-chain verify, and the relationship graph
+(`relate` / `neighbors` / `path`).
+
+---
+
 ## Framework integrations
 
 | Framework | Install | Import |

--- a/agentmem/sdk/c/CMakeLists.txt
+++ b/agentmem/sdk/c/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.15)
+project(lians_c_sdk C)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
+find_package(CURL REQUIRED)
+
+# ── Library ──────────────────────────────────────────────────────────────────
+add_library(lians src/lians.c src/lians_json.c)
+target_include_directories(lians
+  PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(lians PUBLIC CURL::libcurl)
+
+if(MSVC)
+  target_compile_options(lians PRIVATE /W3)
+else()
+  target_compile_options(lians PRIVATE -Wall -Wextra)
+endif()
+
+# ── Example (compiles; needs a running server + env vars to do anything) ─────
+add_executable(lians_example examples/example.c)
+target_link_libraries(lians_example PRIVATE lians)
+
+# ── Tests (pure helpers — no network, no libcurl needed) ─────────────────────
+enable_testing()
+add_executable(lians_test_json tests/test_json.c src/lians_json.c)
+target_include_directories(lians_test_json PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(NAME json_unit COMMAND lians_test_json)

--- a/agentmem/sdk/c/README.md
+++ b/agentmem/sdk/c/README.md
@@ -1,0 +1,104 @@
+# Lians C SDK
+
+Financial-grade agent memory for native, low-latency, and embedded systems —
+bitemporal recall, SEC 17a-4 audit chain, GDPR/HIPAA crypto-shred, information
+barriers, and a relationship graph (conflict-of-interest / related-party /
+care-network).
+
+A thin [libcurl](https://curl.se/libcurl/) client. Responses come back as raw
+JSON strings, so it drops into HFT gateways, market-data plants, trading systems,
+and on-prem C/C++ stacks where Python and JVM SDKs don't fit. Pair with your JSON
+parser of choice (cJSON, jansson, RapidJSON, …).
+
+## Requirements
+
+- A C99 compiler and CMake ≥ 3.15
+- libcurl development headers (`libcurl4-openssl-dev` on Debian/Ubuntu,
+  `curl-devel` on RHEL, `brew install curl` on macOS)
+
+## Build
+
+```bash
+cd agentmem/sdk/c
+cmake -B build
+cmake --build build
+ctest --test-dir build --output-on-failure   # runs the pure-function unit tests
+```
+
+This produces the `lians` library, a `lians_example` binary, and the test runner.
+
+## Usage
+
+```c
+#include "lians.h"
+#include <stdio.h>
+
+int main(void) {
+    lians_global_init();
+    lians_client_t *c = lians_client_new("https://api.lians.dev", getenv("LIANS_API_KEY"), NULL);
+
+    /* Store a fact with its BUSINESS event-time (ISO-8601 UTC). */
+    lians_response_t r = lians_add(c, "equity-desk",
+        "NVDA FY2026 revenue guidance raised to $40B",
+        "2025-11-19T16:00:00Z",
+        "{\"ticker\":\"NVDA\",\"metric\":\"revenue_guidance\"}",
+        "analyst", NULL, 0.6);
+    printf("%ld %s\n", r.status, r.body);
+    lians_response_free(&r);
+
+    /* Recall current (non-stale) facts. */
+    r = lians_recall(c, "equity-desk", "NVDA revenue guidance", 5, NULL, NULL);
+    printf("%s\n", r.body);
+    lians_response_free(&r);
+
+    /* Point-in-time: what did we know on a past date? */
+    r = lians_recall(c, "equity-desk", "NVDA revenue guidance", 5, "2025-09-01T00:00:00Z", NULL);
+    lians_response_free(&r);
+
+    /* Conflict-of-interest reachability via the relationship graph. */
+    r = lians_path(c, "matter-7", "Attorney", "PartyY", 4, NULL);
+    /* -> {"connected": true, "hops": 2, "path": [...]} */
+    lians_response_free(&r);
+
+    lians_client_free(c);
+    lians_global_cleanup();
+    return 0;
+}
+```
+
+See [`examples/example.c`](examples/example.c) for a complete program.
+
+## API
+
+| Function | Purpose |
+|----------|---------|
+| `lians_add` | Store a fact (with event-time, metadata, subject) |
+| `lians_recall` | Recall current facts; pass `as_of` for point-in-time |
+| `lians_snapshot` | Exhaustive knowledge state at a date |
+| `lians_backtest_check` | Lookahead-bias detection |
+| `lians_fact_history` | Time-series of a ticker+metric |
+| `lians_erase` | GDPR/HIPAA crypto-shred a subject |
+| `lians_verify_chain` | Verify the SEC 17a-4 audit chain (admin) |
+| `lians_relate` / `lians_unrelate` | Assert / invalidate a graph edge |
+| `lians_neighbors` | N-hop neighbors of an entity |
+| `lians_path` | Connection between two entities (COI / related-party) |
+
+Every call returns a `lians_response_t { long status; char *body; }`:
+- `status` is the HTTP status code, or `< 0` if the request never completed.
+- `body` is a malloc'd JSON string — release it with `lians_response_free()`.
+
+## Memory & threading
+
+- Free every response body with `lians_response_free()`.
+- A `lians_client_t` is immutable after creation and safe to share across threads;
+  each call uses its own libcurl easy handle. Call `lians_global_init()` once at
+  startup in multi-threaded programs.
+
+## Why C + Lians
+
+mem0 ships Python/TypeScript only; Zep adds Go. Neither offers a C SDK — yet the
+lowest-latency and most regulated systems (HFT, exchange gateways, on-prem medical
+and legal devices) are native. This SDK brings the full compliance memory layer and
+the relationship graph to them. See the
+[mem0](../../../docs/compare-mem0.md) and [Zep/Graphiti](../../../docs/compare-zep.md)
+comparisons.

--- a/agentmem/sdk/c/examples/example.c
+++ b/agentmem/sdk/c/examples/example.c
@@ -1,0 +1,63 @@
+/*
+ * Lians C SDK example.
+ *
+ * Build:  cmake -B build && cmake --build build
+ * Run:    LIANS_URL=https://api.lians.dev LIANS_API_KEY=lians_... ./build/lians_example
+ */
+#include "lians.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static void show(const char *label, lians_response_t *r) {
+    printf("%-12s -> %ld  %s\n", label, r->status, r->body ? r->body : "(no body)");
+    lians_response_free(r);
+}
+
+int main(void) {
+    const char *url = getenv("LIANS_URL");
+    const char *key = getenv("LIANS_API_KEY");
+    if (!url || !key) {
+        printf("Set LIANS_URL and LIANS_API_KEY to run this example.\n");
+        return 0;
+    }
+
+    lians_global_init();
+    lians_client_t *c = lians_client_new(url, key, getenv("LIANS_ADMIN_SECRET"));
+    if (!c) {
+        fprintf(stderr, "client init failed\n");
+        lians_global_cleanup();
+        return 1;
+    }
+
+    /* Store a fact with its business event-time. */
+    lians_response_t r = lians_add(
+        c, "equity-desk", "NVDA FY2026 revenue guidance raised to $40B",
+        "2025-11-19T16:00:00Z",
+        "{\"ticker\":\"NVDA\",\"metric\":\"revenue_guidance\"}",
+        "analyst", NULL, 0.6);
+    show("add", &r);
+
+    /* Recall current facts. */
+    r = lians_recall(c, "equity-desk", "NVDA revenue guidance", 5, NULL, NULL);
+    show("recall", &r);
+
+    /* Point-in-time recall. */
+    r = lians_recall(c, "equity-desk", "NVDA revenue guidance", 5,
+                     "2025-09-01T00:00:00Z", NULL);
+    show("recall_at", &r);
+
+    /* Relationship graph: conflict-of-interest reachability. */
+    r = lians_relate(c, "matter-7", "Attorney", "represented", "ClientX",
+                     "2026-01-01T00:00:00Z", 0, 0);
+    show("relate", &r);
+    r = lians_relate(c, "matter-7", "ClientX", "adverse_to", "PartyY",
+                     "2026-01-01T00:00:00Z", 0, 0);
+    show("relate", &r);
+    r = lians_path(c, "matter-7", "Attorney", "PartyY", 4, NULL);
+    show("coi path", &r);
+
+    lians_client_free(c);
+    lians_global_cleanup();
+    return 0;
+}

--- a/agentmem/sdk/c/include/lians.h
+++ b/agentmem/sdk/c/include/lians.h
@@ -1,0 +1,127 @@
+/*
+ * Lians C SDK — financial-grade agent memory over the REST API.
+ *
+ * A thin libcurl-based client for the Lians memory layer: bitemporal recall,
+ * SEC 17a-4 audit chain, GDPR/HIPAA crypto-shred, information barriers, and a
+ * relationship graph (conflict-of-interest / related-party / care-network).
+ *
+ * Built for the native, low-latency, and embedded world — HFT, market-data
+ * gateways, and on-prem systems in finance, healthcare, and legal — where Python
+ * and JVM SDKs don't reach. Responses are returned as raw JSON strings; pair with
+ * your JSON parser of choice.
+ *
+ * Thread-safety: a lians_client_t is immutable after creation and may be shared
+ * across threads; each call uses its own libcurl easy handle.
+ *
+ * Memory: every call returns a lians_response_t whose `body` you must release
+ * with lians_response_free().
+ */
+#ifndef LIANS_H
+#define LIANS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque client handle. */
+typedef struct lians_client lians_client_t;
+
+/* Result of a request. status<0 means the request never completed (network/setup);
+ * otherwise status is the HTTP status code. body is a malloc'd NUL-terminated
+ * string (may be NULL on hard failure) that the caller frees via
+ * lians_response_free(). */
+typedef struct {
+    long  status;
+    char *body;
+} lians_response_t;
+
+/* One-time global init/cleanup (wraps curl_global_init/cleanup). Call lians_global_init
+ * once before creating clients in a multi-threaded program; optional otherwise. */
+int  lians_global_init(void);
+void lians_global_cleanup(void);
+
+/* Create a client. base_url and api_key are required; admin_secret may be NULL
+ * (needed only for /v1/admin/* audit endpoints). Returns NULL on failure. */
+lians_client_t *lians_client_new(const char *base_url, const char *api_key,
+                                 const char *admin_secret);
+
+/* Set the per-request timeout in milliseconds (default 30000). */
+void lians_client_set_timeout_ms(lians_client_t *client, long timeout_ms);
+
+/* Free a client. */
+void lians_client_free(lians_client_t *client);
+
+/* Free a response body. Safe on a zero-initialized response. */
+void lians_response_free(lians_response_t *resp);
+
+/* ── Write ─────────────────────────────────────────────────────────────────── */
+
+/* Store a fact. event_time is ISO-8601 UTC (the BUSINESS time, not now).
+ * metadata_json/source/subject_id may be NULL. metadata_json must be a raw JSON
+ * object literal, e.g. "{\"ticker\":\"NVDA\",\"metric\":\"eps\"}". */
+lians_response_t lians_add(lians_client_t *client, const char *agent_id,
+                           const char *content, const char *event_time,
+                           const char *metadata_json, const char *source,
+                           const char *subject_id, double importance);
+
+/* ── Read ──────────────────────────────────────────────────────────────────── */
+
+/* Recall current (non-stale) facts. as_of/filters_json may be NULL. Pass as_of
+ * (ISO-8601 UTC) for point-in-time recall. */
+lians_response_t lians_recall(lians_client_t *client, const char *agent_id,
+                              const char *query, int k, const char *as_of,
+                              const char *filters_json);
+
+/* Exhaustive knowledge-state reconstruction at as_of (ISO-8601 UTC). */
+lians_response_t lians_snapshot(lians_client_t *client, const char *agent_id,
+                                const char *as_of, int limit);
+
+/* Detect lookahead bias relative to simulation_as_of (ISO-8601 UTC). */
+lians_response_t lians_backtest_check(lians_client_t *client, const char *agent_id,
+                                      const char *simulation_as_of);
+
+/* Time-series of a structured fact (ticker + metric), oldest first. */
+lians_response_t lians_fact_history(lians_client_t *client, const char *agent_id,
+                                    const char *ticker, const char *metric, int limit);
+
+/* ── Compliance / erasure ──────────────────────────────────────────────────── */
+
+/* GDPR/HIPAA crypto-shred a data subject. */
+lians_response_t lians_erase(lians_client_t *client, const char *subject_id,
+                             const char *request_ref);
+
+/* Verify the SEC 17a-4 tamper-evidence hash chain (requires admin secret). */
+lians_response_t lians_verify_chain(lians_client_t *client, const char *namespace_);
+
+/* ── Relationship graph ────────────────────────────────────────────────────── */
+
+/* Assert an edge src --rel_type--> dst. event_time is ISO-8601 UTC. */
+lians_response_t lians_relate(lians_client_t *client, const char *agent_id,
+                              const char *src_entity, const char *rel_type,
+                              const char *dst_entity, const char *event_time,
+                              int exclusive, int normalize);
+
+/* Invalidate a live edge (sets valid_to). */
+lians_response_t lians_unrelate(lians_client_t *client, const char *agent_id,
+                                const char *src_entity, const char *rel_type,
+                                const char *dst_entity);
+
+/* Entities within `depth` hops of `entity`. direction is "any"|"in"|"out"
+ * (NULL => "any"); as_of (ISO-8601 UTC) may be NULL for present-time. */
+lians_response_t lians_neighbors(lians_client_t *client, const char *agent_id,
+                                 const char *entity, int depth,
+                                 const char *direction, const char *as_of);
+
+/* Shortest connection between two entities — the conflict-of-interest /
+ * related-party reachability query. as_of may be NULL. */
+lians_response_t lians_path(lians_client_t *client, const char *agent_id,
+                            const char *src_entity, const char *dst_entity,
+                            int max_depth, const char *as_of);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIANS_H */

--- a/agentmem/sdk/c/src/lians.c
+++ b/agentmem/sdk/c/src/lians.c
@@ -1,0 +1,447 @@
+#include "lians.h"
+#include "lians_json.h"
+
+#include <curl/curl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct lians_client {
+    char *base_url;     /* no trailing slash */
+    char *api_key;
+    char *admin_secret; /* may be NULL */
+    long  timeout_ms;
+};
+
+/* ── small utilities ───────────────────────────────────────────────────────── */
+
+static char *dupstr(const char *s) {
+    if (!s) {
+        return NULL;
+    }
+    size_t n = strlen(s);
+    char *p = (char *)malloc(n + 1);
+    if (p) {
+        memcpy(p, s, n + 1);
+    }
+    return p;
+}
+
+static char *concat2(const char *a, const char *b) {
+    size_t na = strlen(a), nb = strlen(b);
+    char *p = (char *)malloc(na + nb + 1);
+    if (!p) {
+        return NULL;
+    }
+    memcpy(p, a, na);
+    memcpy(p + na, b, nb + 1);
+    return p;
+}
+
+struct membuf {
+    char  *data;
+    size_t len;
+};
+
+static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *userdata) {
+    size_t n = size * nmemb;
+    struct membuf *m = (struct membuf *)userdata;
+    char *p = (char *)realloc(m->data, m->len + n + 1);
+    if (!p) {
+        return 0; /* signals error to libcurl */
+    }
+    m->data = p;
+    memcpy(m->data + m->len, ptr, n);
+    m->len += n;
+    m->data[m->len] = '\0';
+    return n;
+}
+
+/* Append "?key=val" / "&key=val" with URL-encoded value; skips NULL values. */
+static void qadd(lians_sb *url, int *first, const char *key, const char *val) {
+    if (!val) {
+        return;
+    }
+    char *ev = curl_easy_escape(NULL, val, 0);
+    if (!ev) {
+        return;
+    }
+    lians_sb_append(url, *first ? "?" : "&");
+    *first = 0;
+    lians_sb_append(url, key);
+    lians_sb_append(url, "=");
+    lians_sb_append(url, ev);
+    curl_free(ev);
+}
+
+static void qadd_int(lians_sb *url, int *first, const char *key, long val) {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%ld", val);
+    qadd(url, first, key, buf);
+}
+
+/* ── core request ──────────────────────────────────────────────────────────── */
+
+static lians_response_t do_request(lians_client_t *c, const char *method,
+                                   const char *url, const char *body, int admin) {
+    lians_response_t resp;
+    resp.status = -1;
+    resp.body = NULL;
+
+    CURL *h = curl_easy_init();
+    if (!h) {
+        resp.body = dupstr("curl_easy_init failed");
+        return resp;
+    }
+
+    struct membuf mb;
+    mb.data = NULL;
+    mb.len = 0;
+
+    struct curl_slist *hdrs = NULL;
+    char *apihdr = concat2("X-API-Key: ", c->api_key);
+    if (apihdr) {
+        hdrs = curl_slist_append(hdrs, apihdr);
+        free(apihdr);
+    }
+    if (body) {
+        hdrs = curl_slist_append(hdrs, "Content-Type: application/json");
+    }
+    if (admin && c->admin_secret) {
+        char *adm = concat2("X-Admin-Secret: ", c->admin_secret);
+        if (adm) {
+            hdrs = curl_slist_append(hdrs, adm);
+            free(adm);
+        }
+    }
+
+    curl_easy_setopt(h, CURLOPT_URL, url);
+    curl_easy_setopt(h, CURLOPT_CUSTOMREQUEST, method);
+    curl_easy_setopt(h, CURLOPT_HTTPHEADER, hdrs);
+    curl_easy_setopt(h, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(h, CURLOPT_WRITEDATA, &mb);
+    curl_easy_setopt(h, CURLOPT_TIMEOUT_MS, c->timeout_ms);
+    curl_easy_setopt(h, CURLOPT_USERAGENT, "lians-c-sdk/0.2.0");
+    if (body) {
+        curl_easy_setopt(h, CURLOPT_POSTFIELDS, body);
+        curl_easy_setopt(h, CURLOPT_POSTFIELDSIZE, (long)strlen(body));
+    }
+
+    CURLcode rc = curl_easy_perform(h);
+    if (rc == CURLE_OK) {
+        long code = 0;
+        curl_easy_getinfo(h, CURLINFO_RESPONSE_CODE, &code);
+        resp.status = code;
+        resp.body = mb.data ? mb.data : dupstr("");
+    } else {
+        resp.status = -1;
+        free(mb.data);
+        resp.body = dupstr(curl_easy_strerror(rc));
+    }
+
+    curl_slist_free_all(hdrs);
+    curl_easy_cleanup(h);
+    return resp;
+}
+
+/* Build "<base_url><path>" into a fresh lians_sb (caller must lians_sb_free). */
+static void url_begin(lians_sb *url, lians_client_t *c, const char *path) {
+    lians_sb_init(url);
+    lians_sb_append(url, c->base_url);
+    lians_sb_append(url, path);
+}
+
+/* ── lifecycle ─────────────────────────────────────────────────────────────── */
+
+int lians_global_init(void) {
+    return curl_global_init(CURL_GLOBAL_DEFAULT) == CURLE_OK ? 0 : -1;
+}
+
+void lians_global_cleanup(void) {
+    curl_global_cleanup();
+}
+
+lians_client_t *lians_client_new(const char *base_url, const char *api_key,
+                                 const char *admin_secret) {
+    if (!base_url || !api_key) {
+        return NULL;
+    }
+    lians_client_t *c = (lians_client_t *)calloc(1, sizeof(*c));
+    if (!c) {
+        return NULL;
+    }
+    /* strip a single trailing slash */
+    size_t n = strlen(base_url);
+    if (n > 0 && base_url[n - 1] == '/') {
+        c->base_url = (char *)malloc(n);
+        if (c->base_url) {
+            memcpy(c->base_url, base_url, n - 1);
+            c->base_url[n - 1] = '\0';
+        }
+    } else {
+        c->base_url = dupstr(base_url);
+    }
+    c->api_key = dupstr(api_key);
+    c->admin_secret = dupstr(admin_secret); /* NULL stays NULL */
+    c->timeout_ms = 30000;
+
+    if (!c->base_url || !c->api_key) {
+        lians_client_free(c);
+        return NULL;
+    }
+    return c;
+}
+
+void lians_client_set_timeout_ms(lians_client_t *client, long timeout_ms) {
+    if (client && timeout_ms > 0) {
+        client->timeout_ms = timeout_ms;
+    }
+}
+
+void lians_client_free(lians_client_t *client) {
+    if (!client) {
+        return;
+    }
+    free(client->base_url);
+    free(client->api_key);
+    free(client->admin_secret);
+    free(client);
+}
+
+void lians_response_free(lians_response_t *resp) {
+    if (resp && resp->body) {
+        free(resp->body);
+        resp->body = NULL;
+    }
+}
+
+/* ── write ─────────────────────────────────────────────────────────────────── */
+
+lians_response_t lians_add(lians_client_t *client, const char *agent_id,
+                           const char *content, const char *event_time,
+                           const char *metadata_json, const char *source,
+                           const char *subject_id, double importance) {
+    lians_sb b;
+    lians_sb_init(&b);
+    lians_sb_append(&b, "{\"agent_id\":");
+    lians_sb_append_json_string(&b, agent_id);
+    lians_sb_append(&b, ",\"content\":");
+    lians_sb_append_json_string(&b, content);
+    lians_sb_append(&b, ",\"event_time\":");
+    lians_sb_append_json_string(&b, event_time);
+    char imp[40];
+    snprintf(imp, sizeof(imp), ",\"importance\":%g", importance);
+    lians_sb_append(&b, imp);
+    if (source) {
+        lians_sb_append(&b, ",\"source\":");
+        lians_sb_append_json_string(&b, source);
+    }
+    if (subject_id) {
+        lians_sb_append(&b, ",\"subject_id\":");
+        lians_sb_append_json_string(&b, subject_id);
+    }
+    if (metadata_json) {
+        lians_sb_append(&b, ",\"metadata\":");
+        lians_sb_append(&b, metadata_json);
+    }
+    lians_sb_append(&b, "}");
+
+    lians_sb url;
+    url_begin(&url, client, "/v1/memories");
+    lians_response_t r = do_request(client, "POST", url.data, b.data, 0);
+    lians_sb_free(&url);
+    lians_sb_free(&b);
+    return r;
+}
+
+/* ── read ──────────────────────────────────────────────────────────────────── */
+
+lians_response_t lians_recall(lians_client_t *client, const char *agent_id,
+                              const char *query, int k, const char *as_of,
+                              const char *filters_json) {
+    lians_sb b;
+    lians_sb_init(&b);
+    lians_sb_append(&b, "{\"agent_id\":");
+    lians_sb_append_json_string(&b, agent_id);
+    lians_sb_append(&b, ",\"query\":");
+    lians_sb_append_json_string(&b, query);
+    char kbuf[32];
+    snprintf(kbuf, sizeof(kbuf), ",\"k\":%d", k);
+    lians_sb_append(&b, kbuf);
+    if (as_of) {
+        lians_sb_append(&b, ",\"as_of\":");
+        lians_sb_append_json_string(&b, as_of);
+    }
+    if (filters_json) {
+        lians_sb_append(&b, ",\"filters\":");
+        lians_sb_append(&b, filters_json);
+    }
+    lians_sb_append(&b, "}");
+
+    lians_sb url;
+    url_begin(&url, client, "/v1/recall");
+    lians_response_t r = do_request(client, "POST", url.data, b.data, 0);
+    lians_sb_free(&url);
+    lians_sb_free(&b);
+    return r;
+}
+
+lians_response_t lians_snapshot(lians_client_t *client, const char *agent_id,
+                                const char *as_of, int limit) {
+    lians_sb url;
+    url_begin(&url, client, "/v1/snapshot");
+    int first = 1;
+    qadd(&url, &first, "agent_id", agent_id);
+    qadd(&url, &first, "as_of", as_of);
+    qadd_int(&url, &first, "limit", limit);
+    lians_response_t r = do_request(client, "GET", url.data, NULL, 0);
+    lians_sb_free(&url);
+    return r;
+}
+
+lians_response_t lians_backtest_check(lians_client_t *client, const char *agent_id,
+                                      const char *simulation_as_of) {
+    lians_sb b;
+    lians_sb_init(&b);
+    lians_sb_append(&b, "{\"agent_id\":");
+    lians_sb_append_json_string(&b, agent_id);
+    lians_sb_append(&b, ",\"simulation_as_of\":");
+    lians_sb_append_json_string(&b, simulation_as_of);
+    lians_sb_append(&b, "}");
+
+    lians_sb url;
+    url_begin(&url, client, "/v1/backtest/check");
+    lians_response_t r = do_request(client, "POST", url.data, b.data, 0);
+    lians_sb_free(&url);
+    lians_sb_free(&b);
+    return r;
+}
+
+lians_response_t lians_fact_history(lians_client_t *client, const char *agent_id,
+                                    const char *ticker, const char *metric, int limit) {
+    lians_sb url;
+    url_begin(&url, client, "/v1/facts/history");
+    int first = 1;
+    qadd(&url, &first, "agent_id", agent_id);
+    qadd(&url, &first, "ticker", ticker);
+    qadd(&url, &first, "metric", metric);
+    qadd_int(&url, &first, "limit", limit);
+    lians_response_t r = do_request(client, "GET", url.data, NULL, 0);
+    lians_sb_free(&url);
+    return r;
+}
+
+/* ── compliance / erasure ──────────────────────────────────────────────────── */
+
+lians_response_t lians_erase(lians_client_t *client, const char *subject_id,
+                             const char *request_ref) {
+    lians_sb b;
+    lians_sb_init(&b);
+    lians_sb_append(&b, "{\"subject_id\":");
+    lians_sb_append_json_string(&b, subject_id);
+    lians_sb_append(&b, ",\"request_ref\":");
+    lians_sb_append_json_string(&b, request_ref);
+    lians_sb_append(&b, "}");
+
+    lians_sb url;
+    url_begin(&url, client, "/v1/erase");
+    lians_response_t r = do_request(client, "POST", url.data, b.data, 0);
+    lians_sb_free(&url);
+    lians_sb_free(&b);
+    return r;
+}
+
+lians_response_t lians_verify_chain(lians_client_t *client, const char *namespace_) {
+    lians_sb url;
+    url_begin(&url, client, "/v1/admin/audit/verify");
+    int first = 1;
+    qadd(&url, &first, "namespace", namespace_);
+    lians_response_t r = do_request(client, "GET", url.data, NULL, 1 /* admin */);
+    lians_sb_free(&url);
+    return r;
+}
+
+/* ── relationship graph ────────────────────────────────────────────────────── */
+
+lians_response_t lians_relate(lians_client_t *client, const char *agent_id,
+                              const char *src_entity, const char *rel_type,
+                              const char *dst_entity, const char *event_time,
+                              int exclusive, int normalize) {
+    lians_sb b;
+    lians_sb_init(&b);
+    lians_sb_append(&b, "{\"agent_id\":");
+    lians_sb_append_json_string(&b, agent_id);
+    lians_sb_append(&b, ",\"src_entity\":");
+    lians_sb_append_json_string(&b, src_entity);
+    lians_sb_append(&b, ",\"rel_type\":");
+    lians_sb_append_json_string(&b, rel_type);
+    lians_sb_append(&b, ",\"dst_entity\":");
+    lians_sb_append_json_string(&b, dst_entity);
+    lians_sb_append(&b, ",\"event_time\":");
+    lians_sb_append_json_string(&b, event_time);
+    lians_sb_append(&b, exclusive ? ",\"exclusive\":true" : ",\"exclusive\":false");
+    lians_sb_append(&b, normalize ? ",\"normalize\":true" : ",\"normalize\":false");
+    lians_sb_append(&b, "}");
+
+    lians_sb url;
+    url_begin(&url, client, "/v1/graph/relate");
+    lians_response_t r = do_request(client, "POST", url.data, b.data, 0);
+    lians_sb_free(&url);
+    lians_sb_free(&b);
+    return r;
+}
+
+lians_response_t lians_unrelate(lians_client_t *client, const char *agent_id,
+                                const char *src_entity, const char *rel_type,
+                                const char *dst_entity) {
+    lians_sb b;
+    lians_sb_init(&b);
+    lians_sb_append(&b, "{\"agent_id\":");
+    lians_sb_append_json_string(&b, agent_id);
+    lians_sb_append(&b, ",\"src_entity\":");
+    lians_sb_append_json_string(&b, src_entity);
+    lians_sb_append(&b, ",\"rel_type\":");
+    lians_sb_append_json_string(&b, rel_type);
+    lians_sb_append(&b, ",\"dst_entity\":");
+    lians_sb_append_json_string(&b, dst_entity);
+    lians_sb_append(&b, "}");
+
+    lians_sb url;
+    url_begin(&url, client, "/v1/graph/unrelate");
+    lians_response_t r = do_request(client, "POST", url.data, b.data, 0);
+    lians_sb_free(&url);
+    lians_sb_free(&b);
+    return r;
+}
+
+lians_response_t lians_neighbors(lians_client_t *client, const char *agent_id,
+                                 const char *entity, int depth,
+                                 const char *direction, const char *as_of) {
+    lians_sb url;
+    url_begin(&url, client, "/v1/graph/neighbors");
+    int first = 1;
+    qadd(&url, &first, "agent_id", agent_id);
+    qadd(&url, &first, "entity", entity);
+    qadd_int(&url, &first, "depth", depth);
+    qadd(&url, &first, "direction", direction ? direction : "any");
+    qadd(&url, &first, "as_of", as_of);
+    lians_response_t r = do_request(client, "GET", url.data, NULL, 0);
+    lians_sb_free(&url);
+    return r;
+}
+
+lians_response_t lians_path(lians_client_t *client, const char *agent_id,
+                            const char *src_entity, const char *dst_entity,
+                            int max_depth, const char *as_of) {
+    lians_sb url;
+    url_begin(&url, client, "/v1/graph/path");
+    int first = 1;
+    qadd(&url, &first, "agent_id", agent_id);
+    qadd(&url, &first, "src", src_entity);
+    qadd(&url, &first, "dst", dst_entity);
+    qadd_int(&url, &first, "max_depth", max_depth);
+    qadd(&url, &first, "as_of", as_of);
+    lians_response_t r = do_request(client, "GET", url.data, NULL, 0);
+    lians_sb_free(&url);
+    return r;
+}

--- a/agentmem/sdk/c/src/lians_json.c
+++ b/agentmem/sdk/c/src/lians_json.c
@@ -1,0 +1,109 @@
+#include "lians_json.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int lians_sb_init(lians_sb *sb) {
+    sb->cap = 64;
+    sb->len = 0;
+    sb->data = (char *)malloc(sb->cap);
+    if (!sb->data) {
+        sb->cap = 0;
+        return -1;
+    }
+    sb->data[0] = '\0';
+    return 0;
+}
+
+static int lians_sb_reserve(lians_sb *sb, size_t extra) {
+    size_t need = sb->len + extra + 1; /* +1 for NUL */
+    if (need <= sb->cap) {
+        return 0;
+    }
+    size_t cap = sb->cap ? sb->cap : 64;
+    while (cap < need) {
+        cap *= 2;
+    }
+    char *p = (char *)realloc(sb->data, cap);
+    if (!p) {
+        return -1;
+    }
+    sb->data = p;
+    sb->cap = cap;
+    return 0;
+}
+
+int lians_sb_append_n(lians_sb *sb, const char *s, size_t n) {
+    if (lians_sb_reserve(sb, n) != 0) {
+        return -1;
+    }
+    memcpy(sb->data + sb->len, s, n);
+    sb->len += n;
+    sb->data[sb->len] = '\0';
+    return 0;
+}
+
+int lians_sb_append(lians_sb *sb, const char *s) {
+    return lians_sb_append_n(sb, s, strlen(s));
+}
+
+void lians_sb_free(lians_sb *sb) {
+    if (sb && sb->data) {
+        free(sb->data);
+        sb->data = NULL;
+        sb->cap = 0;
+        sb->len = 0;
+    }
+}
+
+/* Append the escaped form of a single char to the buffer. */
+static int append_escaped_char(lians_sb *sb, unsigned char c) {
+    char buf[8];
+    switch (c) {
+        case '"':  return lians_sb_append_n(sb, "\\\"", 2);
+        case '\\': return lians_sb_append_n(sb, "\\\\", 2);
+        case '\b': return lians_sb_append_n(sb, "\\b", 2);
+        case '\f': return lians_sb_append_n(sb, "\\f", 2);
+        case '\n': return lians_sb_append_n(sb, "\\n", 2);
+        case '\r': return lians_sb_append_n(sb, "\\r", 2);
+        case '\t': return lians_sb_append_n(sb, "\\t", 2);
+        default:
+            if (c < 0x20) {
+                snprintf(buf, sizeof(buf), "\\u%04x", c);
+                return lians_sb_append_n(sb, buf, 6);
+            }
+            buf[0] = (char)c;
+            return lians_sb_append_n(sb, buf, 1);
+    }
+}
+
+int lians_sb_append_json_string(lians_sb *sb, const char *s) {
+    if (lians_sb_append_n(sb, "\"", 1) != 0) {
+        return -1;
+    }
+    if (s) {
+        for (const unsigned char *p = (const unsigned char *)s; *p; p++) {
+            if (append_escaped_char(sb, *p) != 0) {
+                return -1;
+            }
+        }
+    }
+    return lians_sb_append_n(sb, "\"", 1);
+}
+
+char *lians_json_escape(const char *s) {
+    lians_sb sb;
+    if (lians_sb_init(&sb) != 0) {
+        return NULL;
+    }
+    if (s) {
+        for (const unsigned char *p = (const unsigned char *)s; *p; p++) {
+            if (append_escaped_char(&sb, *p) != 0) {
+                lians_sb_free(&sb);
+                return NULL;
+            }
+        }
+    }
+    return sb.data; /* caller frees */
+}

--- a/agentmem/sdk/c/src/lians_json.h
+++ b/agentmem/sdk/c/src/lians_json.h
@@ -1,0 +1,41 @@
+/*
+ * Internal helpers for the Lians C SDK: a growable string buffer and JSON string
+ * escaping. These are pure (no I/O), so they are unit-tested without a server.
+ */
+#ifndef LIANS_JSON_H
+#define LIANS_JSON_H
+
+#include <stddef.h>
+
+/* Growable string buffer. */
+typedef struct {
+    char  *data;
+    size_t len;
+    size_t cap;
+} lians_sb;
+
+/* Initialize an empty buffer. Returns 0 on success, -1 on allocation failure. */
+int  lians_sb_init(lians_sb *sb);
+
+/* Append a NUL-terminated string. Returns 0 on success, -1 on allocation failure. */
+int  lians_sb_append(lians_sb *sb, const char *s);
+
+/* Append `n` bytes. Returns 0 on success, -1 on allocation failure. */
+int  lians_sb_append_n(lians_sb *sb, const char *s, size_t n);
+
+/*
+ * Append `s` as a quoted, escaped JSON string (including the surrounding quotes).
+ * Returns 0 on success, -1 on allocation failure.
+ */
+int  lians_sb_append_json_string(lians_sb *sb, const char *s);
+
+/* Free the buffer's storage. Safe to call on a zero-initialized buffer. */
+void lians_sb_free(lians_sb *sb);
+
+/*
+ * Return a freshly malloc'd JSON-escaped copy of `s` WITHOUT surrounding quotes.
+ * Caller frees. Returns NULL on allocation failure.
+ */
+char *lians_json_escape(const char *s);
+
+#endif /* LIANS_JSON_H */

--- a/agentmem/sdk/c/tests/test_json.c
+++ b/agentmem/sdk/c/tests/test_json.c
@@ -1,0 +1,62 @@
+/* Unit tests for the pure JSON/string helpers — no network, no libcurl. */
+#include "lians_json.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                  \
+    do {                                                  \
+        if (!(cond)) {                                    \
+            printf("FAIL: %s\n", (msg));                  \
+            failures++;                                   \
+        }                                                 \
+    } while (0)
+
+int main(void) {
+    /* Quotes, backslash, newline, tab. */
+    char *e = lians_json_escape("he said \"hi\"\n\tend\\");
+    CHECK(e != NULL, "escape returns non-NULL");
+    CHECK(e && strcmp(e, "he said \\\"hi\\\"\\n\\tend\\\\") == 0, "escape content");
+    free(e);
+
+    /* Control character -> \u00xx. */
+    char in[2];
+    in[0] = 0x01;
+    in[1] = '\0';
+    char *ctrl = lians_json_escape(in);
+    CHECK(ctrl && strcmp(ctrl, "\\u0001") == 0, "control char escapes to \\u0001");
+    free(ctrl);
+
+    /* NULL escapes to empty string. */
+    char *nul = lians_json_escape(NULL);
+    CHECK(nul != NULL && nul[0] == '\0', "NULL escapes to empty string");
+    free(nul);
+
+    /* String builder + quoted JSON string. */
+    lians_sb sb;
+    CHECK(lians_sb_init(&sb) == 0, "sb_init");
+    lians_sb_append(&sb, "{\"k\":");
+    lians_sb_append_json_string(&sb, "a\"b");
+    lians_sb_append(&sb, "}");
+    CHECK(strcmp(sb.data, "{\"k\":\"a\\\"b\"}") == 0, "sb builds escaped JSON object");
+    lians_sb_free(&sb);
+
+    /* Growth past the initial capacity. */
+    lians_sb big;
+    lians_sb_init(&big);
+    for (int i = 0; i < 1000; i++) {
+        lians_sb_append(&big, "x");
+    }
+    CHECK(big.len == 1000 && strlen(big.data) == 1000, "sb grows correctly");
+    lians_sb_free(&big);
+
+    if (failures == 0) {
+        printf("OK: all JSON helper tests passed\n");
+        return 0;
+    }
+    printf("%d failure(s)\n", failures);
+    return 1;
+}

--- a/agentmem/sdk/java/README.md
+++ b/agentmem/sdk/java/README.md
@@ -1,0 +1,109 @@
+# Lians Java SDK
+
+Financial-grade agent memory for the JVM — bitemporal recall, SEC 17a-4 audit
+chain, GDPR/HIPAA crypto-shred, information barriers, and a relationship graph for
+conflict-of-interest / related-party / care-network queries.
+
+Built for where Java already runs: bank and insurer risk systems, healthcare
+platforms, and legal tech. Java 11+, one dependency (Jackson); HTTP is the JDK's
+`java.net.http`.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>dev.lians</groupId>
+  <artifactId>lians-sdk</artifactId>
+  <version>0.2.0</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation "dev.lians:lians-sdk:0.2.0"
+```
+
+## Quick start
+
+```java
+import dev.lians.LiansClient;
+import dev.lians.LiansClientOptions;
+import dev.lians.model.MemoryOut;
+import dev.lians.model.RecallResult;
+import java.time.Instant;
+import java.util.Map;
+
+LiansClient client = new LiansClient(LiansClientOptions.builder()
+        .baseUrl("https://api.lians.dev")              // or your self-hosted server
+        .apiKey(System.getenv("LIANS_API_KEY"))
+        .adminSecret(System.getenv("LIANS_ADMIN_SECRET"))   // only for /v1/admin/* audit calls
+        .build());
+
+// Store a fact with its BUSINESS event-time (not now)
+client.addMemory("equity-desk", "NVDA FY2026 revenue guidance raised to $40B",
+        Instant.parse("2025-11-19T16:00:00Z"),
+        Map.of("ticker", "NVDA", "metric", "revenue_guidance"));
+
+// Recall current (non-stale) facts
+RecallResult r = client.recall("equity-desk", "NVDA revenue guidance", 5);
+for (MemoryOut m : r.memories) {
+    System.out.println(m.eventTime + "  " + m.content);
+}
+
+// Point-in-time — what did we know on a past date?
+RecallResult past = client.recallAt("equity-desk", "NVDA revenue guidance",
+        Instant.parse("2025-09-01T00:00:00Z"), 5);
+```
+
+## Compliance & graph surfaces
+
+```java
+// Exhaustive knowledge state at a date (regulator demo)
+client.snapshot("equity-desk", Instant.parse("2026-03-01T00:00:00Z"), 1000);
+
+// Lookahead-bias proof before trusting a backtest
+client.backtestCheck("equity-desk", Instant.parse("2026-01-01T00:00:00Z"));
+
+// GDPR/HIPAA crypto-shred + verify the tamper-evident chain
+client.eraseSubject("MRN-00042", "GDPR-REQ-2026-001");
+client.verifyChain("your-namespace");   // requires adminSecret
+
+// Relationship graph — conflict-of-interest / related-party reachability
+client.relate("matter-7", "Attorney", "represented", "ClientX",
+        Instant.parse("2026-01-01T00:00:00Z"), false, false);
+client.relate("matter-7", "ClientX", "adverse_to", "PartyY",
+        Instant.parse("2026-01-01T00:00:00Z"), false, false);
+var coi = client.path("matter-7", "Attorney", "PartyY", 4, null);
+// -> {"connected": true, "hops": 2, "path": [...]}
+
+// Graph-proximity reranking
+client.recallNear("equity-desk", "earnings", "FundA", "ticker", 5);
+```
+
+## Notes
+
+- Timestamps are `java.time.Instant` (serialized as ISO-8601 UTC).
+- Errors (non-2xx) throw `LiansException` exposing `status()` and `body()`.
+- Responses with rich schemas (snapshot, graph, conflicts, audit) return Jackson
+  `JsonNode`; `addMemory`/`recall` return typed `MemoryOut` / `RecallResult`.
+- `LiansClient` is thread-safe — create one and share it.
+
+## Why Java + Lians
+
+mem0 ships Python/TypeScript only; Zep adds Go. Neither offers a Java SDK — yet
+Java is the backbone of regulated back-offices. This SDK brings the full
+compliance memory layer (and the relationship graph that neither competitor pairs
+with an open compliance spine) to the JVM. See the
+[mem0](../../../docs/compare-mem0.md) and [Zep/Graphiti](../../../docs/compare-zep.md)
+comparisons.
+
+## Build & test
+
+```bash
+cd agentmem/sdk/java
+mvn test      # JUnit tests run against an in-process mock server — no live Lians needed
+mvn package
+```

--- a/agentmem/sdk/java/pom.xml
+++ b/agentmem/sdk/java/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dev.lians</groupId>
+  <artifactId>lians-sdk</artifactId>
+  <version>0.2.0</version>
+  <packaging>jar</packaging>
+
+  <name>Lians SDK</name>
+  <description>Financial-grade agent memory for the JVM — bitemporal recall, SEC 17a-4 audit chain, GDPR/HIPAA crypto-shred, information barriers, and a relationship graph. For banks, insurers, healthcare, and legal teams on Java.</description>
+  <url>https://github.com/Lians-ai/Lians</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jackson.version>2.17.1</jackson.version>
+    <junit.version>5.10.2</junit.version>
+  </properties>
+
+  <dependencies>
+    <!-- HTTP is java.net.http (JDK 11+, no dependency). JSON via Jackson. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/agentmem/sdk/java/src/main/java/dev/lians/LiansClient.java
+++ b/agentmem/sdk/java/src/main/java/dev/lians/LiansClient.java
@@ -1,0 +1,373 @@
+package dev.lians;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.lians.model.MemoryOut;
+import dev.lians.model.RecallResult;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Synchronous HTTP client for the Lians financial-grade memory API.
+ *
+ * <p>Lians is a memory layer for AI agents built for regulated environments
+ * (financial institutions, healthcare, legal). Unlike a plain vector store it
+ * uses a bitemporal model — superseded facts are excluded at the database layer,
+ * every write lands in a tamper-evident SHA-256 audit chain (SEC 17a-4),
+ * per-subject keys give GDPR/HIPAA crypto-shred, and information barriers are
+ * enforced at PostgreSQL row-level security. It also exposes a bitemporal
+ * relationship graph for conflict-of-interest / related-party / care-network
+ * reachability queries.
+ *
+ * <pre>{@code
+ * LiansClient client = new LiansClient(LiansClientOptions.builder()
+ *     .baseUrl("https://api.lians.dev")
+ *     .apiKey(System.getenv("LIANS_API_KEY"))
+ *     .build());
+ *
+ * client.addMemory("equity-desk", "NVDA FY2026 guidance raised to $40B",
+ *     Instant.parse("2025-11-19T16:00:00Z"),
+ *     Map.of("ticker", "NVDA", "metric", "revenue_guidance"));
+ *
+ * RecallResult r = client.recall("equity-desk", "NVDA guidance", 5);
+ * for (MemoryOut m : r.memories) System.out.println(m.eventTime + "  " + m.content);
+ * }</pre>
+ *
+ * Instances are thread-safe and may be shared.
+ */
+public final class LiansClient {
+
+    private final String baseUrl;
+    private final String apiKey;
+    private final String adminSecret;
+    private final HttpClient http;
+    private final java.time.Duration timeout;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public LiansClient(LiansClientOptions options) {
+        this.baseUrl = stripTrailingSlash(options.baseUrl());
+        this.apiKey = options.apiKey();
+        this.adminSecret = options.adminSecret();
+        this.timeout = options.timeout();
+        this.http = HttpClient.newBuilder().connectTimeout(options.timeout()).build();
+    }
+
+    /** Convenience constructor for the common case (no admin secret, default timeout). */
+    public LiansClient(String baseUrl, String apiKey) {
+        this(LiansClientOptions.builder().baseUrl(baseUrl).apiKey(apiKey).build());
+    }
+
+    // ── Write ───────────────────────────────────────────────────────────────
+
+    /** Store a fact with its business event-time. */
+    public MemoryOut addMemory(String agentId, String content, Instant eventTime,
+                               Map<String, ?> metadata) {
+        return addMemory(agentId, content, eventTime, metadata, null, null, 0.5);
+    }
+
+    /** Store a fact with full control over provenance, subject, and importance. */
+    public MemoryOut addMemory(String agentId, String content, Instant eventTime,
+                               Map<String, ?> metadata, String source, String subjectId,
+                               double importance) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("agent_id", agentId);
+        body.put("content", content);
+        body.put("event_time", iso(eventTime));
+        body.put("importance", importance);
+        putIfPresent(body, "source", source);
+        putIfPresent(body, "subject_id", subjectId);
+        putIfPresent(body, "metadata", metadata);
+        return request("POST", "/v1/memories", body, null, false, MemoryOut.class);
+    }
+
+    /** Add multiple memories in one request (processed sequentially). */
+    public JsonNode batchAdd(List<Map<String, ?>> memories) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("memories", memories);
+        return requestJson("POST", "/v1/memories/batch", body, null, false);
+    }
+
+    // ── Read ────────────────────────────────────────────────────────────────
+
+    /** Retrieve the current (non-stale) memories relevant to {@code query}. */
+    public RecallResult recall(String agentId, String query, int k) {
+        return recall(agentId, query, k, null, null);
+    }
+
+    /**
+     * Recall with optional point-in-time ({@code asOf}) and metadata {@code filters}.
+     * Pass {@code asOf} to ask "what did the agent know on this date?" — the
+     * compliance query mem0 and Zep cannot answer.
+     */
+    public RecallResult recall(String agentId, String query, int k, Instant asOf,
+                               Map<String, ?> filters) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("agent_id", agentId);
+        body.put("query", query);
+        body.put("k", k);
+        putIfPresent(body, "as_of", asOf == null ? null : iso(asOf));
+        putIfPresent(body, "filters", filters);
+        return request("POST", "/v1/recall", body, null, false, RecallResult.class);
+    }
+
+    /** Point-in-time recall — sugar for {@link #recall(String, String, int, Instant, Map)}. */
+    public RecallResult recallAt(String agentId, String query, Instant asOf, int k) {
+        return recall(agentId, query, k, asOf, null);
+    }
+
+    /** Time-series of a structured fact (ticker + metric), oldest first. */
+    public JsonNode factHistory(String agentId, String ticker, String metric, int limit) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("agent_id", agentId);
+        p.put("ticker", ticker);
+        p.put("metric", metric);
+        p.put("limit", limit);
+        return requestJson("GET", "/v1/facts/history", null, p, false);
+    }
+
+    /** Full supersession lineage for a memory. */
+    public JsonNode getLineage(String memoryId) {
+        return requestJson("GET", "/v1/memories/" + enc(memoryId) + "/lineage", null, null, false);
+    }
+
+    /** Exhaustive knowledge-state reconstruction at {@code asOf} (audit/regulator demo). */
+    public JsonNode snapshot(String agentId, Instant asOf, int limit) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("agent_id", agentId);
+        p.put("as_of", iso(asOf));
+        p.put("limit", limit);
+        return requestJson("GET", "/v1/snapshot", null, p, false);
+    }
+
+    /** Detect lookahead bias — facts the agent held that it couldn't have known. */
+    public JsonNode backtestCheck(String agentId, Instant simulationAsOf) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("agent_id", agentId);
+        body.put("simulation_as_of", iso(simulationAsOf));
+        return requestJson("POST", "/v1/backtest/check", body, null, false);
+    }
+
+    // ── Compliance / erasure ─────────────────────────────────────────────────
+
+    /** GDPR/HIPAA crypto-shred: destroy a data subject's per-subject key. */
+    public JsonNode eraseSubject(String subjectId, String requestRef) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("subject_id", subjectId);
+        body.put("request_ref", requestRef);
+        return requestJson("POST", "/v1/erase", body, null, false);
+    }
+
+    /** Proof-of-erasure certificate for a data subject (admin scope). */
+    public JsonNode erasureCertificate(String subjectId) {
+        return requestJson("GET", "/v1/erase/" + enc(subjectId) + "/certificate", null, null, false);
+    }
+
+    /** Compliance report for the caller's namespace. */
+    public JsonNode complianceReport(Instant from, Instant to, boolean verify) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        putIfPresent(p, "from", from == null ? null : iso(from));
+        putIfPresent(p, "to", to == null ? null : iso(to));
+        p.put("verify", verify);
+        return requestJson("GET", "/v1/compliance/report", null, p, false);
+    }
+
+    // ── Conflicts ─────────────────────────────────────────────────────────────
+
+    /** List detected conflicts (same-time contradictions awaiting review). */
+    public JsonNode listConflicts(String status, int limit) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        putIfPresent(p, "status", status);
+        p.put("limit", limit);
+        return requestJson("GET", "/v1/conflicts", null, p, false);
+    }
+
+    /** Resolve a conflict: {@code accept_a}, {@code accept_b}, or {@code dismiss}. */
+    public JsonNode resolveConflict(String conflictId, String resolution, String note) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("resolution", resolution);
+        putIfPresent(body, "note", note);
+        return requestJson("POST", "/v1/conflicts/" + enc(conflictId) + "/resolve", body, null, false);
+    }
+
+    // ── Relationship graph ────────────────────────────────────────────────────
+
+    /** Assert a relationship edge {@code src --relType--> dst}. */
+    public JsonNode relate(String agentId, String srcEntity, String relType, String dstEntity,
+                           Instant eventTime, boolean exclusive, boolean normalize) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("agent_id", agentId);
+        body.put("src_entity", srcEntity);
+        body.put("rel_type", relType);
+        body.put("dst_entity", dstEntity);
+        body.put("event_time", iso(eventTime));
+        body.put("exclusive", exclusive);
+        body.put("normalize", normalize);
+        return requestJson("POST", "/v1/graph/relate", body, null, false);
+    }
+
+    /** Invalidate a live edge (sets {@code valid_to}). */
+    public JsonNode unrelate(String agentId, String srcEntity, String relType, String dstEntity) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("agent_id", agentId);
+        body.put("src_entity", srcEntity);
+        body.put("rel_type", relType);
+        body.put("dst_entity", dstEntity);
+        return requestJson("POST", "/v1/graph/unrelate", body, null, false);
+    }
+
+    /** Entities within {@code depth} hops of {@code entity} (optional point-in-time {@code asOf}). */
+    public JsonNode neighbors(String agentId, String entity, int depth, String direction, Instant asOf) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("entity", entity);
+        p.put("agent_id", agentId);
+        p.put("depth", depth);
+        p.put("direction", direction == null ? "any" : direction);
+        putIfPresent(p, "as_of", asOf == null ? null : iso(asOf));
+        return requestJson("GET", "/v1/graph/neighbors", null, p, false);
+    }
+
+    /**
+     * Shortest connection between two entities — the conflict-of-interest /
+     * related-party reachability query. {@code "connected": false} is the clean result.
+     */
+    public JsonNode path(String agentId, String srcEntity, String dstEntity, int maxDepth, Instant asOf) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("src", srcEntity);
+        p.put("dst", dstEntity);
+        p.put("agent_id", agentId);
+        p.put("max_depth", maxDepth);
+        putIfPresent(p, "as_of", asOf == null ? null : iso(asOf));
+        return requestJson("GET", "/v1/graph/path", null, p, false);
+    }
+
+    /** Recall with graph-proximity reranking around {@code nearEntity}. */
+    public RecallResult recallNear(String agentId, String query, String nearEntity, String nearKey, int k) {
+        Map<String, Object> filters = new LinkedHashMap<>();
+        filters.put("_near_entity", nearEntity);
+        filters.put("_near_key", nearKey == null ? "ticker" : nearKey);
+        return recall(agentId, query, k, null, filters);
+    }
+
+    // ── Admin / audit chain ───────────────────────────────────────────────────
+
+    /** Verify the SEC 17a-4 tamper-evidence hash chain (requires admin secret). */
+    public JsonNode verifyChain(String namespace) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("namespace", namespace);
+        return requestJson("GET", "/v1/admin/audit/verify", null, p, true);
+    }
+
+    /** Export the full audit log for a namespace (requires admin secret). */
+    public JsonNode auditExport(String namespace, Instant from, Instant to, int limit, boolean verify) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("namespace", namespace);
+        putIfPresent(p, "from_", from == null ? null : iso(from));
+        putIfPresent(p, "to", to == null ? null : iso(to));
+        p.put("limit", limit);
+        p.put("verify_chain", verify);
+        return requestJson("GET", "/v1/admin/audit/export", null, p, true);
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────────
+
+    private JsonNode requestJson(String method, String path, Object body,
+                                 Map<String, Object> params, boolean admin) {
+        return request(method, path, body, params, admin, JsonNode.class);
+    }
+
+    private <T> T request(String method, String path, Object body,
+                          Map<String, Object> params, boolean admin, Class<T> type) {
+        URI uri = URI.create(baseUrl + path + queryString(params));
+        HttpRequest.Builder rb = HttpRequest.newBuilder(uri)
+                .timeout(timeout)
+                .header("X-API-Key", apiKey);
+        if (admin && adminSecret != null) {
+            rb.header("X-Admin-Secret", adminSecret);
+        }
+
+        HttpRequest.BodyPublisher pub;
+        if (body != null) {
+            byte[] json;
+            try {
+                json = mapper.writeValueAsBytes(body);
+            } catch (IOException e) {
+                throw new LiansException("Failed to serialize request body", e);
+            }
+            pub = HttpRequest.BodyPublishers.ofByteArray(json);
+            rb.header("Content-Type", "application/json");
+        } else {
+            pub = HttpRequest.BodyPublishers.noBody();
+        }
+        rb.method(method, pub);
+
+        HttpResponse<String> resp;
+        try {
+            resp = http.send(rb.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new LiansException("Request to " + method + " " + path + " failed", e);
+        }
+
+        int code = resp.statusCode();
+        if (code < 200 || code >= 300) {
+            throw new LiansException(code, resp.body(),
+                    "Lians " + method + " " + path + " -> " + code + ": " + resp.body());
+        }
+        if (code == 204 || resp.body() == null || resp.body().isEmpty()) {
+            return null;
+        }
+        try {
+            if (type == JsonNode.class) {
+                return type.cast(mapper.readTree(resp.body()));
+            }
+            return mapper.readValue(resp.body(), type);
+        } catch (IOException e) {
+            throw new LiansException("Failed to parse response from " + method + " " + path, e);
+        }
+    }
+
+    private String queryString(Map<String, Object> params) {
+        if (params == null || params.isEmpty()) {
+            return "";
+        }
+        List<String> parts = new ArrayList<>();
+        for (Map.Entry<String, Object> e : params.entrySet()) {
+            if (e.getValue() == null) {
+                continue;
+            }
+            parts.add(enc(e.getKey()) + "=" + enc(String.valueOf(e.getValue())));
+        }
+        return parts.isEmpty() ? "" : "?" + String.join("&", parts);
+    }
+
+    private static void putIfPresent(Map<String, Object> m, String key, Object value) {
+        if (value != null) {
+            m.put(key, value);
+        }
+    }
+
+    private static String iso(Instant instant) {
+        return instant.toString();
+    }
+
+    private static String enc(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/agentmem/sdk/java/src/main/java/dev/lians/LiansClientOptions.java
+++ b/agentmem/sdk/java/src/main/java/dev/lians/LiansClientOptions.java
@@ -1,0 +1,63 @@
+package dev.lians;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Connection options for {@link LiansClient}.
+ *
+ * <pre>{@code
+ * LiansClient client = new LiansClient(
+ *     LiansClientOptions.builder()
+ *         .baseUrl("https://mem.yourfirm.internal")
+ *         .apiKey(System.getenv("LIANS_API_KEY"))
+ *         .adminSecret(System.getenv("LIANS_ADMIN_SECRET"))  // optional
+ *         .build());
+ * }</pre>
+ */
+public final class LiansClientOptions {
+
+    private final String baseUrl;
+    private final String apiKey;
+    private final String adminSecret;
+    private final Duration timeout;
+
+    private LiansClientOptions(Builder b) {
+        this.baseUrl = Objects.requireNonNull(b.baseUrl, "baseUrl is required");
+        this.apiKey = Objects.requireNonNull(b.apiKey, "apiKey is required");
+        this.adminSecret = b.adminSecret;
+        this.timeout = b.timeout != null ? b.timeout : Duration.ofSeconds(30);
+    }
+
+    public String baseUrl()     { return baseUrl; }
+    public String apiKey()      { return apiKey; }
+    public String adminSecret() { return adminSecret; }
+    public Duration timeout()   { return timeout; }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String baseUrl;
+        private String apiKey;
+        private String adminSecret;
+        private Duration timeout;
+
+        /** Base URL of the Lians server, e.g. {@code https://api.lians.dev}. */
+        public Builder baseUrl(String baseUrl) { this.baseUrl = baseUrl; return this; }
+
+        /** API key with the scopes your calls require (read/write/admin). */
+        public Builder apiKey(String apiKey) { this.apiKey = apiKey; return this; }
+
+        /** Admin secret, required only for {@code /v1/admin/*} audit endpoints. */
+        public Builder adminSecret(String adminSecret) { this.adminSecret = adminSecret; return this; }
+
+        /** Per-request timeout (default 30s). */
+        public Builder timeout(Duration timeout) { this.timeout = timeout; return this; }
+
+        public LiansClientOptions build() {
+            return new LiansClientOptions(this);
+        }
+    }
+}

--- a/agentmem/sdk/java/src/main/java/dev/lians/LiansException.java
+++ b/agentmem/sdk/java/src/main/java/dev/lians/LiansException.java
@@ -1,0 +1,38 @@
+package dev.lians;
+
+/**
+ * Thrown when the Lians server returns a non-2xx response, or when a request
+ * cannot be completed (network/timeout/serialization error).
+ */
+public class LiansException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /** HTTP status code, or 0 when the failure was not an HTTP response. */
+    private final int status;
+
+    /** Raw response body (or error detail) returned by the server. */
+    private final String body;
+
+    public LiansException(int status, String body, String message) {
+        super(message);
+        this.status = status;
+        this.body = body;
+    }
+
+    public LiansException(String message, Throwable cause) {
+        super(message, cause);
+        this.status = 0;
+        this.body = "";
+    }
+
+    /** HTTP status code, or 0 when the failure was not an HTTP response. */
+    public int status() {
+        return status;
+    }
+
+    /** Raw response body (or error detail) returned by the server. */
+    public String body() {
+        return body;
+    }
+}

--- a/agentmem/sdk/java/src/main/java/dev/lians/model/MemoryOut.java
+++ b/agentmem/sdk/java/src/main/java/dev/lians/model/MemoryOut.java
@@ -1,0 +1,36 @@
+package dev.lians.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * A single memory returned by recall, snapshot, or fact-history.
+ *
+ * <p>{@code content} is {@code null} when the memory was crypto-shredded
+ * (GDPR/HIPAA erasure) — its existence and metadata survive, the content does not.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class MemoryOut {
+
+    @JsonProperty("id")              public String id;
+    @JsonProperty("namespace")       public String namespace;
+    @JsonProperty("agent_id")        public String agentId;
+    @JsonProperty("content")         public String content;          // null if erased
+    @JsonProperty("subject_id")      public String subjectId;
+    @JsonProperty("event_time")      public String eventTime;        // ISO-8601
+    @JsonProperty("valid_from")      public String validFrom;
+    @JsonProperty("valid_to")        public String validTo;          // null = currently valid
+    @JsonProperty("superseded_by")   public String supersededBy;
+    @JsonProperty("importance")      public double importance;
+    @JsonProperty("source")          public String source;
+    @JsonProperty("content_hash")    public String contentHash;
+    @JsonProperty("erased_at")       public String erasedAt;
+    @JsonProperty("metadata")        public JsonNode metadata;
+
+    @Override
+    public String toString() {
+        return "MemoryOut{id=" + id + ", eventTime=" + eventTime
+                + ", content=" + (content == null ? "<erased>" : content) + "}";
+    }
+}

--- a/agentmem/sdk/java/src/main/java/dev/lians/model/RecallResult.java
+++ b/agentmem/sdk/java/src/main/java/dev/lians/model/RecallResult.java
@@ -1,0 +1,22 @@
+package dev.lians.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Result of a recall: the current (non-stale) memories relevant to the query. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class RecallResult {
+
+    @JsonProperty("memories")
+    public List<MemoryOut> memories = Collections.emptyList();
+
+    /** Point-in-time checkpoint when the recall used {@code as_of}; otherwise null. */
+    @JsonProperty("as_of")
+    public String asOf;
+
+    @JsonProperty("total_candidates")
+    public int totalCandidates;
+}

--- a/agentmem/sdk/java/src/test/java/dev/lians/LiansClientTest.java
+++ b/agentmem/sdk/java/src/test/java/dev/lians/LiansClientTest.java
@@ -1,0 +1,174 @@
+package dev.lians;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpServer;
+import dev.lians.model.MemoryOut;
+import dev.lians.model.RecallResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the client against Java's built-in HttpServer — exercises request
+ * construction (headers, JSON body, query params) and response parsing with no
+ * external dependency or live Lians server.
+ */
+class LiansClientTest {
+
+    private HttpServer server;
+    private LiansClient client;
+
+    // Captured from the most recent request.
+    volatile String lastMethod;
+    volatile String lastPath;
+    volatile String lastQuery;
+    volatile String lastBody;
+    volatile String lastApiKey;
+    volatile String lastAdminSecret;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            lastMethod = exchange.getRequestMethod();
+            lastPath = exchange.getRequestURI().getPath();
+            lastQuery = exchange.getRequestURI().getQuery();
+            lastApiKey = exchange.getRequestHeaders().getFirst("X-API-Key");
+            lastAdminSecret = exchange.getRequestHeaders().getFirst("X-Admin-Secret");
+            lastBody = readAll(exchange.getRequestBody());
+
+            String path = lastPath;
+            int status = 200;
+            String resp;
+
+            if (path.equals("/v1/memories") && lastBody.contains("\"BOOM\"")) {
+                status = 422;
+                resp = "{\"detail\":\"boom\"}";
+            } else if (path.equals("/v1/memories")) {
+                resp = "{\"id\":\"m-1\",\"namespace\":\"ns\",\"agent_id\":\"desk\","
+                        + "\"content\":\"NVDA guidance $40B\",\"event_time\":\"2025-11-19T16:00:00Z\","
+                        + "\"valid_to\":null,\"importance\":0.5,\"content_hash\":\"h\","
+                        + "\"metadata\":{\"ticker\":\"NVDA\"}}";
+            } else if (path.equals("/v1/recall")) {
+                resp = "{\"memories\":[{\"id\":\"m-1\",\"content\":\"NVDA guidance $40B\","
+                        + "\"event_time\":\"2025-11-19T16:00:00Z\",\"metadata\":{\"ticker\":\"NVDA\"}}],"
+                        + "\"as_of\":null,\"total_candidates\":1}";
+            } else if (path.equals("/v1/graph/path")) {
+                resp = "{\"src\":\"Attorney\",\"dst\":\"PartyY\",\"connected\":true,"
+                        + "\"hops\":2,\"as_of\":null,\"path\":[]}";
+            } else if (path.equals("/v1/admin/audit/verify")) {
+                resp = "{\"status\":\"ok\",\"rows_checked\":7}";
+            } else {
+                resp = "{}";
+            }
+
+            byte[] bytes = resp.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(status, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        server.start();
+
+        String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+        client = new LiansClient(LiansClientOptions.builder()
+                .baseUrl(baseUrl)
+                .apiKey("test-key")
+                .adminSecret("admin-secret")
+                .build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.stop(0);
+    }
+
+    @Test
+    void addMemorySendsKeyAndBodyAndParsesResult() {
+        MemoryOut m = client.addMemory("desk", "NVDA FY2026 guidance raised to $40B",
+                Instant.parse("2025-11-19T16:00:00Z"),
+                Map.of("ticker", "NVDA", "metric", "revenue_guidance"));
+
+        assertEquals("POST", lastMethod);
+        assertEquals("/v1/memories", lastPath);
+        assertEquals("test-key", lastApiKey);
+        assertTrue(lastBody.contains("\"agent_id\":\"desk\""));
+        assertTrue(lastBody.contains("\"event_time\":\"2025-11-19T16:00:00Z\""));
+        assertTrue(lastBody.contains("\"ticker\":\"NVDA\""));
+
+        assertEquals("m-1", m.id);
+        assertEquals("NVDA guidance $40B", m.content);
+        assertEquals("NVDA", m.metadata.get("ticker").asText());
+    }
+
+    @Test
+    void recallParsesMemories() {
+        RecallResult r = client.recall("desk", "NVDA guidance", 5);
+        assertEquals("/v1/recall", lastPath);
+        assertEquals(1, r.memories.size());
+        assertEquals("NVDA guidance $40B", r.memories.get(0).content);
+        assertEquals(1, r.totalCandidates);
+    }
+
+    @Test
+    void recallAtSendsAsOf() {
+        client.recallAt("desk", "NVDA guidance", Instant.parse("2025-09-01T00:00:00Z"), 5);
+        assertTrue(lastBody.contains("\"as_of\":\"2025-09-01T00:00:00Z\""));
+    }
+
+    @Test
+    void recallNearAddsProximityFilters() {
+        client.recallNear("desk", "earnings", "FundA", "ticker", 5);
+        assertTrue(lastBody.contains("\"_near_entity\":\"FundA\""));
+        assertTrue(lastBody.contains("\"_near_key\":\"ticker\""));
+    }
+
+    @Test
+    void graphPathParsesConnectivity() {
+        JsonNode res = client.path("desk", "Attorney", "PartyY", 4, null);
+        assertEquals("GET", lastMethod);
+        assertEquals("/v1/graph/path", lastPath);
+        assertTrue(lastQuery.contains("src=Attorney"));
+        assertTrue(lastQuery.contains("dst=PartyY"));
+        assertTrue(res.get("connected").asBoolean());
+        assertEquals(2, res.get("hops").asInt());
+    }
+
+    @Test
+    void verifyChainSendsAdminSecret() {
+        JsonNode res = client.verifyChain("ns");
+        assertEquals("/v1/admin/audit/verify", lastPath);
+        assertEquals("admin-secret", lastAdminSecret);
+        assertEquals("ok", res.get("status").asText());
+    }
+
+    @Test
+    void nonSuccessThrowsLiansException() {
+        LiansException ex = assertThrows(LiansException.class, () ->
+                client.addMemory("desk", "BOOM", Instant.parse("2026-01-01T00:00:00Z"), Map.of()));
+        assertEquals(422, ex.status());
+        assertTrue(ex.body().contains("boom"));
+    }
+
+    private static String readAll(InputStream in) {
+        try (in) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buf = new byte[4096];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                out.write(buf, 0, n);
+            }
+            return out.toString(StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Why
mem0 ships Python/TypeScript; Zep adds Go. **Neither has a Java or C SDK** — yet Java runs regulated back-offices (bank/insurer risk systems) and C owns low-latency / embedded (HFT, market-data gateways, on-prem healthcare/legal). These bring the full compliance memory layer + relationship graph to both.

## Java — `agentmem/sdk/java`
- Maven, Java 11+, `java.net.http` + Jackson (one dependency).
- Typed `MemoryOut` / `RecallResult`, `JsonNode` for richer responses, `LiansException` exposing `status()`/`body()`.
- Full surface incl. graph (`relate`/`neighbors`/`path`) and `recallNear`.
- JUnit 5 tests run against an **in-process `com.sun.net.httpserver` mock** — verifies headers, JSON body, query params, and error handling with no live server.

## C — `agentmem/sdk/c`
- C99 + libcurl, CMake. `lians.h`/`lians.c`; every call returns `lians_response_t { long status; char *body; }`.
- Pure JSON/string helpers (`lians_json.*`) with a **no-network unit test**; example program; thread-safe immutable client.

## CI
New `java` (Temurin 11/17/21, `mvn verify`) and `c` (libcurl + cmake build + `ctest`) jobs. README gains a **Language SDKs** section.

> Note: I can't compile Java/C in this environment, so correctness is gated on this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)