### PR TITLE
Ops hardening: idempotency keys, SDK retries, /livez+/readyz, release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release SDK artifacts
+
+# Cut a release by pushing a semver tag (e.g. v0.2.1). Builds the language
+# artifacts and attaches them to the GitHub Release. Python and npm have their
+# own publish workflows; this covers Java (jar) and C (source tarball), and
+# sanity-builds Go. See docs/publishing.md.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  java-jar:
+    name: Build Java jar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+      - name: Package
+        run: mvn -B --no-transfer-progress package
+        working-directory: agentmem/sdk/java
+      - name: Attach jar to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: agentmem/sdk/java/target/*.jar
+
+  c-tarball:
+    name: Package C source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create tarball
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          tar -czf "lians-c-${version}.tar.gz" -C agentmem/sdk c
+      - name: Attach tarball to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: lians-c-*.tar.gz
+
+  go-verify:
+    name: Verify Go module builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+      - name: Build & vet
+        run: go vet ./... && go build ./...
+        working-directory: agentmem/sdk/go

--- a/README.md
+++ b/README.md
@@ -384,14 +384,15 @@ Full reference: [agentmem/.env.example](agentmem/.env.example)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/v1/memories` | Add a memory (triggers supersession check) |
+| `POST` | `/v1/memories` | Add a memory (supersession check; `Idempotency-Key` header for exactly-once retries) |
 | `POST` | `/v1/memories/batch` | Batch ingest |
 | `POST` | `/v1/recall` | Hybrid BM25+cosine recall; optional `as_of` |
 | `POST` | `/v1/erase` | GDPR crypto-shred by `subject_id` |
 | `GET`  | `/v1/audit/reconstruct` | Reconstruct agent state at any past date |
 | `GET`  | `/v1/admin/audit/verify` | Verify SHA-256 hash chain integrity |
 | `GET`  | `/v1/admin/audit/export` | Export audit log (SEC/FINRA/CFTC) |
-| `GET`  | `/health` | Deep health check (DB + Redis) |
+| `GET`  | `/livez` | Liveness probe (cheap; process up) |
+| `GET`  | `/readyz` · `/health` | Readiness / deep health check (DB + Redis) |
 
 Interactive docs: `http://localhost:8000/docs`
 

--- a/agentmem/alembic/versions/0014_idempotency_keys.py
+++ b/agentmem/alembic/versions/0014_idempotency_keys.py
@@ -1,0 +1,35 @@
+"""idempotency_keys table for exactly-once writes
+
+Revision ID: 0014_idempotency_keys
+Revises: 0013_restrictive_barriers
+Create Date: 2026-06-29
+
+Maps a client-supplied Idempotency-Key (scoped to a namespace) to the memory it
+created. A retried POST /v1/memories carrying the same key returns the original
+result instead of inserting a duplicate.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "0014_idempotency_keys"
+down_revision = "0013_restrictive_barriers"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "idempotency_keys",
+        sa.Column("key", sa.String(), primary_key=True),
+        sa.Column("namespace", sa.String(), primary_key=True),
+        sa.Column("memory_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_idempotency_keys_created_at", "idempotency_keys", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_idempotency_keys_created_at", table_name="idempotency_keys")
+    op.drop_table("idempotency_keys")

--- a/agentmem/sdk/python/lians/client.py
+++ b/agentmem/sdk/python/lians/client.py
@@ -2,6 +2,8 @@
 Lians Python SDK — async HTTP client for the REST API.
 """
 from __future__ import annotations
+import asyncio
+import random
 from datetime import datetime
 from typing import Any, Optional
 import httpx
@@ -30,13 +32,22 @@ class AsyncLiansClient:
         api_key: str = "",
         admin_secret: str = "",
         timeout: float = 30.0,
+        max_retries: int = 2,
+        backoff_factor: float = 0.5,
     ):
         self._base = base_url.rstrip("/")
         self._headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
         self._admin_headers = {"X-Admin-Secret": admin_secret, "Content-Type": "application/json"}
         self._timeout = timeout
+        self._max_retries = max_retries
+        self._backoff_factor = backoff_factor
 
     # ── Internal ──────────────────────────────────────────────────────────────
+
+    async def _sleep_backoff(self, attempt: int) -> None:
+        # Exponential backoff with jitter: base * 2^attempt * (1 .. 1.25)
+        delay = self._backoff_factor * (2 ** attempt) * (1.0 + random.random() * 0.25)
+        await asyncio.sleep(delay)
 
     async def _req(
         self,
@@ -46,16 +57,37 @@ class AsyncLiansClient:
         json: Any = None,
         params: Optional[dict] = None,
         admin: bool = False,
+        extra_headers: Optional[dict] = None,
     ) -> dict:
-        headers = self._admin_headers if admin else self._headers
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            resp = await client.request(
-                method,
-                f"{self._base}{path}",
-                headers=headers,
-                json=json,
-                params={k: v for k, v in (params or {}).items() if v is not None},
-            )
+        headers = dict(self._admin_headers if admin else self._headers)
+        if extra_headers:
+            headers.update(extra_headers)
+        url = f"{self._base}{path}"
+        clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+
+        attempt = 0
+        while True:
+            try:
+                async with httpx.AsyncClient(timeout=self._timeout) as client:
+                    resp = await client.request(
+                        method, url, headers=headers, json=json, params=clean_params,
+                    )
+            except httpx.TransportError:
+                # Connection/read/timeout error — safe to retry (writes carry an
+                # Idempotency-Key, so a retried POST won't double-write).
+                if attempt >= self._max_retries:
+                    raise
+                await self._sleep_backoff(attempt)
+                attempt += 1
+                continue
+
+            # Retry transient server errors / throttling.
+            if resp.status_code >= 500 or resp.status_code == 429:
+                if attempt < self._max_retries:
+                    await self._sleep_backoff(attempt)
+                    attempt += 1
+                    continue
+
             resp.raise_for_status()
             return resp.json()
 
@@ -70,8 +102,16 @@ class AsyncLiansClient:
         subject_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         importance: float = 0.5,
+        idempotency_key: Optional[str] = None,
     ) -> dict:
-        """Store a financial fact.  Returns the created MemoryOut as a dict."""
+        """
+        Store a financial fact.  Returns the created MemoryOut as a dict.
+
+        A stable ``Idempotency-Key`` is generated automatically (or pass your own)
+        so that an automatic retry after a network blip cannot create a duplicate.
+        """
+        import uuid as _uuid
+        key = idempotency_key or str(_uuid.uuid4())
         return await self._req("POST", "/v1/memories", json={
             "agent_id": agent_id,
             "content": content,
@@ -80,7 +120,7 @@ class AsyncLiansClient:
             "subject_id": subject_id,
             "metadata": metadata or {},
             "importance": importance,
-        })
+        }, extra_headers={"Idempotency-Key": key})
 
     async def batch_add(self, memories: list[dict[str, Any]]) -> dict:
         """

--- a/agentmem/src/lians/api/routes_memory.py
+++ b/agentmem/src/lians/api/routes_memory.py
@@ -1,6 +1,7 @@
+from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Header
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_db
@@ -9,7 +10,10 @@ from ..schemas import (
     MemoryBatchAdd, MemoryBatchResult, MemoryLineageResult,
     FactHistoryResult,
 )
-from ..memory_service import add_memory, recall_memories, batch_add_memories, get_memory_lineage, get_structured_fact_history
+from ..memory_service import (
+    add_memory, add_memory_idempotent, recall_memories, batch_add_memories,
+    get_memory_lineage, get_structured_fact_history,
+)
 from ..adapters import get_adapter
 from .deps import get_auth, AuthContext
 
@@ -21,9 +25,15 @@ async def create_memory(
     req: MemoryAdd,
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_db),
+    idempotency_key: Optional[str] = Header(default=None, alias="Idempotency-Key"),
 ):
+    """
+    Add a memory. Supply an ``Idempotency-Key`` header to make the write safe to
+    retry: a repeated request with the same key returns the original memory
+    instead of inserting a duplicate.
+    """
     auth.require("write")
-    return await add_memory(db, auth.namespace, req)
+    return await add_memory_idempotent(db, auth.namespace, req, idempotency_key)
 
 
 @router.post("/memories/batch", response_model=MemoryBatchResult)

--- a/agentmem/src/lians/main.py
+++ b/agentmem/src/lians/main.py
@@ -264,3 +264,22 @@ async def health(db: AsyncSession = Depends(_get_db)):
         content={"status": "ok" if all_ok else "degraded", "checks": checks},
         status_code=200 if all_ok else 503,
     )
+
+
+@app.get("/livez", include_in_schema=False)
+async def livez():
+    """
+    Liveness probe — confirms the process is up. Intentionally cheap: it never
+    touches the database or Redis, so a transient dependency blip does not cause
+    Kubernetes to restart an otherwise-healthy pod. Use for livenessProbe.
+    """
+    return {"status": "alive"}
+
+
+@app.get("/readyz", include_in_schema=False)
+async def readyz(db: AsyncSession = Depends(_get_db)):
+    """
+    Readiness probe — deep dependency check (same as /health). A 503 takes the
+    instance out of rotation without killing the process. Use for readinessProbe.
+    """
+    return await health(db)

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import time as _time
 
-from .models import Memory, EventLog, SubjectKey, AgentBarrierGroup, NamespacePolicy, ConflictFlag
+from .models import Memory, EventLog, SubjectKey, AgentBarrierGroup, NamespacePolicy, ConflictFlag, IdempotencyKey
 from .audit_chain import chain_log
 from .telemetry import tracer
 from .metrics import record_write, observe_add, record_recall, observe_recall, record_erase
@@ -348,6 +348,51 @@ async def add_memory(
         observe_add(namespace, _time.perf_counter() - _add_t0)
 
         return _memory_to_out(mem, req.content)
+
+
+async def add_memory_idempotent(
+    db: AsyncSession,
+    namespace: str,
+    req: MemoryAdd,
+    idempotency_key: Optional[str],
+) -> MemoryOut:
+    """
+    Idempotent wrapper around :func:`add_memory`.
+
+    When ``idempotency_key`` is supplied, a previously-seen key (in this
+    namespace) returns the original memory instead of inserting a duplicate —
+    giving exactly-once semantics for a retried write. Without a key, behaves
+    exactly like ``add_memory``.
+
+    The SDKs send a stable key on automatic retries, so a write that succeeded
+    server-side but whose response was lost to a network blip is not duplicated.
+    """
+    if not idempotency_key:
+        return await add_memory(db, namespace, req)
+
+    existing = await db.get(IdempotencyKey, (idempotency_key, namespace))
+    if existing is not None:
+        mem = await db.get(Memory, existing.memory_id)
+        if mem is not None:
+            subject_keys = await _load_namespace_subject_keys(db, namespace)
+            from .ranking import _decrypt
+            return _memory_to_out(mem, _decrypt(mem, subject_keys))
+
+    result = await add_memory(db, namespace, req)
+    db.add(IdempotencyKey(key=idempotency_key, namespace=namespace, memory_id=result.id))
+    try:
+        await db.commit()
+    except Exception:
+        # Lost a race with a concurrent identical request — return the winner's row.
+        await db.rollback()
+        existing = await db.get(IdempotencyKey, (idempotency_key, namespace))
+        if existing is not None:
+            mem = await db.get(Memory, existing.memory_id)
+            if mem is not None:
+                subject_keys = await _load_namespace_subject_keys(db, namespace)
+                from .ranking import _decrypt
+                return _memory_to_out(mem, _decrypt(mem, subject_keys))
+    return result
 
 
 async def recall_memories(

--- a/agentmem/src/lians/models.py
+++ b/agentmem/src/lians/models.py
@@ -342,6 +342,21 @@ class NamespacePolicy(Base):
     updated_at = Column(DateTime(timezone=True), nullable=False, default=_now, onupdate=_now)
 
 
+class IdempotencyKey(Base):
+    """
+    Maps a client-supplied Idempotency-Key (per namespace) to the memory it
+    created, so a retried write returns the original result instead of inserting
+    a duplicate. The SDK sends the same key on automatic retries, giving
+    exactly-once write semantics across network blips.
+    """
+    __tablename__ = "idempotency_keys"
+
+    key = Column(String, primary_key=True)
+    namespace = Column(String, primary_key=True)
+    memory_id = Column(UUID(as_uuid=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=_now)
+
+
 class Relationship(Base):
     """
     Bitemporal relationship edge between two entities — the knowledge-graph layer.

--- a/agentmem/tests/test_idempotency.py
+++ b/agentmem/tests/test_idempotency.py
@@ -1,0 +1,97 @@
+"""
+Idempotency-Key + readiness probe tests.
+
+- A retried POST /v1/memories with the same Idempotency-Key returns the original
+  memory (exactly-once write), while a different key creates a new one.
+- /livez is a cheap liveness probe; /readyz is the deep readiness check.
+"""
+from __future__ import annotations
+
+import hashlib
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+
+from httpx import AsyncClient, ASGITransport
+
+from src.lians.main import app
+from src.lians.db import get_db
+from src.lians.models import ApiKey
+
+NS = "idem-ns"
+KEY = "idem-key"
+AGENT = "idem-agent"
+T = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    db.add(ApiKey(hashed_key=hashlib.sha256(KEY.encode()).hexdigest(),
+                  namespace=NS, scopes=["read", "write", "admin"]))
+    await db.commit()
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _h(extra=None):
+    h = {"X-API-Key": KEY}
+    if extra:
+        h.update(extra)
+    return h
+
+
+def _body(content):
+    return {"agent_id": AGENT, "content": content, "event_time": T.isoformat(),
+            "metadata": {"ticker": "NVDA", "metric": "eps"}}
+
+
+@pytest.mark.asyncio
+async def test_same_idempotency_key_returns_original(client):
+    r1 = await client.post("/v1/memories", headers=_h({"Idempotency-Key": "abc-123"}),
+                           json=_body("NVDA EPS $6.20"))
+    assert r1.status_code == 200, r1.text
+    # Retry with the SAME key but even a different body — must return the original.
+    r2 = await client.post("/v1/memories", headers=_h({"Idempotency-Key": "abc-123"}),
+                           json=_body("NVDA EPS $9.99"))
+    assert r2.status_code == 200
+    assert r1.json()["id"] == r2.json()["id"]
+    assert r2.json()["content"] == "NVDA EPS $6.20"  # original, not the retry body
+
+
+@pytest.mark.asyncio
+async def test_different_idempotency_key_creates_new(client):
+    r1 = await client.post("/v1/memories", headers=_h({"Idempotency-Key": "k1"}),
+                           json=_body("AAPL EPS $1.50"))
+    r2 = await client.post("/v1/memories", headers=_h({"Idempotency-Key": "k2"}),
+                           json=_body("AAPL EPS $1.62"))
+    assert r1.json()["id"] != r2.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_no_key_still_works(client):
+    r = await client.post("/v1/memories", headers=_h(), json=_body("MSFT cloud $25B"))
+    assert r.status_code == 200
+    assert r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_livez_is_cheap_and_alive(client):
+    r = await client.get("/livez")
+    assert r.status_code == 200
+    assert r.json()["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_readyz_deep_check(client):
+    r = await client.get("/readyz")
+    assert r.status_code in (200, 503)          # deep check; shape always present
+    assert "checks" in r.json()
+    assert r.json()["checks"]["db"] == "ok"

--- a/agentmem/tests/test_sdk_retry.py
+++ b/agentmem/tests/test_sdk_retry.py
@@ -1,0 +1,64 @@
+"""
+SDK resilience: the HTTP client retries transient failures with backoff, and a
+retried write reuses the same Idempotency-Key (so it can't double-write).
+"""
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from datetime import datetime, timezone
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk" / "python"))
+from lians import AsyncLiansClient
+
+
+class _Handler(BaseHTTPRequestHandler):
+    idem_keys: list = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        self.rfile.read(length)
+        _Handler.idem_keys.append(self.headers.get("Idempotency-Key"))
+        if len(_Handler.idem_keys) == 1:
+            # First attempt: transient server error.
+            self.send_response(503)
+            self.end_headers()
+            self.wfile.write(b'{"detail":"busy"}')
+        else:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"id":"m-1","content":"ok"}')
+
+    def log_message(self, *args):  # silence test server logging
+        pass
+
+
+@pytest.fixture
+def server():
+    _Handler.idem_keys = []
+    srv = HTTPServer(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+
+
+async def test_retry_on_503_then_success(server):
+    port = server.server_address[1]
+    client = AsyncLiansClient(
+        base_url=f"http://127.0.0.1:{port}", api_key="k", backoff_factor=0.01
+    )
+    out = await client.add(
+        agent_id="a", content="x",
+        event_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    assert out["id"] == "m-1"
+    # Exactly one retry, and the retried request carried the SAME idempotency key.
+    assert len(_Handler.idem_keys) == 2
+    assert _Handler.idem_keys[0] is not None
+    assert _Handler.idem_keys[0] == _Handler.idem_keys[1]

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,52 @@
+# Publishing the SDKs
+
+Lians ships five SDKs. This is the release process and the registry path for each.
+Releases are cut by pushing a semver tag; `release.yml` builds the language
+artifacts and attaches them to the GitHub Release.
+
+```bash
+git tag v0.2.1
+git push origin v0.2.1
+```
+
+| SDK | Registry | How it's published | Secret(s) needed |
+|-----|----------|--------------------|------------------|
+| **Python** | [PyPI](https://pypi.org/project/lians-sdk) | `publish-lian.yml` builds sdist+wheel and uploads via `twine` | `PYPI_API_TOKEN` |
+| **TypeScript** | [npm](https://www.npmjs.com/package/@ebeirne/lians) | `publish-lian-npm.yml` runs `npm publish` | `NPM_TOKEN` |
+| **Go** | proxy.golang.org / pkg.go.dev | **No build step** — a module tag *is* the release (see below) | none |
+| **Java** | Maven Central / GitHub Packages | `mvn deploy` (or jar attached to the Release) | `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `MAVEN_GPG_KEY`, `MAVEN_GPG_PASSPHRASE` |
+| **C** | source tarball on the GitHub Release | packaged by `release.yml` (vendored into the consumer build) | none |
+
+## Go module tags
+
+Because the Go module lives in a subdirectory, `go get` resolves a version from a
+tag **prefixed with the module path**:
+
+```bash
+git tag agentmem/sdk/go/v0.2.1
+git push origin agentmem/sdk/go/v0.2.1
+```
+
+Then consumers use:
+
+```bash
+go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.2.1
+```
+
+The plain `v0.2.1` release tag covers Python/TS/Java/C; the prefixed tag covers Go.
+
+## Java → Maven Central
+
+`release.yml` attaches the built jar to the GitHub Release out of the box (no
+secrets). To publish to **Maven Central** instead, add the OSSRH + GPG secrets
+above and switch the Java job to `mvn -B deploy -P release` with a
+`distributionManagement` block and the `maven-gpg-plugin` in `pom.xml`. To publish
+to **GitHub Packages** (simpler, no GPG), point `distributionManagement` at
+`https://maven.pkg.github.com/Lians-ai/Lians` and authenticate with `GITHUB_TOKEN`.
+
+## C
+
+The C SDK is distributed as source (header + `.c` files) — the idiomatic model for
+a small libcurl client. `release.yml` packages `agentmem/sdk/c` into
+`lians-c-<version>.tar.gz` on the Release; consumers vendor it and build with
+their own CMake/Make. (A future option: an apt/conan/vcpkg recipe.)


### PR DESCRIPTION
Production-readiness items (program item 2).

## Exactly-once writes
- `idempotency_keys` table (migration `0014`) maps a client `Idempotency-Key` (per namespace) to the memory it created. `POST /v1/memories` honors the header — a retried write returns the **original** memory instead of a duplicate.
- `AsyncLiansClient.add` auto-generates a stable `Idempotency-Key`, so a retried POST is exactly-once end-to-end.

## Resilience
- `AsyncLiansClient` retries transient failures (transport errors, 5xx, 429) with exponential backoff + jitter (`max_retries`/`backoff_factor`). Sync client inherits it.

## Kubernetes probes
- `/livez` — cheap liveness (never touches DB/Redis; a dependency blip won't restart the pod). `/readyz` — deep readiness (alias of `/health`).

## Release
- `docs/publishing.md` (registry path + required secrets for all 5 SDKs) and `release.yml` (tag-triggered: Java jar + C tarball to the GitHub Release, Go verify).

## Tests
`test_idempotency.py` (idempotency + probes) and `test_sdk_retry.py` (503→200 with the reused key) — 6 new, green; 58 route-regression tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)