### PR TITLE
docs: reflect production features in mem0/Zep comparisons + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,24 @@ See [docs/testing.md](docs/testing.md) for the six named invariants (temporal so
 
 ---
 
+## Production & operations
+
+Built to run in a regulated production environment, not just to demo:
+
+- **Exactly-once writes** — `Idempotency-Key` on `POST /v1/memories`; the SDKs send a stable key automatically, so a retried write never duplicates.
+- **Resilient clients** — built-in retry with exponential backoff on transport errors / 5xx / 429.
+- **Kubernetes probes** — cheap `/livez` (liveness) and deep `/readyz` (readiness), so a dependency blip doesn't restart healthy pods.
+- **Rate limiting** — per-API-key sliding window (Redis), fails open.
+- **Access control** — namespace-scoped keys, `read`/`write`/`admin` scopes, **RBAC roles** (`owner`/`analyst`/`compliance`/`readonly`), and SSO via gateway forward-auth.
+- **DB-layer information barriers** — `RESTRICTIVE` PostgreSQL RLS, **proven in CI** against a non-superuser role. *Run the app as a non-superuser DB role* — superusers bypass RLS.
+- **SIEM streaming** — every audit event forwarded to Splunk HEC / Datadog / Elastic (`SIEM_URL`), fire-and-forget.
+- **Observability** — Prometheus metrics + Grafana, OpenTelemetry traces, JSON access logs with a request ID.
+- **Evaluation** — a judge-free memory-eval harness (`agentmem/benchmarks/memory_eval.py`) in the LoCoMo/LongMemEval shape.
+
+Security & procurement docs: [security-whitepaper.md](docs/security-whitepaper.md) · [threat-model.md](docs/threat-model.md) · [soc2-hipaa-readiness.md](docs/soc2-hipaa-readiness.md) · [sso.md](docs/sso.md) · [publishing.md](docs/publishing.md)
+
+---
+
 ## Compliance
 
 | Requirement | Feature |

--- a/docs/compare-mem0.md
+++ b/docs/compare-mem0.md
@@ -25,17 +25,24 @@ and **access** (who can read what, and is it provably controlled?).
 | "What did we know on date X?" | No temporal reconstruction | `recall_at` / `snapshot` — exhaustive point-in-time state |
 | Tamper-evidence | Not documented | SHA-256 hash chain (SEC 17a-4), `verify_chain()` |
 | Right-to-erasure | Delete API; no audit-preserving proof | Per-subject AES-256-GCM crypto-shred; audit trail survives; erasure certificate |
-| Access control | `user_id` filtering | Scoped API keys + PostgreSQL Row-Level Security information barriers |
+| Access control | `user_id` filtering | Scoped keys + **RBAC roles** + PostgreSQL RLS barriers (DB-layer, CI-proven against a non-superuser role) |
 | Lookahead-bias proof | None | `backtest_check` contamination report |
+| Reranking | Hybrid search + reranker | Hybrid (BM25 + cosine + recency) + opt-in **MMR diversity** rerank |
+| Context assembly | Returns a memory list | `/v1/context` — token-budgeted, ready-to-inject block (point-in-time + MMR aware) |
+| Production hardening | Managed platform | **Idempotency keys** (exactly-once writes), SDK retry/backoff, `/livez`+`/readyz`, per-key rate limiting, **SIEM audit streaming** |
+| Evaluation | Published LoCoMo/LongMemEval scores | Bundled judge-free harness (`answer_recall@k`) + the supersession invariant |
 | Regulatory export | None documented | `compliance_report`, audit export (SEC/FINRA/CFTC) |
 | Domain modeling | Generic | Finance / healthcare / legal adapters (entity normalization) |
 | Language SDKs | Python, TypeScript (2) | Python, TypeScript, **Go, Java, C** (5) |
 
 Where mem0 leads: breadth of out-of-the-box *framework* integrations (LangChain,
-CrewAI, …), a polished hosted onboarding, a browser extension, and strong
-general-chat benchmark scores (LoCoMo / LongMemEval). If you are building a consumer
-assistant, that breadth is real value. If you are building for a bank, hospital, or
-law firm, the rows above are the ones that get you through procurement and audit.
+CrewAI, …), a polished hosted onboarding, a browser extension, and *published*
+general-chat benchmark scores (LoCoMo / LongMemEval). Lians ships the eval harness
+to run those benchmarks (`agentmem/benchmarks/memory_eval.py`) but doesn't lead with
+a single recall number — its thesis is correct, current, auditable recall, not
+recall at any cost. If you are building a consumer assistant, mem0's breadth is real
+value. If you are building for a bank, hospital, or law firm, the rows above are the
+ones that get you through procurement and audit.
 
 On *language* reach, though, Lians is ahead: mem0 ships Python and TypeScript;
 Lians ships **Python, TypeScript, Go, Java, and C** — the two of those that matter

--- a/docs/compare-zep.md
+++ b/docs/compare-zep.md
@@ -23,13 +23,16 @@ design worth adopting — on our terms, for regulated work.
 |---|---|---|
 | Temporal model | Bitemporal **edges** (`valid_at`/`invalid_at`) | Bitemporal **facts** (`event_time` + `valid_from/valid_to`) |
 | Data shape | Entity–relationship **graph** (triplets) | Atomic facts + structured metadata |
-| Retrieval | Semantic + BM25 + **graph traversal** + node-distance rerank | Semantic + BM25 + recency + validity gate + **graph traversal + node-distance rerank** (shipped) |
+| Retrieval | Semantic + BM25 + **graph traversal** + node-distance rerank | Semantic + BM25 + recency + validity gate + graph traversal + node-distance + **MMR** rerank |
+| Text → graph | LLM extraction (always) | `/v1/graph/extract` — **rule-based default** (deterministic, auditable), LLM opt-in |
+| Context assembly | `memory.context` block | `/v1/context` — token-budgeted, ready-to-inject, point-in-time + MMR aware |
 | Fact updates | **LLM-extracted**, dedup, contradiction → invalidate edge | **Deterministic** keyed supersession; LLM only as optional adjudicator |
-| Entity model | LLM entity nodes + evolving summaries + communities | Entity *normalization* (ISIN/CUSIP/ICD-10) — no node graph |
-| Ontology | Custom entity/edge **types** (Pydantic) | Domain adapters (key normalization only) |
+| Entity model | LLM entity nodes + evolving summaries + communities | Entity *normalization* (ISIN/CUSIP/ICD-10); explicit + extracted edges (no communities/summaries yet) |
 | Tamper-evidence | Episode provenance only | SHA-256 hash chain (SEC 17a-4), `verify_chain` |
 | Right-to-erasure | Not a feature | Per-subject crypto-shred + erasure certificate |
-| Access control | None in Graphiti; Zep Cloud only | Scoped keys + PostgreSQL RLS information barriers |
+| Access control | None in Graphiti; Zep Cloud only | Scoped keys + **RBAC roles** + PostgreSQL RLS barriers (DB-layer, CI-proven) |
+| Audit egress | — | **SIEM streaming** (Splunk/Datadog/Elastic) + signed-webhook events + export |
+| Production | Managed cloud only | Self-host: idempotency keys, SDK retries, `/livez`+`/readyz`, rate limiting, air-gap |
 | Backend | Neo4j / FalkorDB / Neptune (graph DB) | Postgres 16 + pgvector (no extra infra) |
 | Determinism | Extraction-quality dependent | Reproducible; same input → same supersession |
 | Language SDKs | Python, TypeScript, Go (3) | Python, TypeScript, Go, **Java, C** (5) |


### PR DESCRIPTION
Updates the comparison docs and README now that the production-readiness program shipped (PRs #7–#12).

- **compare-mem0.md** — new rows: reranking (MMR), context assembly, production hardening (idempotency/probes/SIEM), evaluation harness; RBAC in access control; honest benchmark note.
- **compare-zep.md** — MMR in retrieval; text→graph extraction (rule-based default); context assembly; RBAC; SIEM/audit egress; self-host production rows.
- **README** — new **Production & operations** section (exactly-once writes, retries, `/livez`+`/readyz`, rate limiting, RBAC/SSO, DB-layer barriers, SIEM, observability, eval) + links to security-whitepaper / threat-model / SOC2-HIPAA-readiness / SSO / publishing docs.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)