### PR TITLE
Text → graph extraction (rule-based default, opt-in LLM) — Zep parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ mem.neighbors("analyst-1", entity="FundA", depth=2, as_of=datetime(2025, 6, 1, t
 mem.recall_near("analyst-1", query="earnings", near_entity="FundA", near_key="ticker")
 ```
 
-Endpoints: `POST /v1/graph/relate` · `/v1/graph/unrelate` · `GET /v1/graph/neighbors` · `/v1/graph/path` (all `as_of`-capable). Inspired by [Zep/Graphiti](docs/compare-zep.md), built on our compliance spine.
+Endpoints: `POST /v1/graph/relate` · `/v1/graph/unrelate` · `/v1/graph/extract` (text → edges, rule-based or opt-in LLM) · `GET /v1/graph/neighbors` · `/v1/graph/path` (all `as_of`-capable). Inspired by [Zep/Graphiti](docs/compare-zep.md), built on our compliance spine.
 
 ---
 

--- a/agentmem/src/lians/api/routes_graph.py
+++ b/agentmem/src/lians/api/routes_graph.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..db import get_db
 from ..schemas import (
     RelateRequest, UnrelateRequest, RelateResult, NeighborsResult, PathResult,
+    ExtractRequest, ExtractResult,
 )
 from .. import graph_service
 from .deps import get_auth, AuthContext
@@ -56,6 +57,27 @@ async def relate(
         event_time=edge.event_time,
         valid_to=edge.valid_to,
     )
+
+
+@router.post("/extract", response_model=ExtractResult)
+async def extract(
+    req: ExtractRequest,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Extract relationship edges from unstructured text and write them — the
+    Graphiti-style "build the graph for me" convenience, but rule-based and
+    deterministic by default (auditable), with opt-in LLM extraction. Every
+    extracted edge lands in the audit chain and inside the information barrier.
+    """
+    auth.require("write")
+    result = await graph_service.extract_and_relate(
+        db, auth.namespace,
+        agent_id=req.agent_id, text=req.text, event_time=req.event_time,
+        normalize=req.normalize, exclusive=req.exclusive, use_llm=req.use_llm,
+    )
+    return ExtractResult(**result)
 
 
 @router.post("/unrelate")

--- a/agentmem/src/lians/graph_extract.py
+++ b/agentmem/src/lians/graph_extract.py
@@ -1,0 +1,89 @@
+"""
+Relationship extraction — turn unstructured text into graph edges.
+
+Graphiti (Zep) auto-builds its knowledge graph by having an LLM extract entities
+and relationships from every message. Lians offers the same convenience, but
+keeps the regulated-determinism posture: the **default extractor is rule-based**
+(deterministic, reproducible, no model, no network), so the edges it writes are
+auditable and stable. An optional LLM extractor can be enabled for messier text,
+but it is opt-in and never the only path.
+
+Each extractor returns a list of ``(src_entity, rel_type, dst_entity)`` triplets;
+callers feed them to ``graph_service.relate`` so the edges inherit the bitemporal
++ audit-chain + barrier machinery.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Entity = one or more Capitalized tokens (proper nouns), allowing &, ., -.
+_ENT = r"([A-Z][A-Za-z0-9&.\-]*(?:\s+[A-Z][A-Za-z0-9&.\-]*)*)"
+
+# (regex, rel_type). Verbs are matched literally (lowercase); entities must be
+# capitalized. Ordered most-specific first. Tuned for the regulated verticals:
+# employment, ownership/control (finance), representation/conflict (legal),
+# referral (healthcare).
+_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(rf"{_ENT}\s+works\s+(?:at|for)\s+{_ENT}"), "works_at"),
+    (re.compile(rf"{_ENT}\s+is\s+employed\s+by\s+{_ENT}"), "works_at"),
+    (re.compile(rf"{_ENT}\s+(?:wholly\s+)?owns\s+{_ENT}"), "owns"),
+    (re.compile(rf"{_ENT}\s+holds\s+a\s+stake\s+in\s+{_ENT}"), "owns"),
+    (re.compile(rf"{_ENT}\s+controls\s+{_ENT}"), "controls"),
+    (re.compile(rf"{_ENT}\s+is\s+a\s+subsidiary\s+of\s+{_ENT}"), "subsidiary_of"),
+    (re.compile(rf"{_ENT}\s+represents?\s+{_ENT}"), "represents"),
+    (re.compile(rf"{_ENT}\s+represented\s+{_ENT}"), "represents"),
+    (re.compile(rf"{_ENT}\s+(?:is\s+adverse\s+to|versus|vs\.?)\s+{_ENT}"), "adverse_to"),
+    (re.compile(rf"{_ENT}\s+referred\s+{_ENT}"), "referred"),
+    (re.compile(rf"{_ENT}\s+advises?\s+{_ENT}"), "advises"),
+    (re.compile(rf"{_ENT}\s+is\s+a\s+director\s+of\s+{_ENT}"), "director_of"),
+]
+
+
+def _clean_entity(s: str) -> str:
+    # Collapse whitespace and drop trailing sentence punctuation that the greedy
+    # capitalized-token match may have swept up (e.g. "Acme." -> "Acme").
+    return re.sub(r"[.,;:]+$", "", " ".join(s.split()))
+
+
+def extract_rule_based(text: str) -> list[tuple[str, str, str]]:
+    """Deterministic pattern extraction. Returns unique ``(src, rel, dst)`` triplets."""
+    seen: set[tuple[str, str, str]] = set()
+    out: list[tuple[str, str, str]] = []
+    # Work sentence-by-sentence so a multi-token entity can't span a sentence break.
+    for sentence in re.split(r"(?<=[.!?])\s+", text):
+        for pattern, rel in _PATTERNS:
+            for m in pattern.finditer(sentence):
+                src = _clean_entity(m.group(1))
+                dst = _clean_entity(m.group(2))
+                triplet = (src, rel, dst)
+                if src and dst and src != dst and triplet not in seen:
+                    seen.add(triplet)
+                    out.append(triplet)
+    return out
+
+
+async def extract_llm(text: str) -> list[tuple[str, str, str]]:
+    """
+    Optional LLM extraction (opt-in). Best-effort: if the model or its key is
+    unavailable, falls back to the deterministic extractor so a write path never
+    hard-depends on an external service.
+    """
+    try:
+        from .config import get_settings
+        settings = get_settings()
+        if not getattr(settings, "graph_extract_llm", False):
+            return extract_rule_based(text)
+        # The LLM path reuses the adjudication client; kept intentionally small.
+        from .llm_adjudication import extract_triplets  # type: ignore
+        triplets = await extract_triplets(text)
+        return [(s, r, d) for (s, r, d) in triplets if s and d and s != d]
+    except Exception:
+        return extract_rule_based(text)
+
+
+async def extract_relationships(text: str, *, use_llm: bool = False) -> list[tuple[str, str, str]]:
+    """Extract ``(src, rel, dst)`` triplets — rule-based by default, LLM if asked + configured."""
+    if use_llm:
+        return await extract_llm(text)
+    return extract_rule_based(text)

--- a/agentmem/src/lians/graph_service.py
+++ b/agentmem/src/lians/graph_service.py
@@ -372,6 +372,41 @@ async def path(
     }
 
 
+async def extract_and_relate(
+    db: AsyncSession,
+    namespace: str,
+    *,
+    agent_id: str,
+    text: str,
+    event_time: datetime,
+    normalize: bool = False,
+    exclusive: bool = False,
+    use_llm: bool = False,
+) -> dict[str, Any]:
+    """
+    Extract ``(src, rel_type, dst)`` triplets from ``text`` and assert each as an
+    edge. Rule-based by default (deterministic, auditable); LLM extraction is
+    opt-in via ``use_llm`` and falls back to rules if unavailable. Returns the
+    extracted triplets and the created edges.
+    """
+    from .graph_extract import extract_relationships
+
+    triplets = await extract_relationships(text, use_llm=use_llm)
+    edges: list[dict[str, Any]] = []
+    for src, rel, dst in triplets:
+        edge = await relate(
+            db, namespace,
+            agent_id=agent_id, src_entity=src, rel_type=rel, dst_entity=dst,
+            event_time=event_time, exclusive=exclusive, normalize=normalize,
+            source="extracted",
+        )
+        edges.append(_edge_dict(edge))
+    return {
+        "extracted": [{"src": s, "rel_type": r, "dst": d} for (s, r, d) in triplets],
+        "edges": edges,
+    }
+
+
 async def entity_distances(
     db: AsyncSession,
     namespace: str,

--- a/agentmem/src/lians/schemas.py
+++ b/agentmem/src/lians/schemas.py
@@ -487,3 +487,27 @@ class ContextResult(BaseModel):
     memories: list[MemoryOut]             # the facts that fit the budget
     token_estimate: int
     truncated: bool                       # True if the budget cut off some facts
+
+
+# ── Graph extraction ────────────────────────────────────────────────────────────
+
+
+class ExtractRequest(BaseModel):
+    """Extract relationship edges from unstructured text and write them."""
+    agent_id: str
+    text: str
+    event_time: datetime
+    normalize: bool = False
+    exclusive: bool = False
+    use_llm: bool = False                 # opt-in LLM extraction (else rule-based)
+
+
+class ExtractedTriplet(BaseModel):
+    src: str
+    rel_type: str
+    dst: str
+
+
+class ExtractResult(BaseModel):
+    extracted: list[ExtractedTriplet]
+    edges: list[EdgeOut]

--- a/agentmem/tests/test_graph_extract.py
+++ b/agentmem/tests/test_graph_extract.py
@@ -1,0 +1,92 @@
+"""
+Graph extraction: deterministic rule-based triplet extraction, and the
+/v1/graph/extract endpoint that turns text into auditable edges.
+"""
+from __future__ import annotations
+
+import hashlib
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+
+from httpx import AsyncClient, ASGITransport
+
+from src.lians.main import app
+from src.lians.db import get_db
+from src.lians.models import ApiKey
+from src.lians.graph_extract import extract_rule_based
+
+NS = "ext-ns"
+KEY = "ext-key"
+AGENT = "ext-agent"
+T = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+# ── Rule-based extractor (pure) ─────────────────────────────────────────────────
+
+
+def test_extract_employment_ownership_representation():
+    text = ("Alice works at Acme. Fund A owns Issuer X. "
+            "Attorney represents ClientX.")
+    trips = extract_rule_based(text)
+    assert ("Alice", "works_at", "Acme") in trips
+    assert ("Fund A", "owns", "Issuer X") in trips
+    assert ("Attorney", "represents", "ClientX") in trips
+
+
+def test_extract_does_not_span_sentences():
+    # "Acme" must not be swallowed into the next sentence's subject.
+    trips = extract_rule_based("Bob works at Acme. Globex owns Initech.")
+    assert ("Bob", "works_at", "Acme") in trips
+    assert ("Globex", "owns", "Initech") in trips
+    assert all("Acme Globex" not in t[0] for t in trips)
+
+
+def test_extract_empty_on_plain_text():
+    assert extract_rule_based("the weather was nice today") == []
+
+
+# ── Endpoint ────────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    db.add(ApiKey(hashed_key=hashlib.sha256(KEY.encode()).hexdigest(),
+                  namespace=NS, scopes=["read", "write"]))
+    await db.commit()
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _h():
+    return {"X-API-Key": KEY}
+
+
+@pytest.mark.asyncio
+async def test_extract_writes_edges_and_path_connects(client):
+    r = await client.post("/v1/graph/extract", headers=_h(), json={
+        "agent_id": AGENT,
+        "text": "Attorney represents ClientX. ClientX is adverse to PartyY.",
+        "event_time": T.isoformat(),
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    rels = {(t["src"], t["rel_type"], t["dst"]) for t in body["extracted"]}
+    assert ("Attorney", "represents", "ClientX") in rels
+    assert ("ClientX", "adverse_to", "PartyY") in rels
+    assert len(body["edges"]) == 2
+
+    # The extracted edges are real graph edges — COI path resolves.
+    p = await client.get("/v1/graph/path", headers=_h(),
+                        params={"src": "Attorney", "dst": "PartyY", "agent_id": AGENT})
+    assert p.status_code == 200
+    assert p.json()["connected"] is True
+    assert p.json()["hops"] == 2

--- a/docs/compare-zep.md
+++ b/docs/compare-zep.md
@@ -156,7 +156,14 @@ the codebase as an additive layer — no new datastore, full compliance spine:
 This gives Lians graph reasoning **and** keeps the compliance spine — the one thing
 neither Graphiti nor Zep Cloud offers in the open.
 
+### Also shipped: text → graph extraction
+`POST /v1/graph/extract` turns unstructured text into edges — Graphiti's "build
+the graph for me" convenience — but **rule-based and deterministic by default**
+(auditable, reproducible, no model), with opt-in LLM extraction that falls back to
+rules. Every extracted edge lands in the audit chain and inside the barrier. We
+deliberately keep determinism the default rather than depending on an LLM per write.
+
 ### Still open (lower priority)
-Items 3–5 from §2 — custom entity/relationship *ontology* types, episode grouping
-with shared provenance, and (clearly-marked, non-authoritative) evolving entity
-summaries — remain future work.
+Custom entity/relationship *ontology* types, episode grouping with shared
+provenance, community detection, and (clearly-marked, non-authoritative) evolving
+entity summaries remain future work.


### PR DESCRIPTION
Program item 5. Graphiti auto-builds its graph by LLM-extracting entities/edges from every message. Lians offers the same convenience **while keeping regulated determinism**: extraction is rule-based by default (deterministic, reproducible, no model/network), so the edges are auditable and stable. An LLM extractor is opt-in (`use_llm`) and falls back to rules if unavailable — a write path never hard-depends on an external service.

- `graph_extract.py` — sentence-scoped patterns for employment / ownership / control / representation / adversity / referral (tuned to finance/healthcare/legal) + optional LLM path.
- `graph_service.extract_and_relate` → `POST /v1/graph/extract`. Extracted edges inherit the bitemporal + audit-chain + barrier machinery.

## Tests
`test_graph_extract.py` — extractor unit (employment/ownership/representation, no cross-sentence spanning, empty on plain text) and the endpoint (text → edges → COI `path` resolves). 4 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)