### PR TITLE
MMR reranker + /v1/context token-budgeted assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,8 @@ Full reference: [agentmem/.env.example](agentmem/.env.example)
 |--------|------|-------------|
 | `POST` | `/v1/memories` | Add a memory (supersession check; `Idempotency-Key` header for exactly-once retries) |
 | `POST` | `/v1/memories/batch` | Batch ingest |
-| `POST` | `/v1/recall` | Hybrid BM25+cosine recall; optional `as_of` |
+| `POST` | `/v1/recall` | Hybrid BM25+cosine recall; optional `as_of`, MMR rerank (`filters._rerank=mmr`) |
+| `POST` | `/v1/context` | Token-budgeted, ready-to-inject context block (point-in-time + MMR aware) |
 | `POST` | `/v1/erase` | GDPR crypto-shred by `subject_id` |
 | `GET`  | `/v1/audit/reconstruct` | Reconstruct agent state at any past date |
 | `GET`  | `/v1/admin/audit/verify` | Verify SHA-256 hash chain integrity |

--- a/agentmem/sdk/python/lians/client.py
+++ b/agentmem/sdk/python/lians/client.py
@@ -256,6 +256,33 @@ class AsyncLiansClient:
             "filters": filters or {},
         })
 
+    async def context(
+        self,
+        agent_id: str,
+        query: str,
+        k: int = 10,
+        as_of: Optional[datetime] = None,
+        max_tokens: int = 1500,
+        header: Optional[str] = None,
+        mmr: bool = False,
+    ) -> dict:
+        """
+        Build a token-budgeted, ready-to-inject context block from recall.
+
+        Returns ``{context, memories, token_estimate, truncated}``. The block is
+        bitemporal — never contains stale facts. Pass ``as_of`` for point-in-time
+        context and ``mmr=True`` for diversity reranking.
+        """
+        body: dict[str, Any] = {
+            "agent_id": agent_id, "query": query, "k": k,
+            "max_tokens": max_tokens, "mmr": mmr,
+        }
+        if as_of:
+            body["as_of"] = as_of.isoformat()
+        if header:
+            body["header"] = header
+        return await self._req("POST", "/v1/context", json=body)
+
     async def recall_at(
         self,
         agent_id: str,

--- a/agentmem/sdk/python/lians/sync_client.py
+++ b/agentmem/sdk/python/lians/sync_client.py
@@ -165,6 +165,25 @@ class LiansClient:
             )
         )
 
+    def context(
+        self,
+        agent_id: str,
+        query: str,
+        k: int = 10,
+        as_of: Optional[datetime] = None,
+        max_tokens: int = 1500,
+        header: Optional[str] = None,
+        mmr: bool = False,
+    ) -> dict:
+        """Build a token-budgeted, ready-to-inject context block. Returns a dict
+        ``{context, memories, token_estimate, truncated}``."""
+        return self._loop.run_until_complete(
+            self._async.context(
+                agent_id=agent_id, query=query, k=k, as_of=as_of,
+                max_tokens=max_tokens, header=header, mmr=mmr,
+            )
+        )
+
     def recall_at(
         self,
         agent_id: str,

--- a/agentmem/src/lians/api/routes_memory.py
+++ b/agentmem/src/lians/api/routes_memory.py
@@ -8,11 +8,11 @@ from ..db import get_db
 from ..schemas import (
     MemoryAdd, MemoryOut, RecallRequest, RecallResult,
     MemoryBatchAdd, MemoryBatchResult, MemoryLineageResult,
-    FactHistoryResult,
+    FactHistoryResult, ContextRequest, ContextResult,
 )
 from ..memory_service import (
     add_memory, add_memory_idempotent, recall_memories, batch_add_memories,
-    get_memory_lineage, get_structured_fact_history,
+    get_memory_lineage, get_structured_fact_history, assemble_context,
 )
 from ..adapters import get_adapter
 from .deps import get_auth, AuthContext
@@ -126,3 +126,19 @@ async def recall(
 ):
     auth.require("read")
     return await recall_memories(db, auth.namespace, req)
+
+
+@router.post("/context", response_model=ContextResult)
+async def context(
+    req: ContextRequest,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Build a token-budgeted, ready-to-inject context block from recall — one call
+    to get the "memory context" string for a prompt. Facts are bitemporal, so the
+    block never contains stale revisions; pass ``as_of`` for point-in-time context,
+    ``mmr: true`` for diversity reranking, and ``max_tokens`` to cap the budget.
+    """
+    auth.require("read")
+    return await assemble_context(db, auth.namespace, req)

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -395,6 +395,60 @@ async def add_memory_idempotent(
     return result
 
 
+def _estimate_tokens(text: str) -> int:
+    """Cheap token estimate (~4 chars/token) — good enough for budgeting."""
+    return max(1, len(text) // 4)
+
+
+async def assemble_context(
+    db: AsyncSession,
+    namespace: str,
+    req: "ContextRequest",
+) -> "ContextResult":
+    """
+    Recall the relevant facts and assemble them into a token-budgeted, ready-to-
+    inject context block — the one-call "memory context" surface (Zep parity),
+    backed by Lians' bitemporal recall so the block never contains stale facts.
+
+    Facts are included in relevance order until ``max_tokens`` is reached; each
+    line carries event-time and source so the model can reason about recency and
+    provenance. Erased (crypto-shredded) facts are skipped.
+    """
+    from .schemas import ContextResult
+    filters: dict[str, Any] = {}
+    if req.mmr:
+        filters["_rerank"] = "mmr"
+    recall_req = RecallRequest(
+        agent_id=req.agent_id, query=req.query, k=req.k, as_of=req.as_of, filters=filters,
+    )
+    result = await recall_memories(db, namespace, recall_req)
+
+    lines = [req.header]
+    used = _estimate_tokens(req.header)
+    included: list = []
+    truncated = False
+    for m in result.memories:
+        if not m.content:
+            continue  # erased — content unrecoverable
+        stamp = m.event_time.isoformat()[:16].replace("T", " ") if m.event_time else "undated"
+        prov = f" [{m.source}]" if m.source else ""
+        line = f"- ({stamp}){prov} {m.content}"
+        t = _estimate_tokens(line)
+        if used + t > req.max_tokens:
+            truncated = True
+            break
+        lines.append(line)
+        used += t
+        included.append(m)
+
+    return ContextResult(
+        context="\n".join(lines),
+        memories=included,
+        token_estimate=used,
+        truncated=truncated,
+    )
+
+
 async def recall_memories(
     db: AsyncSession,
     namespace: str,
@@ -414,12 +468,19 @@ async def recall_memories(
         # recall cache when present (results depend on the live graph).
         near_entity: Optional[str] = None
         near_key = "ticker"
+        rerank: Optional[str] = None
+        mmr_lambda = 0.5
         if req.filters:
             near_entity = req.filters.pop("_near_entity", None)
             near_key = req.filters.pop("_near_key", "ticker")
+            rerank = req.filters.pop("_rerank", None)
+            try:
+                mmr_lambda = float(req.filters.pop("_mmr_lambda", 0.5))
+            except (TypeError, ValueError):
+                mmr_lambda = 0.5
 
         # Hot cache (Redis)
-        if settings.recall_cache_enabled and not req.as_of and not near_entity:
+        if settings.recall_cache_enabled and not req.as_of and not near_entity and not rerank:
             cached = await get_cached_recall(
                 namespace, req.agent_id, req.query, req.as_of, req.k, req.filters
             )
@@ -501,6 +562,14 @@ async def recall_memories(
             )
 
         span.set_attribute("result_count", len(results))
+
+        # MMR reranking (opt-in via filters {"_rerank": "mmr"}): reorder the
+        # candidate set to balance relevance against diversity, so the top-k isn't
+        # dominated by near-duplicate restatements of the same fact.
+        if rerank == "mmr" and len(results) > 1:
+            from .ranking import mmr_rerank
+            results = mmr_rerank(results, lambda_=mmr_lambda)
+            span.set_attribute("mmr_rerank", True)
 
         # Graph-proximity reranking: boost results whose entity sits near the
         # anchor entity in the relationship graph (Graphiti-style node-distance).

--- a/agentmem/src/lians/ranking.py
+++ b/agentmem/src/lians/ranking.py
@@ -48,6 +48,50 @@ def _cosine(a: list[float], b: list[float]) -> float:
     return dot / (na * nb + 1e-9)
 
 
+def mmr_rerank(
+    results: list[tuple[Any, float, Optional[str]]],
+    lambda_: float = 0.5,
+) -> list[tuple[Any, float, Optional[str]]]:
+    """
+    Maximal Marginal Relevance reorder of recall candidates.
+
+    Greedily picks the item maximizing ``λ·relevance − (1−λ)·max_similarity_to_
+    already_selected``, where relevance is the existing fusion score and
+    similarity is cosine over the candidates' embeddings. This keeps the top-k
+    from being dominated by near-duplicate restatements of the same fact —
+    higher diversity at a small relevance cost. ``λ=1`` is pure relevance,
+    ``λ=0`` is pure diversity.
+
+    Items are reordered, never dropped; items without an embedding contribute
+    zero similarity (treated as maximally diverse).
+    """
+    lambda_ = min(1.0, max(0.0, lambda_))
+    embs: list[Optional[list[float]]] = [
+        list(r[0].embedding) if getattr(r[0], "embedding", None) is not None else None
+        for r in results
+    ]
+    remaining = list(range(len(results)))
+    order: list[int] = []
+    while remaining:
+        best_i: Optional[int] = None
+        best_val: Optional[float] = None
+        for i in remaining:
+            rel = results[i][1]
+            if order and embs[i] is not None:
+                sim = max(
+                    (_cosine(embs[i], embs[j]) for j in order if embs[j] is not None),
+                    default=0.0,
+                )
+            else:
+                sim = 0.0
+            val = lambda_ * rel - (1.0 - lambda_) * sim
+            if best_val is None or val > best_val:
+                best_val, best_i = val, i
+        order.append(best_i)  # type: ignore[arg-type]
+        remaining.remove(best_i)
+    return [results[i] for i in order]
+
+
 _BM25_K1 = 1.5
 _BM25_B = 0.75
 _BM25_AVG_DOC_LEN = 50.0

--- a/agentmem/src/lians/schemas.py
+++ b/agentmem/src/lians/schemas.py
@@ -466,3 +466,24 @@ class PathResult(BaseModel):
     hops: int
     as_of: Optional[str]
     path: list[EdgeOut]
+
+
+# ── Context assembly ────────────────────────────────────────────────────────────
+
+
+class ContextRequest(BaseModel):
+    """Build a token-budgeted, ready-to-inject context block from recall."""
+    agent_id: str
+    query: str
+    k: int = Field(default=10, ge=1, le=100)
+    as_of: Optional[datetime] = None
+    max_tokens: int = Field(default=1500, ge=64, le=32000)
+    header: str = "Relevant facts from memory (most recent, non-stale):"
+    mmr: bool = False                     # diversity reranking before assembly
+
+
+class ContextResult(BaseModel):
+    context: str                          # the assembled block, ready to inject
+    memories: list[MemoryOut]             # the facts that fit the budget
+    token_estimate: int
+    truncated: bool                       # True if the budget cut off some facts

--- a/agentmem/tests/test_context.py
+++ b/agentmem/tests/test_context.py
@@ -1,0 +1,124 @@
+"""
+Context-assembly endpoint + MMR reranker.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+from httpx import AsyncClient, ASGITransport
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.lians.main import app
+from src.lians.db import get_db
+from src.lians.models import ApiKey
+
+NS = "ctx-ns"
+KEY = "ctx-key"
+AGENT = "ctx-agent"
+T = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+# ── MMR unit test (pure function) ───────────────────────────────────────────────
+
+
+class _FakeMem:
+    def __init__(self, emb):
+        self.embedding = emb
+
+
+def test_mmr_promotes_diversity():
+    from src.lians.ranking import mmr_rerank
+    a = _FakeMem([1.0, 0.0])   # a and b are near-duplicates
+    b = _FakeMem([1.0, 0.0])
+    c = _FakeMem([0.0, 1.0])   # c is orthogonal (diverse)
+    results = [(a, 0.90, "a"), (b, 0.85, "b"), (c, 0.50, "c")]
+
+    out = mmr_rerank(results, lambda_=0.5)
+    # Top by relevance is 'a'; MMR should then prefer the diverse 'c' over the
+    # near-duplicate 'b', even though 'b' has higher raw relevance.
+    assert out[0][2] == "a"
+    assert out[1][2] == "c"
+
+
+def test_mmr_lambda_one_is_pure_relevance():
+    from src.lians.ranking import mmr_rerank
+    a = _FakeMem([1.0, 0.0])
+    b = _FakeMem([1.0, 0.0])
+    c = _FakeMem([0.0, 1.0])
+    results = [(a, 0.90, "a"), (b, 0.85, "b"), (c, 0.50, "c")]
+    out = mmr_rerank(results, lambda_=1.0)
+    assert [r[2] for r in out] == ["a", "b", "c"]  # strict relevance order
+
+
+# ── Context endpoint (app-level) ────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    db.add(ApiKey(hashed_key=hashlib.sha256(KEY.encode()).hexdigest(),
+                  namespace=NS, scopes=["read", "write"]))
+    await db.commit()
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _h():
+    return {"X-API-Key": KEY}
+
+
+async def _add(client, content, ticker="NVDA"):
+    r = await client.post("/v1/memories", headers=_h(), json={
+        "agent_id": AGENT, "content": content, "event_time": T.isoformat(),
+        "metadata": {"ticker": ticker, "metric": "guidance"},
+    })
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_context_returns_injectable_block(client):
+    await _add(client, "NVDA FY2026 revenue guidance raised to $40B")
+    r = await client.post("/v1/context", headers=_h(), json={
+        "agent_id": AGENT, "query": "NVDA revenue guidance", "k": 5,
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "NVDA FY2026 revenue guidance" in body["context"]
+    assert body["context"].startswith("Relevant facts")
+    assert body["token_estimate"] > 0
+    assert len(body["memories"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_context_respects_token_budget(client):
+    for i in range(6):
+        await _add(client, f"Long fact number {i} " + ("padding " * 30), ticker=f"T{i}")
+    r = await client.post("/v1/context", headers=_h(), json={
+        "agent_id": AGENT, "query": "fact", "k": 10, "max_tokens": 80,
+    })
+    body = r.json()
+    assert body["truncated"] is True
+    assert body["token_estimate"] <= 80
+
+
+@pytest.mark.asyncio
+async def test_context_mmr_flag_ok(client):
+    await _add(client, "AAPL gross margin expanded to 46%", ticker="AAPL")
+    r = await client.post("/v1/context", headers=_h(), json={
+        "agent_id": AGENT, "query": "AAPL margin", "k": 5, "mmr": True,
+    })
+    assert r.status_code == 200
+    assert "AAPL" in r.json()["context"]


### PR DESCRIPTION
Recall-quality + DX (program item 3).

## MMR reranker
`ranking.mmr_rerank` reorders recall candidates by Maximal Marginal Relevance (`λ·relevance − (1−λ)·max_similarity`), so the top-k isn't dominated by near-duplicate restatements. Opt-in per recall via `filters: {"_rerank": "mmr", "_mmr_lambda": 0.5}`.

## Context assembly (Zep `memory.context` parity)
`POST /v1/context` → `{context, memories, token_estimate, truncated}` — a ready-to-inject block built from recall, ordered by relevance, capped at `max_tokens`, point-in-time + MMR aware, and **bitemporal so it never contains stale facts**. Exposed as `context()` on the async + sync Python clients.

## Tests
`test_context.py` — MMR unit (diversity; `λ=1` pure relevance) and the endpoint (injectable block, token-budget truncation, mmr flag). 27 recall/context/SDK tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)