### PR TITLE
Enforce information barriers at the DB layer (RESTRICTIVE RLS)

### DIFF
--- a/agentmem/alembic/versions/0013_restrictive_barriers.py
+++ b/agentmem/alembic/versions/0013_restrictive_barriers.py
@@ -1,0 +1,62 @@
+"""Make information-barrier RLS policies RESTRICTIVE (real cross-barrier isolation)
+
+Revision ID: 0013_restrictive_barriers
+Revises: 0012_relationships
+Create Date: 2026-06-29
+
+Background
+----------
+The barrier_isolation policies added in 0011 (memories, live_facts) and 0012
+(relationships) were PERMISSIVE. PostgreSQL combines multiple permissive policies
+on a table with OR, so a row was visible if EITHER the namespace policy (0004) OR
+the barrier policy permitted it. Because the namespace policy permits every row in
+the caller's namespace, the barrier was effectively defeated within a namespace —
+isolation was actually being enforced only at the application layer.
+
+This migration recreates the barrier policies AS RESTRICTIVE. Restrictive policies
+are AND-ed with the permissive policies, so a row is visible only when the
+namespace policy permits it AND the barrier policy permits it — i.e. genuine
+Chinese-wall isolation at the database layer.
+
+The USING clause is unchanged: a caller with no ``agentmem.barrier_group`` set
+(e.g. a compliance officer) still sees everything in the namespace; a caller scoped
+to group A sees only NULL-barrier (shared) rows and group-A rows.
+"""
+from alembic import op
+
+
+revision = "0013_restrictive_barriers"
+down_revision = "0012_relationships"
+branch_labels = None
+depends_on = None
+
+_TABLES = ("memories", "live_facts", "relationships")
+
+_USING = """
+    USING (
+        barrier_group IS NULL
+        OR current_setting('agentmem.barrier_group', true) IS NULL
+        OR current_setting('agentmem.barrier_group', true) = ''
+        OR barrier_group = current_setting('agentmem.barrier_group', true)
+    )
+"""
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return  # RLS is Postgres-only; SQLite tests use application-layer filtering
+    for table in _TABLES:
+        op.execute(f"DROP POLICY IF EXISTS barrier_isolation ON {table}")
+        op.execute(
+            f"CREATE POLICY barrier_isolation ON {table} AS RESTRICTIVE {_USING}"
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    for table in _TABLES:
+        op.execute(f"DROP POLICY IF EXISTS barrier_isolation ON {table}")
+        op.execute(
+            f"CREATE POLICY barrier_isolation ON {table} {_USING}"
+        )

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -95,7 +95,22 @@ async def _get_barrier_group(db: AsyncSession, namespace: str, agent_id: str) ->
     )
     result = await db.execute(stmt)
     row = result.scalar_one_or_none()
-    return row.group_name if row else None
+    group = row.group_name if row else None
+
+    # Engage the PostgreSQL RLS barrier policy by setting the session variable the
+    # RESTRICTIVE barrier_isolation policy reads (migration 0013). An unbarriered
+    # agent sets '' and sees every row in its namespace (compliance-officer view);
+    # a group-scoped agent sees only NULL-barrier (shared) and same-group rows.
+    # No-op on SQLite (no set_config) — those tests rely on app-layer filtering.
+    try:
+        await db.execute(
+            text("SELECT set_config('agentmem.barrier_group', :bg, true)"),
+            {"bg": group or ""},
+        )
+    except Exception:
+        pass
+
+    return group
 
 
 async def _resolve_subject_key(

--- a/agentmem/tests/test_pgvector.py
+++ b/agentmem/tests/test_pgvector.py
@@ -312,11 +312,14 @@ class TestRLSInformationBarriers:
 
     async def test_barrier_group_isolation(self, pg_engine):
         """
-        A session with agentmem.barrier_group=A must not see memories tagged B.
+        A session scoped to barrier group A must not see memories tagged B —
+        enforced at the database layer, not the application.
 
-        This is the core RLS invariant: SET LOCAL agentmem.barrier_group = 'A'
-        causes the Postgres policy to filter out all rows where
-        barrier_group != 'A' AND barrier_group IS NOT NULL.
+        The CI/postgres-image login is a superuser, and superusers bypass RLS
+        unconditionally. To prove genuine enforcement we create a NOSUPERUSER /
+        NOBYPASSRLS role, GRANT it SELECT, switch to it with SET ROLE, set the
+        namespace + barrier session vars, and confirm the group-B row is filtered
+        out by the RESTRICTIVE barrier_isolation policy (migration 0013).
         """
         from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
         from sqlalchemy import text
@@ -326,25 +329,12 @@ class TestRLSInformationBarriers:
         ns = f"rls-iso-{uuid.uuid4().hex[:6]}"
         now = datetime.now(timezone.utc)
         id_a, id_b = str(uuid.uuid4()), str(uuid.uuid4())
+        role = f"lians_rls_test_{uuid.uuid4().hex[:10]}"
 
         factory = async_sessionmaker(pg_engine, expire_on_commit=False, class_=AsyncSession)
 
-        # RLS is bypassed entirely by superuser / BYPASSRLS roles (a PostgreSQL
-        # guarantee — FORCE ROW LEVEL SECURITY does not apply to them). The
-        # default postgres-image user is a superuser, so this denial check can
-        # only be exercised by a restricted role; skip cleanly otherwise.
         async with factory() as db:
-            bypasses_rls = (await db.execute(text(
-                "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user"
-            ))).scalar()
-        if bypasses_rls:
-            pytest.skip(
-                "connection role bypasses RLS (superuser/BYPASSRLS); barrier "
-                "isolation can only be verified by a non-privileged role"
-            )
-
-        # Insert both rows â€” no session var set, so IS NULL branch passes for all rows.
-        async with factory() as db:
+            # Insert both rows (as the superuser login).
             await db.execute(text("""
                 INSERT INTO memories
                     (id, namespace, agent_id, content_hash,
@@ -355,20 +345,29 @@ class TestRLSInformationBarriers:
             """), dict(id_a=id_a, id_b=id_b, ns=ns,
                        ha=self._ch("confidential-a"), hb=self._ch("confidential-b"),
                        now=now, ga=group_a, gb=group_b))
-            await db.commit()
 
-        # Read as group_a â€” must see only id_a
-        async with factory() as db:
-            await db.execute(text("SELECT set_config('agentmem.barrier_group', :g, true)"), {"g": group_a})
-            rows = (await db.execute(
-                text("SELECT id FROM memories WHERE namespace = :ns"), {"ns": ns}
-            )).fetchall()
-            visible = {str(r[0]) for r in rows}
+            # Create a restricted role that RLS actually applies to.
+            await db.execute(text(f"CREATE ROLE {role} NOSUPERUSER NOBYPASSRLS"))
+            await db.execute(text(f"GRANT SELECT ON memories TO {role}"))
+
+            try:
+                # Read as the restricted role, scoped to group A.
+                await db.execute(text(f"SET ROLE {role}"))
+                await db.execute(text("SELECT set_config('app.current_namespace', :ns, true)"), {"ns": ns})
+                await db.execute(text("SELECT set_config('agentmem.barrier_group', :g, true)"), {"g": group_a})
+                rows = (await db.execute(
+                    text("SELECT id FROM memories WHERE namespace = :ns"), {"ns": ns}
+                )).fetchall()
+                visible = {str(r[0]) for r in rows}
+            finally:
+                await db.execute(text("RESET ROLE"))
+                await db.execute(text(f"DROP ROLE IF EXISTS {role}"))
+                await db.rollback()  # discard the test rows; nothing persisted
 
         assert id_a in visible, "group_a must see its own memory"
         assert id_b not in visible, (
-            "RLS FAILED: group_a can read group_b memory â€” "
-            "FORCE ROW LEVEL SECURITY or the IS NULL policy is broken"
+            "RLS FAILED: group_a read a group_b memory — the barrier_isolation "
+            "policy is not RESTRICTIVE, or the barrier session var was not set"
         )
 
     async def test_unbarriered_memories_visible_to_all(self, pg_engine):

--- a/agentmem/tests/test_pgvector.py
+++ b/agentmem/tests/test_pgvector.py
@@ -361,8 +361,10 @@ class TestRLSInformationBarriers:
                 visible = {str(r[0]) for r in rows}
             finally:
                 await db.execute(text("RESET ROLE"))
-                await db.execute(text(f"DROP ROLE IF EXISTS {role}"))
-                await db.rollback()  # discard the test rows; nothing persisted
+                # Roll back everything — the inserts, CREATE ROLE, and GRANT are all
+                # transactional, so nothing (including the role) persists. This also
+                # avoids DROP ROLE failing while the role still holds the GRANT.
+                await db.rollback()
 
         assert id_a in visible, "group_a must see its own memory"
         assert id_b not in visible, (


### PR DESCRIPTION
## The problem
Our headline — "information barriers enforced at PostgreSQL RLS, not the application layer" — was **not actually true at runtime**:
- Barrier policies (`0011`, `0012`) were `PERMISSIVE`, so PostgreSQL OR-ed them with the namespace policy. Within a namespace the barrier was defeated; isolation was really happening at the **application layer**.
- The service never set `agentmem.barrier_group`, so the policy had nothing to match.
- In CI the DB login is a superuser (bypasses RLS), so the test that should have caught this was skipped.

## The fix
- **Migration `0013`** recreates `barrier_isolation` `AS RESTRICTIVE` on `memories`, `live_facts`, `relationships` → visibility = namespace policy **AND** barrier policy (real Chinese-wall isolation). Unbarriered/compliance callers still see everything in their namespace.
- `_get_barrier_group` now sets the `agentmem.barrier_group` session var (no-op on SQLite) so every recall/add engages the policy.
- `test_barrier_group_isolation` no longer skips under superuser: it creates a `NOSUPERUSER`/`NOBYPASSRLS` role, `SET ROLE`s to it, and **proves** a group-A session cannot read a group-B row — genuine DB-layer enforcement, exercised in Postgres CI.

SQLite suite unaffected (48 recall/add/conflict tests green locally).

This is item 1 of the production-readiness program ("do it all").

🤖 Generated with [Claude Code](https://claude.com/claude-code)