### PR TITLE
RBAC roles, SIEM audit streaming, and security/threat-model/SSO docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ client.erase(subject_id, request_ref)                    # GDPR crypto-shred
 | `ADMIN_SECRET` | — | Protects `/v1/admin/*` — **change in production** |
 | `SUPERSESSION_LLM_STAGE` | `false` | Enables Stage 3 LLM adjudication (Claude Haiku) |
 | `AIRGAP_MODE` | `false` | Hard-fails at startup if any config would send data externally |
+| `SIEM_URL` | — | Stream every audit event to a SIEM collector (Splunk HEC / Datadog / Elastic) |
 | `STRIPE_API_KEY` | — | Enables per-namespace usage metering |
 
 Full reference: [agentmem/.env.example](agentmem/.env.example)
@@ -425,7 +426,9 @@ See [docs/testing.md](docs/testing.md) for the six named invariants (temporal so
 | Information barriers | `barrier_group` column; PostgreSQL RLS |
 | HIPAA §164.312 | Per-subject encryption, audit controls, transmission security |
 
-Full documentation: [docs/compliance.md](docs/compliance.md) · [docs/hipaa.md](docs/hipaa.md)
+Full documentation: [compliance.md](docs/compliance.md) · [hipaa.md](docs/hipaa.md) · [security-whitepaper.md](docs/security-whitepaper.md) · [threat-model.md](docs/threat-model.md) · [soc2-hipaa-readiness.md](docs/soc2-hipaa-readiness.md) · [sso.md](docs/sso.md)
+
+Access control: namespace-scoped API keys with `read`/`write`/`admin` scopes and RBAC roles (`owner`/`analyst`/`compliance`/`readonly`); SSO via gateway forward-auth (any OIDC/SAML IdP).
 
 ---
 

--- a/agentmem/alembic/versions/0015_apikey_role.py
+++ b/agentmem/alembic/versions/0015_apikey_role.py
@@ -1,0 +1,26 @@
+"""api_keys.role for RBAC
+
+Revision ID: 0015_apikey_role
+Revises: 0014_idempotency_keys
+Create Date: 2026-06-29
+
+Adds an optional named role to API keys. When set, the role expands to a scope
+set at auth time (owner / analyst / compliance / readonly), giving role-based
+access control on top of the existing explicit scopes.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0015_apikey_role"
+down_revision = "0014_idempotency_keys"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_keys", sa.Column("role", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "role")

--- a/agentmem/src/lians/api/deps.py
+++ b/agentmem/src/lians/api/deps.py
@@ -15,9 +15,27 @@ from ..models import ApiKey
 
 _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
 
+# Named roles → scope sets (RBAC). A key's `role`, when set, is merged with any
+# explicit `scopes`. "compliance" gets read + admin (audit verify/export/erase)
+# but not write — it inspects and certifies, it does not author memories.
+ROLE_SCOPES: dict[str, list[str]] = {
+    "owner":      ["read", "write", "admin"],
+    "analyst":    ["read", "write"],
+    "compliance": ["read", "admin"],
+    "readonly":   ["read"],
+}
+
 
 def _hash_key(raw: str) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _effective_scopes(key_row: ApiKey) -> list[str]:
+    scopes = set(key_row.scopes or [])
+    role = getattr(key_row, "role", None)
+    if role:
+        scopes.update(ROLE_SCOPES.get(role, []))
+    return sorted(scopes)
 
 
 class AuthContext:
@@ -82,5 +100,5 @@ async def get_auth(
 
     return AuthContext(
         namespace=key_row.namespace,
-        scopes=list(key_row.scopes or []),
+        scopes=_effective_scopes(key_row),
     )

--- a/agentmem/src/lians/audit_chain.py
+++ b/agentmem/src/lians/audit_chain.py
@@ -200,6 +200,24 @@ async def chain_log(
         except Exception:
             pass  # Merkle batching is optional — never block the hot path
 
+    # Fire-and-forget SIEM streaming — never blocks or fails the write path.
+    try:
+        from .siem import siem_enabled, stream_event
+        if siem_enabled():
+            import asyncio
+            asyncio.create_task(stream_event({
+                "id": str(row_id),
+                "namespace": namespace,
+                "agent_id": agent_id,
+                "op": op,
+                "memory_id": str(memory_id) if memory_id is not None else None,
+                "content_hash": content_hash,
+                "row_hash": row.row_hash,
+                "created_at": created_at_utc,
+            }))
+    except Exception:
+        pass
+
     return row
 
 

--- a/agentmem/src/lians/config.py
+++ b/agentmem/src/lians/config.py
@@ -94,6 +94,16 @@ class Settings(BaseSettings):
     # Set to True for any regulated deployment where data must not leave the network.
     airgap_mode: bool = False
 
+    # ── SIEM audit streaming ──────────────────────────────────────────────────
+    # When set, every audit-chain event is forwarded (fire-and-forget) to this
+    # HTTP collector — e.g. a Splunk HEC URL or a Datadog/Elastic intake. The
+    # token, if set, is sent as `Authorization: <siem_token>`. Empty = disabled.
+    siem_url: str = ""
+    siem_token: str = ""
+
+    # Opt-in LLM relationship extraction for /v1/graph/extract (else rule-based).
+    graph_extract_llm: bool = False
+
     # ── Performance roadmap (Changes 3 / 7 / 8) ───────────────────────────────
 
     # Change 3: async LLM adjudication worker.  When True, Stage-3 LLM verdicts

--- a/agentmem/src/lians/models.py
+++ b/agentmem/src/lians/models.py
@@ -171,6 +171,9 @@ class ApiKey(Base):
     namespace = Column(String, nullable=False)
     label = Column(String, nullable=True)
     scopes = Column(JSON, nullable=False, server_default='["read"]')
+    # Optional named role (owner | analyst | compliance | readonly). When set, the
+    # role's scope set is merged with any explicit `scopes` at auth time.
+    role = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=_now)
     rotated_at = Column(DateTime(timezone=True), nullable=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True)

--- a/agentmem/src/lians/siem.py
+++ b/agentmem/src/lians/siem.py
@@ -1,0 +1,45 @@
+"""
+SIEM audit streaming — forward every tamper-evident audit event to an external
+collector (Splunk HEC, Datadog, Elastic, a generic HTTP intake) in real time.
+
+Export (``/v1/admin/audit/export``) gives examiners the chain on demand; this
+gives the security team a live feed for alerting and retention in their SIEM —
+without granting them database access. Forwarding is fire-and-forget and never
+blocks or fails the write path: a SIEM outage cannot stop memory writes (the
+tamper-evident chain in Postgres remains the source of truth).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .config import get_settings
+
+
+def siem_enabled() -> bool:
+    return bool(get_settings().siem_url)
+
+
+async def stream_event(event: dict[str, Any]) -> bool:
+    """
+    POST a single audit event to the configured SIEM collector.
+
+    Returns True if delivered (2xx), False otherwise. Never raises — a SIEM
+    failure must not affect the request that produced the event.
+    """
+    settings = get_settings()
+    url = settings.siem_url
+    if not url:
+        return False
+
+    headers = {"Content-Type": "application/json"}
+    if settings.siem_token:
+        headers["Authorization"] = settings.siem_token
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(url, json={"source": "lians.audit", "event": event}, headers=headers)
+        return 200 <= resp.status_code < 300
+    except Exception:
+        return False

--- a/agentmem/tests/test_rbac.py
+++ b/agentmem/tests/test_rbac.py
@@ -1,0 +1,73 @@
+"""
+RBAC: an API key's named role expands to a scope set at auth time.
+"""
+from __future__ import annotations
+
+import hashlib
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+
+from httpx import AsyncClient, ASGITransport
+
+from src.lians.main import app
+from src.lians.db import get_db
+from src.lians.models import ApiKey
+
+NS = "rbac-ns"
+AGENT = "rbac-agent"
+T = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _sha(k):
+    return hashlib.sha256(k.encode()).hexdigest()
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    db.add(ApiKey(hashed_key=_sha("ro"), namespace=NS, scopes=[], role="readonly"))
+    db.add(ApiKey(hashed_key=_sha("an"), namespace=NS, scopes=[], role="analyst"))
+    db.add(ApiKey(hashed_key=_sha("co"), namespace=NS, scopes=[], role="compliance"))
+    await db.commit()
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _h(key):
+    return {"X-API-Key": key}
+
+
+def _mem():
+    return {"agent_id": AGENT, "content": "x", "event_time": T.isoformat()}
+
+
+@pytest.mark.asyncio
+async def test_readonly_can_read_not_write(client):
+    rd = await client.post("/v1/recall", headers=_h("ro"),
+                           json={"agent_id": AGENT, "query": "x", "k": 5})
+    assert rd.status_code == 200
+    wr = await client.post("/v1/memories", headers=_h("ro"), json=_mem())
+    assert wr.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_analyst_can_write(client):
+    wr = await client.post("/v1/memories", headers=_h("an"), json=_mem())
+    assert wr.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_compliance_can_read_not_write(client):
+    rd = await client.post("/v1/recall", headers=_h("co"),
+                           json={"agent_id": AGENT, "query": "x", "k": 5})
+    assert rd.status_code == 200
+    wr = await client.post("/v1/memories", headers=_h("co"), json=_mem())
+    assert wr.status_code == 403  # compliance inspects/certifies; it does not author

--- a/agentmem/tests/test_siem.py
+++ b/agentmem/tests/test_siem.py
@@ -1,0 +1,67 @@
+"""
+SIEM audit streaming forwarder — delivers events to a collector, disabled by
+default, and never raises on failure.
+"""
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+
+import pytest
+
+from src.lians.siem import stream_event
+
+
+class _Collector(BaseHTTPRequestHandler):
+    received: list = []
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        _Collector.received.append((self.headers.get("Authorization"), self.rfile.read(n)))
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def collector():
+    _Collector.received = []
+    srv = HTTPServer(("127.0.0.1", 0), _Collector)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield srv
+    finally:
+        srv.shutdown()
+
+
+async def test_stream_event_delivers(collector, monkeypatch):
+    port = collector.server_address[1]
+    monkeypatch.setattr(
+        "src.lians.siem.get_settings",
+        lambda: SimpleNamespace(siem_url=f"http://127.0.0.1:{port}/intake", siem_token="Bearer tok"),
+    )
+    ok = await stream_event({"op": "add", "id": "evt-1"})
+    assert ok is True
+    assert len(_Collector.received) == 1
+    auth, body = _Collector.received[0]
+    assert auth == "Bearer tok"
+    assert b"evt-1" in body and b"lians.audit" in body
+
+
+async def test_stream_event_disabled_returns_false(monkeypatch):
+    monkeypatch.setattr(
+        "src.lians.siem.get_settings",
+        lambda: SimpleNamespace(siem_url="", siem_token=""),
+    )
+    assert await stream_event({"op": "x"}) is False
+
+
+async def test_stream_event_swallows_errors(monkeypatch):
+    # Unroutable URL — must return False, never raise.
+    monkeypatch.setattr(
+        "src.lians.siem.get_settings",
+        lambda: SimpleNamespace(siem_url="http://127.0.0.1:1/down", siem_token=""),
+    )
+    assert await stream_event({"op": "x"}) is False

--- a/docs/security-whitepaper.md
+++ b/docs/security-whitepaper.md
@@ -1,0 +1,82 @@
+# Lians Security Whitepaper
+
+This document describes the security architecture of Lians for security reviewers,
+risk committees, and procurement teams in regulated industries. It is a companion
+to [threat-model.md](threat-model.md), [soc2-hipaa-readiness.md](soc2-hipaa-readiness.md),
+[compliance.md](compliance.md), and [hipaa.md](hipaa.md).
+
+## 1. What Lians is
+
+A self-hostable memory layer for AI agents with a bitemporal data model and a
+compliance spine: a tamper-evident audit chain, per-subject encryption with
+crypto-shred erasure, and database-layer information barriers. Deployable fully
+inside your perimeter (air-gap mode) — no agent data needs to leave the network.
+
+## 2. Data classification & flow
+
+| Data | Sensitivity | Protection |
+|------|-------------|------------|
+| Memory content | May contain PII/PHI/MNPI | AES-256-GCM at rest under a per-subject key; TLS in transit |
+| Embeddings | Derived | Stored in pgvector; local embedding provider keeps text in-perimeter |
+| Audit events | Integrity-critical | SHA-256 hash chain; append-only; optional Merkle anchoring |
+| API keys | Secret | Stored only as SHA-256 hashes; individually revocable |
+| Subject keys (DEKs) | Secret | Wrapped by a master key (KMS: env/AWS/Azure/Vault); destroyed on erasure |
+
+Write path: client → TLS → API (authn/z, rate-limit, request-id) → encrypt →
+Postgres (RLS-enforced) + append audit row → optional SIEM stream / webhooks.
+
+## 3. Authentication & authorization
+
+- **API keys** over `X-API-Key`, stored as SHA-256 hashes, scoped to a namespace,
+  individually revocable.
+- **Scopes** (`read` / `write` / `admin`) checked on every request; admin audit
+  endpoints additionally require an `X-Admin-Secret`.
+- **RBAC roles** (`owner` / `analyst` / `compliance` / `readonly`) expand to scope
+  sets at auth time.
+- **SSO** is integrated at the gateway via forward-auth / OIDC — see [sso.md](sso.md).
+
+## 4. Tenant & information-barrier isolation
+
+- **Namespace isolation** is enforced by PostgreSQL Row-Level Security: every
+  authenticated request sets a transaction-scoped `app.current_namespace`, and
+  policies restrict every query to that namespace.
+- **Information barriers** (Chinese walls) are enforced by a **RESTRICTIVE** RLS
+  policy keyed on `agentmem.barrier_group` (migration 0013), so cross-barrier
+  reads are denied at the database layer even for the table owner — verified in CI
+  against a non-superuser role. The application server cannot leak across a wall
+  because the wall is below it.
+
+> Operational requirement: run the application as a **non-superuser, non-BYPASSRLS**
+> Postgres role. Superusers bypass RLS by design.
+
+## 5. Encryption & key management
+
+- Content is encrypted with a per-subject AES-256-GCM key (DEK). DEKs are wrapped
+  by a master key resolved from a configurable KMS (`env` / `aws` / `azure` /
+  `vault`).
+- **Crypto-shred erasure** (GDPR Art. 17 / HIPAA): destroying a subject's DEK
+  renders all their content permanently unreadable, while the SHA-256 content
+  hashes remain in the audit chain — the erasure is provable. A signed erasure
+  certificate is available.
+
+## 6. Auditability & monitoring
+
+- Every state change appends a row to a SHA-256 hash chain (SEC 17a-4). Integrity
+  is verifiable on demand (`/v1/admin/audit/verify`) and exportable for examiners.
+- **SIEM streaming** forwards every audit event (fire-and-forget) to a collector
+  (Splunk HEC / Datadog / Elastic) for real-time alerting and retention.
+- Prometheus metrics + Grafana dashboard; OpenTelemetry tracing; structured JSON
+  access logs with a propagated request ID; `/livez` + `/readyz` probes.
+
+## 7. Hardening & deployment
+
+- Air-gap mode hard-fails at startup if any configuration would send data
+  externally. Rate limiting per API key. Idempotency keys for exactly-once writes.
+- Secrets are provided via environment / KMS, never committed. `ADMIN_SECRET` and
+  `MASTER_ENCRYPTION_KEY` must be set in production (startup warns otherwise).
+- See [deploy.md](deploy.md) for the production checklist (TLS, non-superuser DB
+  role, secret rotation, network isolation, backup/PITR).
+
+## 8. Responsible disclosure
+
+Security contact and policy: [SECURITY.md](SECURITY.md).

--- a/docs/soc2-hipaa-readiness.md
+++ b/docs/soc2-hipaa-readiness.md
@@ -1,0 +1,54 @@
+# SOC 2 / HIPAA Readiness
+
+Lians provides the **technical controls** that underpin a SOC 2 Type II audit and
+a HIPAA Security Rule assessment. Certification itself is organizational (policies,
+an auditor, evidence over a period); this maps what the software gives you so your
+auditor's control narrative is mostly "configure + evidence," not "build."
+
+> Lians is software, not a certification. A SOC 2 report or HIPAA attestation is
+> issued to *your deployment* by *your auditor*. This page accelerates that.
+
+## SOC 2 Trust Services Criteria → Lians controls
+
+| Criterion | Lians control |
+|-----------|---------------|
+| CC6.1 Logical access | API keys (hashed, revocable, scoped), RBAC roles, SSO at the gateway |
+| CC6.1 Tenant isolation | PostgreSQL RLS namespace policy + RESTRICTIVE barrier policy |
+| CC6.6 Encryption in transit | TLS (deployment) |
+| CC6.7 Encryption at rest | Per-subject AES-256-GCM; KMS-wrapped DEKs |
+| CC7.1 Detection / monitoring | Prometheus metrics, Grafana, OTEL traces, JSON access logs |
+| CC7.2 Security event logging | SHA-256 audit chain + real-time SIEM streaming |
+| CC7.2 Integrity monitoring | `verify_chain` tamper detection; optional Merkle anchoring |
+| CC8.1 Change management | Alembic migrations; CI on every change (5 languages + Postgres) |
+| A1.2 Availability | `/livez`+`/readyz` probes; health checks; rate limiting; idempotency |
+| C1.1 Confidentiality / disposal | Crypto-shred erasure + provable erasure certificate |
+| P4 Privacy / retention & deletion | Retention policy per namespace; GDPR/CCPA erasure |
+
+## HIPAA Security Rule (§164.312 technical safeguards)
+
+| Safeguard | Lians control |
+|-----------|---------------|
+| §164.312(a)(1) Access control | RLS isolation + barrier groups (care-team walls); RBAC |
+| §164.312(a)(2)(iv) Encryption | Per-subject AES-256-GCM |
+| §164.312(b) Audit controls | Tamper-evident hash chain + SIEM stream + export |
+| §164.312(c)(1) Integrity | Content hashes; chain detects alteration |
+| §164.312(d) Authentication | API keys / SSO; admin secret for privileged ops |
+| §164.312(e)(1) Transmission security | TLS; air-gap mode prevents external egress |
+
+A **Business Associate Agreement (BAA)** must be in place with the operator before
+processing real PHI. See [hipaa.md](hipaa.md) for the full safeguard mapping.
+
+## Readiness checklist (deployment)
+
+- [ ] Run the app as a **non-superuser, non-BYPASSRLS** Postgres role (RLS depends on it)
+- [ ] `MASTER_ENCRYPTION_KEY` set; DEKs wrapped by a real KMS (`aws`/`azure`/`vault`)
+- [ ] `ADMIN_SECRET` set to a strong value; rotate on schedule
+- [ ] TLS terminated in front of the API; HSTS
+- [ ] `SIEM_URL` configured to your collector; alerting on `verify_chain` failures
+- [ ] Backups encrypted + point-in-time recovery enabled; restore tested
+- [ ] Retention policy set per namespace; erasure runbook documented
+- [ ] `AIRGAP_MODE=true` if data must not leave the perimeter
+- [ ] Access reviews: periodic API-key/role review; revoke on offboarding
+- [ ] Penetration test of the deployed surface (annual)
+
+See [deploy.md](deploy.md) and [security-whitepaper.md](security-whitepaper.md).

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -1,0 +1,55 @@
+# SSO Integration
+
+Lians authenticates API calls with namespace-scoped API keys. For human access and
+enterprise identity, put SSO at the **gateway** in front of Lians — the standard,
+low-coupling pattern that works with any IdP (Okta, Entra ID, Auth0, Ping, Google)
+over OIDC or SAML, and keeps the memory layer focused on data, not identity.
+
+## Pattern: forward-auth at the gateway
+
+```
+User ─▶ Reverse proxy / API gateway ──(OIDC/SAML)──▶ IdP
+            │  (validates session, injects identity)
+            ▼
+        Lians API  ── X-API-Key (per team/role) ──▶ namespace + scopes
+```
+
+1. The gateway (NGINX `auth_request`, Envoy ext_authz, oauth2-proxy, Cloudflare
+   Access, AWS ALB OIDC, etc.) authenticates the user against your IdP.
+2. On success it forwards the request to Lians with a Lians **API key** chosen for
+   the user's team/role — or injects the identity headers your edge maps to one.
+3. Lians enforces namespace + scope/role from that key.
+
+This means **no IdP code in Lians**, SSO works with every provider, and revocation
+/ MFA / conditional access stay in your IdP where security teams expect them.
+
+## Mapping IdP groups → Lians roles
+
+Map IdP group claims to Lians API keys with the matching `role` (see RBAC):
+
+| IdP group | Lians role | Effective scopes |
+|-----------|-----------|------------------|
+| `lians-owners` | `owner` | read, write, admin |
+| `lians-analysts` | `analyst` | read, write |
+| `lians-compliance` | `compliance` | read, admin |
+| `lians-viewers` | `readonly` | read |
+
+Provision one API key per (team/namespace, role); the gateway selects the key from
+the authenticated group claim. Rotate keys on role changes; revoke on offboarding.
+
+## Per-tenant isolation
+
+Each team/tenant maps to a Lians **namespace** (its own API key). Namespace
+isolation is enforced at PostgreSQL RLS, so even a gateway misconfiguration cannot
+read another tenant's memories. Within a namespace, **information barriers**
+(barrier groups) wall off desks/care-teams/matters at the DB layer
+(see [security-whitepaper.md](security-whitepaper.md) §4).
+
+## Why not build OIDC into Lians?
+
+Embedding a full OIDC/SAML stack would duplicate the IdP, couple releases to
+identity changes, and expand the audit surface. Gateway forward-auth is the
+recommended enterprise pattern (it is how most data services integrate SSO) and
+keeps Lians' security boundary small and reviewable. A native OIDC mode may be
+added later for turnkey single-node deployments; the gateway pattern remains the
+recommendation for production.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,55 @@
+# Lians Threat Model
+
+A STRIDE threat model for the Lians memory layer. Scope: the self-hosted API
+server, its Postgres/Redis dependencies, and the SDK clients. Out of scope: the
+customer's own network, IdP, and the LLMs that consume recalled context.
+
+## Assets
+
+- **Memory content** (PII / PHI / MNPI) and its embeddings
+- **Audit chain** integrity (regulatory evidence)
+- **Subject keys (DEKs)** and the master key
+- **API keys** and admin secret
+- **Tenant / barrier isolation** boundaries
+
+## Trust boundaries
+
+Client ↔ API (network) · API ↔ Postgres/Redis (network) · API ↔ KMS · API ↔ SIEM
+/ webhook receivers. The API process is the primary trust boundary enforcing
+authn/z; the database is a second boundary enforcing RLS.
+
+## STRIDE
+
+| Threat | Vector | Mitigation |
+|--------|--------|------------|
+| **Spoofing** | Forged API key | Keys stored as SHA-256 hashes; revocable; TLS; admin endpoints gated by a separate admin secret. SSO at the gateway. |
+| **Tampering (data)** | Alter a stored memory/audit row in the DB | Audit chain: each row's hash binds the previous row; `verify_chain` detects any edit/reorder/deletion. Content has a SHA-256 hash; erased content is unrecoverable but its hash persists. |
+| **Tampering (transit)** | MITM | TLS required in production. |
+| **Repudiation** | "We never knew X" / "we didn't erase Y" | Append-only event log + hash chain; point-in-time `snapshot`/`recall_at` reconstructs exact past state; erasure certificate proves deletion. |
+| **Information disclosure (cross-tenant)** | One namespace reads another's rows | RLS namespace policy (transaction-scoped GUC), enforced in the DB; app-layer filters as defense-in-depth. |
+| **Information disclosure (cross-barrier)** | One desk/care-team/matter reads another's | RESTRICTIVE RLS barrier policy (0013) keyed on `agentmem.barrier_group`; cross-barrier reads denied at the DB layer (CI-proven with a non-superuser role). |
+| **Information disclosure (at rest)** | DB/disk/backup theft | Per-subject AES-256-GCM; DEKs wrapped by a KMS master key; backups inherit encryption. |
+| **Information disclosure (egress)** | Data leaves the perimeter via an LLM/embedding API | Air-gap mode hard-fails at startup on any externalizing config; local embedding provider. |
+| **Denial of service** | Request flood | Per-API-key Redis rate limiting (fails open); timeouts; `/livez` vs `/readyz` so dependency blips don't cause restart storms. |
+| **Elevation of privilege** | Read key performs writes / admin | Per-request scope checks; RBAC roles; admin secret for audit/admin ops. |
+| **Replay / duplication** | Network retry double-writes | Idempotency keys (exactly-once writes); SDK auto-sends a stable key on retry. |
+
+## Key residual risks & assumptions
+
+1. **Run as a non-superuser DB role.** Superusers and `BYPASSRLS` roles bypass all
+   RLS — the single most important deployment control. Enforced/asserted in CI.
+2. **KMS protects the master key.** Compromise of the master key compromises all
+   DEKs; use a real KMS (AWS/Azure/Vault) and rotate.
+3. **Optional LLM stages** (supersession Stage-3, graph extraction with `use_llm`)
+   send text to a model provider — disabled in air-gap mode; rule-based defaults
+   keep the core deterministic and in-perimeter.
+4. **SIEM / webhook receivers** are trusted endpoints; deliveries are HMAC-signed
+   (webhooks) and best-effort (never block the write path).
+
+## Verification
+
+The barrier-isolation control is exercised in CI by a dedicated test that creates
+a `NOSUPERUSER`/`NOBYPASSRLS` role and confirms cross-barrier denial
+(`test_pgvector.py::test_barrier_group_isolation`). Audit-chain tamper detection,
+crypto-shred, and erasure-certificate behavior are covered by the test suite. See
+[testing.md](testing.md).


### PR DESCRIPTION
Final production-readiness item (program item 6).

## RBAC
`api_keys.role` column (migration `0015`) + `ROLE_SCOPES` (`owner`/`analyst`/`compliance`/`readonly`). `deps` expands a key's role to its scope set at auth time, merged with explicit scopes. (`compliance` = read+admin, **not** write.)

## SIEM audit streaming
`siem.py` `stream_event` forwards every audit-chain event (fire-and-forget) to a configured collector (Splunk HEC / Datadog / Elastic). Settings `siem_url`/`siem_token`; wired into `chain_log`, gated, and it never blocks or fails the write path.

## Security artifacts (procurement)
- `security-whitepaper.md`, `threat-model.md` (STRIDE), `soc2-hipaa-readiness.md` (TSC + HIPAA §164.312 control mapping + deployment checklist), `sso.md` (gateway forward-auth; IdP group → role mapping).
- Every doc reiterates the key control: **run the app as a non-superuser DB role**, or RLS isolation is silently bypassed.

## Tests
`test_rbac.py` (role→scope enforcement via app) + `test_siem.py` (delivery, disabled-by-default, error-swallowing). 64 RBAC/SIEM/admin/audit tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)