### PR TITLE
Add Go SDK — five-language coverage, leading every competitor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,3 +150,29 @@ jobs:
       - name: Test (pure helpers)
         run: ctest --test-dir build --output-on-failure
         working-directory: agentmem/sdk/c
+
+  # ── Go SDK tests ────────────────────────────────────────────────────────────
+  go:
+    name: Go SDK (${{ matrix.go-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.21", "1.22", "1.23"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Vet
+        run: go vet ./...
+        working-directory: agentmem/sdk/go
+
+      - name: Test
+        run: go test ./...
+        working-directory: agentmem/sdk/go

--- a/README.md
+++ b/README.md
@@ -267,16 +267,18 @@ closed cloud. Lians keeps the graph **and** the open compliance spine.
 
 ## Language SDKs
 
-Lians ships native SDKs across four languages — including **Java and C, which no
-other open agent-memory layer offers** (mem0 is Python/TypeScript; Zep adds Go).
-That puts the full compliance memory layer where regulated systems actually run:
-JVM risk platforms, and native/low-latency C in trading, market-data, and on-prem
+Lians ships native SDKs across **five languages** — the widest coverage of any open
+agent-memory layer. mem0 is Python/TypeScript; Zep adds Go. Lians matches all of
+those **and** adds **Java and C**, which neither competitor offers — putting the
+full compliance memory layer where regulated systems actually run: JVM risk
+platforms, and native/low-latency C in trading, market-data, and on-prem
 healthcare/legal stacks.
 
 | Language | Install | Client | Docs |
 |----------|---------|--------|------|
 | **Python** | `pip install lians-sdk` | `from lians import LiansClient` | [sdk/python](agentmem/sdk/python) |
 | **TypeScript / Node** | `npm install @ebeirne/lians` | `import { LiansClient } from "@ebeirne/lians"` | [sdk/typescript](agentmem/sdk/typescript) |
+| **Go** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go` | `lians.NewClient(url, key)` | [sdk/go](agentmem/sdk/go) |
 | **Java** (JVM 11+) | `dev.lians:lians-sdk:0.2.0` (Maven) | `new LiansClient(opts)` | [sdk/java](agentmem/sdk/java) |
 | **C** (C99 + libcurl) | `cmake --build build` | `lians_client_new(...)` | [sdk/c](agentmem/sdk/c) |
 

--- a/agentmem/sdk/go/README.md
+++ b/agentmem/sdk/go/README.md
@@ -1,0 +1,105 @@
+# Lians Go SDK
+
+Financial-grade agent memory for Go — bitemporal recall, SEC 17a-4 audit chain,
+GDPR/HIPAA crypto-shred, information barriers, and a relationship graph for
+conflict-of-interest / related-party / care-network queries.
+
+Standard library only (`net/http` + `encoding/json`), `context`-aware, and safe
+for concurrent use. This puts Lians on parity with Zep's Go SDK — while Lians also
+ships Java and C, which neither mem0 nor Zep offers.
+
+## Install
+
+```bash
+go get github.com/Lians-ai/Lians/agentmem/sdk/go
+```
+
+```go
+import lians "github.com/Lians-ai/Lians/agentmem/sdk/go"
+```
+
+## Quick start
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	lians "github.com/Lians-ai/Lians/agentmem/sdk/go"
+)
+
+func main() {
+	ctx := context.Background()
+	c := lians.NewClient("https://api.lians.dev", os.Getenv("LIANS_API_KEY"),
+		lians.WithAdminSecret(os.Getenv("LIANS_ADMIN_SECRET"))) // admin secret optional
+
+	// Store a fact with its BUSINESS event-time (not now)
+	if _, err := c.AddMemory(ctx, lians.AddMemoryRequest{
+		AgentID:   "equity-desk",
+		Content:   "NVDA FY2026 revenue guidance raised to $40B",
+		EventTime: time.Date(2025, 11, 19, 16, 0, 0, 0, time.UTC),
+		Metadata:  map[string]any{"ticker": "NVDA", "metric": "revenue_guidance"},
+	}); err != nil {
+		panic(err)
+	}
+
+	// Recall current (non-stale) facts
+	r, _ := c.Recall(ctx, lians.RecallRequest{AgentID: "equity-desk", Query: "NVDA guidance"})
+	for _, m := range r.Memories {
+		fmt.Println(m.EventTime, *m.Content)
+	}
+
+	// Point-in-time — what did we know on a past date?
+	past, _ := c.RecallAt(ctx, "equity-desk", "NVDA guidance",
+		time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC), 5)
+	_ = past
+}
+```
+
+## Compliance & graph
+
+```go
+// Exhaustive knowledge state at a date (regulator demo)
+c.Snapshot(ctx, "equity-desk", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), 1000)
+
+// Lookahead-bias proof before trusting a backtest
+c.BacktestCheck(ctx, "equity-desk", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+// GDPR/HIPAA crypto-shred + verify the tamper-evident chain
+c.EraseSubject(ctx, "MRN-00042", "GDPR-REQ-2026-001")
+c.VerifyChain(ctx, "your-namespace") // requires admin secret
+
+// Relationship graph — conflict-of-interest reachability
+c.Relate(ctx, lians.RelateRequest{AgentID: "matter-7", SrcEntity: "Attorney",
+	RelType: "represented", DstEntity: "ClientX", EventTime: t})
+c.Relate(ctx, lians.RelateRequest{AgentID: "matter-7", SrcEntity: "ClientX",
+	RelType: "adverse_to", DstEntity: "PartyY", EventTime: t})
+raw, _ := c.Path(ctx, "matter-7", "Attorney", "PartyY", 4, nil)
+// raw -> {"connected": true, "hops": 2, "path": [...]}
+
+// Graph-proximity reranking
+c.RecallNear(ctx, "equity-desk", "earnings", "FundA", "ticker", 5)
+```
+
+## Notes
+
+- Timestamps are `time.Time` (serialized RFC3339 UTC).
+- Errors from non-2xx responses are `*lians.APIError` (`errors.As` to inspect
+  `StatusCode` / `Body`).
+- `AddMemory` / `Recall` return typed `*MemoryOut` / `*RecallResult`; richer
+  responses (snapshot, graph, conflicts, audit) return `json.RawMessage` for you to
+  unmarshal into your own shape.
+
+## Test
+
+```bash
+cd agentmem/sdk/go
+go test ./...   # runs against an in-process httptest server — no live Lians needed
+```
+
+See the [mem0](../../../docs/compare-mem0.md) and [Zep/Graphiti](../../../docs/compare-zep.md)
+comparisons.

--- a/agentmem/sdk/go/client.go
+++ b/agentmem/sdk/go/client.go
@@ -1,0 +1,368 @@
+package lians
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// APIError is returned when the Lians server responds with a non-2xx status.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("lians: HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// Client is a synchronous HTTP client for the Lians memory API. It is safe for
+// concurrent use by multiple goroutines.
+type Client struct {
+	baseURL     string
+	apiKey      string
+	adminSecret string
+	httpClient  *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithAdminSecret sets the admin secret used for /v1/admin/* audit endpoints.
+func WithAdminSecret(secret string) Option {
+	return func(c *Client) { c.adminSecret = secret }
+}
+
+// WithTimeout sets the per-request timeout (default 30s).
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) { c.httpClient.Timeout = d }
+}
+
+// WithHTTPClient supplies a custom *http.Client (for proxies, mTLS, tracing, …).
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) { c.httpClient = h }
+}
+
+// NewClient creates a client for the given base URL and API key.
+//
+//	c := lians.NewClient("https://api.lians.dev", os.Getenv("LIANS_API_KEY"),
+//	    lians.WithAdminSecret(os.Getenv("LIANS_ADMIN_SECRET")))
+func NewClient(baseURL, apiKey string, opts ...Option) *Client {
+	c := &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any, params url.Values, admin bool, out any) error {
+	var reqBody io.Reader
+	hasBody := false
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("lians: marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(b)
+		hasBody = true
+	}
+
+	u := c.baseURL + path
+	if len(params) > 0 {
+		u += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u, reqBody)
+	if err != nil {
+		return fmt.Errorf("lians: new request: %w", err)
+	}
+	req.Header.Set("X-API-Key", c.apiKey)
+	if hasBody {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if admin && c.adminSecret != "" {
+		req.Header.Set("X-Admin-Secret", c.adminSecret)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("lians: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("lians: read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{StatusCode: resp.StatusCode, Body: string(data)}
+	}
+	if out != nil && len(data) > 0 {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("lians: decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func iso(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+// ── Write ──────────────────────────────────────────────────────────────────
+
+// AddMemoryRequest is the input to AddMemory.
+type AddMemoryRequest struct {
+	AgentID    string
+	Content    string
+	EventTime  time.Time      // BUSINESS time the fact became true (not now)
+	Metadata   map[string]any // structured keys (e.g. {"ticker":"NVDA","metric":"eps"})
+	Source     string
+	SubjectID  string
+	Importance float64 // 0..1; left at 0 it defaults to 0.5
+}
+
+// AddMemory stores a fact with its event-time. Supersession, audit-chain append,
+// and per-subject encryption all happen server-side.
+func (c *Client) AddMemory(ctx context.Context, req AddMemoryRequest) (*MemoryOut, error) {
+	importance := req.Importance
+	if importance == 0 {
+		importance = 0.5
+	}
+	body := map[string]any{
+		"agent_id":   req.AgentID,
+		"content":    req.Content,
+		"event_time": iso(req.EventTime),
+		"importance": importance,
+	}
+	if req.Source != "" {
+		body["source"] = req.Source
+	}
+	if req.SubjectID != "" {
+		body["subject_id"] = req.SubjectID
+	}
+	if req.Metadata != nil {
+		body["metadata"] = req.Metadata
+	}
+	var out MemoryOut
+	if err := c.do(ctx, http.MethodPost, "/v1/memories", body, nil, false, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ── Read ───────────────────────────────────────────────────────────────────
+
+// RecallRequest is the input to Recall.
+type RecallRequest struct {
+	AgentID string
+	Query   string
+	K       int        // defaults to 5
+	AsOf    *time.Time // point-in-time recall when non-nil
+	Filters map[string]any
+}
+
+// Recall returns the current (non-stale) memories relevant to the query.
+func (c *Client) Recall(ctx context.Context, req RecallRequest) (*RecallResult, error) {
+	k := req.K
+	if k <= 0 {
+		k = 5
+	}
+	body := map[string]any{"agent_id": req.AgentID, "query": req.Query, "k": k}
+	if req.AsOf != nil {
+		body["as_of"] = iso(*req.AsOf)
+	}
+	if req.Filters != nil {
+		body["filters"] = req.Filters
+	}
+	var out RecallResult
+	if err := c.do(ctx, http.MethodPost, "/v1/recall", body, nil, false, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// RecallAt is point-in-time recall — "what did the agent know on this date?".
+func (c *Client) RecallAt(ctx context.Context, agentID, query string, asOf time.Time, k int) (*RecallResult, error) {
+	return c.Recall(ctx, RecallRequest{AgentID: agentID, Query: query, K: k, AsOf: &asOf})
+}
+
+// RecallNear recalls with graph-proximity reranking around nearEntity.
+func (c *Client) RecallNear(ctx context.Context, agentID, query, nearEntity, nearKey string, k int) (*RecallResult, error) {
+	if nearKey == "" {
+		nearKey = "ticker"
+	}
+	return c.Recall(ctx, RecallRequest{
+		AgentID: agentID, Query: query, K: k,
+		Filters: map[string]any{"_near_entity": nearEntity, "_near_key": nearKey},
+	})
+}
+
+// Snapshot reconstructs the exhaustive knowledge state of an agent at asOf.
+func (c *Client) Snapshot(ctx context.Context, agentID string, asOf time.Time, limit int) (json.RawMessage, error) {
+	params := url.Values{}
+	params.Set("agent_id", agentID)
+	params.Set("as_of", iso(asOf))
+	params.Set("limit", strconv.Itoa(limit))
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodGet, "/v1/snapshot", nil, params, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// BacktestCheck detects lookahead bias relative to simulationAsOf.
+func (c *Client) BacktestCheck(ctx context.Context, agentID string, simulationAsOf time.Time) (json.RawMessage, error) {
+	body := map[string]any{"agent_id": agentID, "simulation_as_of": iso(simulationAsOf)}
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodPost, "/v1/backtest/check", body, nil, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// FactHistory returns the time-series of a structured fact (ticker + metric).
+func (c *Client) FactHistory(ctx context.Context, agentID, ticker, metric string, limit int) (json.RawMessage, error) {
+	params := url.Values{}
+	params.Set("agent_id", agentID)
+	params.Set("ticker", ticker)
+	params.Set("metric", metric)
+	params.Set("limit", strconv.Itoa(limit))
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodGet, "/v1/facts/history", nil, params, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ── Compliance / erasure ───────────────────────────────────────────────────
+
+// EraseSubject performs a GDPR/HIPAA crypto-shred of a data subject.
+func (c *Client) EraseSubject(ctx context.Context, subjectID, requestRef string) (json.RawMessage, error) {
+	body := map[string]any{"subject_id": subjectID, "request_ref": requestRef}
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodPost, "/v1/erase", body, nil, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// VerifyChain verifies the SEC 17a-4 tamper-evidence hash chain (requires admin secret).
+func (c *Client) VerifyChain(ctx context.Context, namespace string) (json.RawMessage, error) {
+	params := url.Values{}
+	params.Set("namespace", namespace)
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodGet, "/v1/admin/audit/verify", nil, params, true, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ── Relationship graph ─────────────────────────────────────────────────────
+
+// RelateRequest is the input to Relate.
+type RelateRequest struct {
+	AgentID   string
+	SrcEntity string
+	RelType   string
+	DstEntity string
+	EventTime time.Time
+	Exclusive bool // invalidate other live src--relType--> edges
+	Normalize bool // collapse company/ISIN/CUSIP to canonical ticker
+	SubjectID string
+	Source    string
+	Metadata  map[string]any
+}
+
+// Relate asserts a relationship edge src --relType--> dst.
+func (c *Client) Relate(ctx context.Context, req RelateRequest) (json.RawMessage, error) {
+	body := map[string]any{
+		"agent_id":   req.AgentID,
+		"src_entity": req.SrcEntity,
+		"rel_type":   req.RelType,
+		"dst_entity": req.DstEntity,
+		"event_time": iso(req.EventTime),
+		"exclusive":  req.Exclusive,
+		"normalize":  req.Normalize,
+	}
+	if req.SubjectID != "" {
+		body["subject_id"] = req.SubjectID
+	}
+	if req.Source != "" {
+		body["source"] = req.Source
+	}
+	if req.Metadata != nil {
+		body["metadata"] = req.Metadata
+	}
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodPost, "/v1/graph/relate", body, nil, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Unrelate invalidates a live edge (sets valid_to).
+func (c *Client) Unrelate(ctx context.Context, agentID, srcEntity, relType, dstEntity string) (json.RawMessage, error) {
+	body := map[string]any{
+		"agent_id":   agentID,
+		"src_entity": srcEntity,
+		"rel_type":   relType,
+		"dst_entity": dstEntity,
+	}
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodPost, "/v1/graph/unrelate", body, nil, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Neighbors returns entities within depth hops of entity. direction is
+// "any" (default), "in", or "out"; asOf may be nil for present-time.
+func (c *Client) Neighbors(ctx context.Context, agentID, entity string, depth int, direction string, asOf *time.Time) (json.RawMessage, error) {
+	if direction == "" {
+		direction = "any"
+	}
+	params := url.Values{}
+	params.Set("agent_id", agentID)
+	params.Set("entity", entity)
+	params.Set("depth", strconv.Itoa(depth))
+	params.Set("direction", direction)
+	if asOf != nil {
+		params.Set("as_of", iso(*asOf))
+	}
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodGet, "/v1/graph/neighbors", nil, params, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Path returns the shortest connection between two entities — the
+// conflict-of-interest / related-party reachability query.
+func (c *Client) Path(ctx context.Context, agentID, srcEntity, dstEntity string, maxDepth int, asOf *time.Time) (json.RawMessage, error) {
+	params := url.Values{}
+	params.Set("agent_id", agentID)
+	params.Set("src", srcEntity)
+	params.Set("dst", dstEntity)
+	params.Set("max_depth", strconv.Itoa(maxDepth))
+	if asOf != nil {
+		params.Set("as_of", iso(*asOf))
+	}
+	var out json.RawMessage
+	if err := c.do(ctx, http.MethodGet, "/v1/graph/path", nil, params, false, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/agentmem/sdk/go/client_test.go
+++ b/agentmem/sdk/go/client_test.go
@@ -1,0 +1,191 @@
+package lians
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type capture struct {
+	method, path, query, body, apiKey, adminSecret string
+}
+
+func newServer(cap *capture) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		cap.method = r.Method
+		cap.path = r.URL.Path
+		cap.query = r.URL.RawQuery
+		cap.body = string(b)
+		cap.apiKey = r.Header.Get("X-API-Key")
+		cap.adminSecret = r.Header.Get("X-Admin-Secret")
+
+		switch {
+		case r.URL.Path == "/v1/memories" && strings.Contains(cap.body, `"BOOM"`):
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			io.WriteString(w, `{"detail":"boom"}`)
+		case r.URL.Path == "/v1/memories":
+			io.WriteString(w, `{"id":"m-1","namespace":"ns","agent_id":"desk",`+
+				`"content":"NVDA guidance $40B","event_time":"2025-11-19T16:00:00Z",`+
+				`"valid_to":null,"importance":0.5,"metadata":{"ticker":"NVDA"}}`)
+		case r.URL.Path == "/v1/recall":
+			io.WriteString(w, `{"memories":[{"id":"m-1","content":"NVDA guidance $40B",`+
+				`"event_time":"2025-11-19T16:00:00Z"}],"as_of":null,"total_candidates":1}`)
+		case r.URL.Path == "/v1/graph/path":
+			io.WriteString(w, `{"src":"Attorney","dst":"PartyY","connected":true,"hops":2,"path":[]}`)
+		case r.URL.Path == "/v1/admin/audit/verify":
+			io.WriteString(w, `{"status":"ok","rows_checked":7}`)
+		default:
+			io.WriteString(w, `{}`)
+		}
+	}))
+}
+
+func newClient(srv *httptest.Server) *Client {
+	return NewClient(srv.URL, "test-key", WithAdminSecret("admin-secret"))
+}
+
+func TestAddMemory(t *testing.T) {
+	cap := &capture{}
+	srv := newServer(cap)
+	defer srv.Close()
+
+	m, err := newClient(srv).AddMemory(context.Background(), AddMemoryRequest{
+		AgentID:   "desk",
+		Content:   "NVDA FY2026 revenue guidance raised to $40B",
+		EventTime: time.Date(2025, 11, 19, 16, 0, 0, 0, time.UTC),
+		Metadata:  map[string]any{"ticker": "NVDA", "metric": "revenue_guidance"},
+	})
+	if err != nil {
+		t.Fatalf("AddMemory: %v", err)
+	}
+	if cap.method != http.MethodPost || cap.path != "/v1/memories" {
+		t.Fatalf("unexpected request: %s %s", cap.method, cap.path)
+	}
+	if cap.apiKey != "test-key" {
+		t.Fatalf("missing api key, got %q", cap.apiKey)
+	}
+	if !strings.Contains(cap.body, `"agent_id":"desk"`) ||
+		!strings.Contains(cap.body, `"event_time":"2025-11-19T16:00:00Z"`) ||
+		!strings.Contains(cap.body, `"ticker":"NVDA"`) {
+		t.Fatalf("unexpected body: %s", cap.body)
+	}
+	if m.ID != "m-1" || m.Content == nil || *m.Content != "NVDA guidance $40B" {
+		t.Fatalf("unexpected result: %+v", m)
+	}
+}
+
+func TestRecall(t *testing.T) {
+	cap := &capture{}
+	srv := newServer(cap)
+	defer srv.Close()
+
+	r, err := newClient(srv).Recall(context.Background(), RecallRequest{AgentID: "desk", Query: "NVDA guidance", K: 5})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if cap.path != "/v1/recall" || len(r.Memories) != 1 || r.TotalCandidates != 1 {
+		t.Fatalf("unexpected recall result: %+v", r)
+	}
+	if r.Memories[0].Content == nil || *r.Memories[0].Content != "NVDA guidance $40B" {
+		t.Fatalf("unexpected content: %+v", r.Memories[0])
+	}
+}
+
+func TestRecallAtSendsAsOf(t *testing.T) {
+	cap := &capture{}
+	srv := newServer(cap)
+	defer srv.Close()
+
+	_, err := newClient(srv).RecallAt(context.Background(), "desk", "NVDA guidance",
+		time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC), 5)
+	if err != nil {
+		t.Fatalf("RecallAt: %v", err)
+	}
+	if !strings.Contains(cap.body, `"as_of":"2025-09-01T00:00:00Z"`) {
+		t.Fatalf("missing as_of in body: %s", cap.body)
+	}
+}
+
+func TestRecallNearAddsFilters(t *testing.T) {
+	cap := &capture{}
+	srv := newServer(cap)
+	defer srv.Close()
+
+	_, err := newClient(srv).RecallNear(context.Background(), "desk", "earnings", "FundA", "ticker", 5)
+	if err != nil {
+		t.Fatalf("RecallNear: %v", err)
+	}
+	if !strings.Contains(cap.body, `"_near_entity":"FundA"`) ||
+		!strings.Contains(cap.body, `"_near_key":"ticker"`) {
+		t.Fatalf("missing proximity filters: %s", cap.body)
+	}
+}
+
+func TestPath(t *testing.T) {
+	cap := &capture{}
+	srv := newServer(cap)
+	defer srv.Close()
+
+	raw, err := newClient(srv).Path(context.Background(), "desk", "Attorney", "PartyY", 4, nil)
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	if cap.method != http.MethodGet || cap.path != "/v1/graph/path" {
+		t.Fatalf("unexpected request: %s %s", cap.method, cap.path)
+	}
+	if !strings.Contains(cap.query, "src=Attorney") || !strings.Contains(cap.query, "dst=PartyY") {
+		t.Fatalf("unexpected query: %s", cap.query)
+	}
+	var pr struct {
+		Connected bool `json:"connected"`
+		Hops      int  `json:"hops"`
+	}
+	if err := json.Unmarshal(raw, &pr); err != nil {
+		t.Fatalf("decode path: %v", err)
+	}
+	if !pr.Connected || pr.Hops != 2 {
+		t.Fatalf("unexpected path result: %+v", pr)
+	}
+}
+
+func TestVerifyChainSendsAdminSecret(t *testing.T) {
+	cap := &capture{}
+	srv := newServer(cap)
+	defer srv.Close()
+
+	if _, err := newClient(srv).VerifyChain(context.Background(), "ns"); err != nil {
+		t.Fatalf("VerifyChain: %v", err)
+	}
+	if cap.path != "/v1/admin/audit/verify" || cap.adminSecret != "admin-secret" {
+		t.Fatalf("admin secret not sent: path=%s secret=%q", cap.path, cap.adminSecret)
+	}
+}
+
+func TestAPIErrorOnNonSuccess(t *testing.T) {
+	cap := &capture{}
+	srv := newServer(cap)
+	defer srv.Close()
+
+	_, err := newClient(srv).AddMemory(context.Background(), AddMemoryRequest{
+		AgentID:   "desk",
+		Content:   "BOOM",
+		EventTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != 422 || !strings.Contains(apiErr.Body, "boom") {
+		t.Fatalf("unexpected APIError: %+v", apiErr)
+	}
+}

--- a/agentmem/sdk/go/doc.go
+++ b/agentmem/sdk/go/doc.go
@@ -1,0 +1,27 @@
+// Package lians is the Go SDK for Lians, a financial-grade memory layer for AI agents.
+//
+// Lians is built for regulated environments (financial institutions, healthcare,
+// legal). Unlike a plain vector store it uses a bitemporal model — superseded
+// facts are excluded at the database layer, every write lands in a tamper-evident
+// SHA-256 audit chain (SEC 17a-4), per-subject keys give GDPR/HIPAA crypto-shred,
+// and information barriers are enforced at PostgreSQL row-level security. It also
+// exposes a bitemporal relationship graph for conflict-of-interest / related-party
+// / care-network reachability queries.
+//
+// The client uses only the standard library (net/http, encoding/json) and is safe
+// for concurrent use. Every method takes a context.Context.
+//
+//	c := lians.NewClient("https://api.lians.dev", os.Getenv("LIANS_API_KEY"))
+//
+//	_, err := c.AddMemory(ctx, lians.AddMemoryRequest{
+//	    AgentID:   "equity-desk",
+//	    Content:   "NVDA FY2026 revenue guidance raised to $40B",
+//	    EventTime: time.Date(2025, 11, 19, 16, 0, 0, 0, time.UTC),
+//	    Metadata:  map[string]any{"ticker": "NVDA", "metric": "revenue_guidance"},
+//	})
+//
+//	r, err := c.Recall(ctx, lians.RecallRequest{AgentID: "equity-desk", Query: "NVDA guidance"})
+//	for _, m := range r.Memories {
+//	    fmt.Println(m.EventTime, *m.Content)
+//	}
+package lians

--- a/agentmem/sdk/go/go.mod
+++ b/agentmem/sdk/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/Lians-ai/Lians/agentmem/sdk/go
+
+go 1.21

--- a/agentmem/sdk/go/types.go
+++ b/agentmem/sdk/go/types.go
@@ -1,0 +1,31 @@
+package lians
+
+import "encoding/json"
+
+// MemoryOut is a single memory returned by recall, snapshot, or fact-history.
+//
+// Content is empty (and ContentErased true) when the memory was crypto-shredded
+// (GDPR/HIPAA erasure): its existence and metadata survive, the content does not.
+type MemoryOut struct {
+	ID           string          `json:"id"`
+	Namespace    string          `json:"namespace"`
+	AgentID      string          `json:"agent_id"`
+	Content      *string         `json:"content"` // nil if erased
+	SubjectID    string          `json:"subject_id,omitempty"`
+	EventTime    string          `json:"event_time"`
+	ValidFrom    string          `json:"valid_from,omitempty"`
+	ValidTo      *string         `json:"valid_to"` // nil = currently valid
+	SupersededBy *string         `json:"superseded_by,omitempty"`
+	Importance   float64         `json:"importance"`
+	Source       *string         `json:"source,omitempty"`
+	ContentHash  string          `json:"content_hash,omitempty"`
+	ErasedAt     *string         `json:"erased_at,omitempty"`
+	Metadata     json.RawMessage `json:"metadata,omitempty"`
+}
+
+// RecallResult is the set of current (non-stale) memories relevant to a query.
+type RecallResult struct {
+	Memories        []MemoryOut `json:"memories"`
+	AsOf            *string     `json:"as_of"` // set when recall used a point-in-time checkpoint
+	TotalCandidates int         `json:"total_candidates"`
+}


### PR DESCRIPTION
## Why
Zep's headline is Python/TypeScript/**Go**; mem0 is Python/TypeScript only. This brings Lians to parity on Go — and combined with the existing **Java** and **C** SDKs, gives Lians the widest language coverage of any open agent-memory layer (5 languages).

## `agentmem/sdk/go`
- **Standard library only** (`net/http` + `encoding/json`), `context`-aware, concurrency-safe.
- `NewClient` + functional options (`WithAdminSecret` / `WithTimeout` / `WithHTTPClient`).
- Typed `MemoryOut` / `RecallResult`; `json.RawMessage` for richer responses; `*APIError` for non-2xx.
- Full surface incl. `RecallAt`, `Snapshot`, `BacktestCheck`, `FactHistory`, `EraseSubject`, `VerifyChain`, the graph (`Relate`/`Unrelate`/`Neighbors`/`Path`), and `RecallNear`.
- Tests run against an in-process `httptest` server — no live server.

## CI
New `go` job (Go 1.21/1.22/1.23, `go vet` + `go test`). README **Language SDKs** table now lists five languages.

> Can't run Go in this dev env — CI is the gate. (Caught and fixed one Go evaluation-order gotcha: `return out, c.do(&out)` reads `out` before `do` populates it; rewritten to populate-then-return.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)