### PR TITLE
Release prep v0.3.0: bump all SDKs, automate Go/Maven publishing, rescope npm

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "lians",
       "source": "./integrations/lians-plugin",
       "description": "Lians financial-grade memory for AI agents. Persistent, bitemporal memory with SEC 17a-4 audit chain and GDPR crypto-shred.",
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,57 @@ jobs:
         with:
           files: lians-c-*.tar.gz
 
-  go-verify:
-    name: Verify Go module builds
+  go-tag:
+    name: Tag Go module for go get
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
       - name: Build & vet
         run: go vet ./... && go build ./...
         working-directory: agentmem/sdk/go
+      # The Go module lives in a subdirectory, so `go get <module>@<version>`
+      # resolves a tag prefixed with the module path. Mirror the vX.Y.Z release
+      # tag to agentmem/sdk/go/vX.Y.Z so consumers can pin a version.
+      - name: Push module-path tag
+        run: |
+          gotag="agentmem/sdk/go/${GITHUB_REF_NAME}"
+          if git rev-parse "$gotag" >/dev/null 2>&1; then
+            echo "$gotag already exists; skipping"
+          else
+            git tag "$gotag" "${GITHUB_REF_NAME}"
+            git push origin "$gotag"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  maven-central:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+    # Opt-in: set repository variable PUBLISH_MAVEN_CENTRAL=true and configure the
+    # OSSRH_* / MAVEN_GPG_* secrets first (see docs/publishing.md). Until then the
+    # java-jar job attaches the jar to the Release.
+    if: ${{ vars.PUBLISH_MAVEN_CENTRAL == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+          server-id: central
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Deploy
+        run: mvn -B --no-transfer-progress -P release deploy
+        working-directory: agentmem/sdk/java
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to Lians. Versions follow semver; SDKs are released in lock-step.
+
+## 0.3.0 — 2026-06-29
+
+The production-readiness + competitive release. Everything below is on `master`
+with full CI (12 checks across 5 languages + Postgres).
+
+### Added
+- **Agent memory harness** (`LiansMemoryHarness`) — drop-in recall-before /
+  remember-after loop with compliance scoping.
+- **Relationship graph** — `relate` / `unrelate` / `neighbors` / `path` (bitemporal,
+  point-in-time), **graph-proximity (node-distance) reranking**, and `POST
+  /v1/graph/extract` (rule-based text→edges, opt-in LLM).
+- **MMR reranking** and `POST /v1/context` — token-budgeted, ready-to-inject block.
+- **Three new SDKs — Go, Java, and C** — now five languages (Python, TypeScript,
+  Go, Java, C). npm package renamed to `@lians-ai/lians`.
+- **Exactly-once writes** — `Idempotency-Key` on `POST /v1/memories`; SDK
+  retry/backoff with an auto idempotency key.
+- **RBAC roles** (`owner`/`analyst`/`compliance`/`readonly`) on API keys.
+- **SIEM audit streaming** (`SIEM_URL`) + `/livez` and `/readyz` probes.
+- Memory **evaluation harness** (LoCoMo/LongMemEval shape, judge-free).
+- Claude Code plugin, Codex integration, cross-tool skills.
+- Docs: security whitepaper, STRIDE threat model, SOC 2/HIPAA readiness, SSO,
+  publishing, and mem0 / Zep comparisons.
+
+### Fixed (correctness / security)
+- **Information barriers now enforced at the database layer.** Barrier RLS policies
+  are `RESTRICTIVE` (migration 0013) and the barrier session var is set per
+  request; cross-barrier denial is proven in CI against a non-superuser role.
+  Previously isolation was app-layer only.
+- Restored `memory_service` functions the API imported but lacked (snapshot,
+  lineage, fact-history, conflicts, erasure certificate); wired conflict
+  persistence and webhook dispatch.
+- Fixed the migration runner (asyncpg multi-statement / parameterized `SET`) and a
+  stack of CI environment issues — CI is green for the first time.
+
+> **Deployment note:** run the application as a **non-superuser, non-BYPASSRLS**
+> Postgres role, or RLS (namespace + barrier isolation) is silently bypassed.
+
+## 0.2.0 — 2026-06-27
+
+Free tier, cloud pricing, GitHub org migration to `Lians-ai`.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
   <a href="https://github.com/Lians-ai/Lians">
     <img src="https://img.shields.io/github/commit-activity/m/Lians-ai/Lians/master?style=flat-square" alt="GitHub commit activity">
   </a>
-  <a href="https://www.npmjs.com/package/@ebeirne/lians">
-    <img src="https://img.shields.io/npm/v/%40ebeirne%2Flians?label=npm" alt="npm version">
+  <a href="https://www.npmjs.com/package/@lians-ai/lians">
+    <img src="https://img.shields.io/npm/v/%40lians-ai%2Flians?label=npm" alt="npm version">
   </a>
   <a href="https://registry.modelcontextprotocol.io/servers/io.github.ebeirne/lians">
     <img src="https://img.shields.io/badge/MCP-Official%20Registry-blueviolet" alt="MCP Official Registry">
@@ -277,7 +277,7 @@ healthcare/legal stacks.
 | Language | Install | Client | Docs |
 |----------|---------|--------|------|
 | **Python** | `pip install lians-sdk` | `from lians import LiansClient` | [sdk/python](agentmem/sdk/python) |
-| **TypeScript / Node** | `npm install @ebeirne/lians` | `import { LiansClient } from "@ebeirne/lians"` | [sdk/typescript](agentmem/sdk/typescript) |
+| **TypeScript / Node** | `npm install @lians-ai/lians` | `import { LiansClient } from "@lians-ai/lians"` | [sdk/typescript](agentmem/sdk/typescript) |
 | **Go** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go` | `lians.NewClient(url, key)` | [sdk/go](agentmem/sdk/go) |
 | **Java** (JVM 11+) | `dev.lians:lians-sdk:0.2.0` (Maven) | `new LiansClient(opts)` | [sdk/java](agentmem/sdk/java) |
 | **C** (C99 + libcurl) | `cmake --build build` | `lians_client_new(...)` | [sdk/c](agentmem/sdk/c) |
@@ -297,7 +297,7 @@ backtest, crypto-shred erasure, audit-chain verify, and the relationship graph
 | **CrewAI** | `pip install lians-sdk[crewai]` | `from lians.crewai_integration import build_crewai_tools` |
 | **OpenAI Agents SDK** | `pip install lians-sdk[openai-agents]` | `from lians.openai_agents_integration import build_openai_agent_tools` |
 | **AutoGen v0.4** | `pip install lians-sdk[autogen]` | `from lians.autogen_integration import build_autogen_tools` |
-| **TypeScript / Node** | `npm install @ebeirne/lians` | `import { LiansClient } from "@ebeirne/lians"` |
+| **TypeScript / Node** | `npm install @lians-ai/lians` | `import { LiansClient } from "@lians-ai/lians"` |
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,44 @@
+# Releasing Lians
+
+One command cuts a release across all five SDKs. Versions are kept in lock-step.
+
+```bash
+# 1. Bump versions (already 0.3.0 — see the files below) and update CHANGELOG.md
+# 2. Tag and push:
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+Pushing a `vX.Y.Z` tag triggers:
+
+| Workflow | Does |
+|----------|------|
+| `publish-lian.yml` | Builds + publishes **Python** `lians-sdk` to PyPI (OIDC trusted publishing) |
+| `publish-lian-npm.yml` | `npm publish` **TypeScript** `@lians-ai/lians` (needs `NPM_TOKEN`) |
+| `release.yml` → `java-jar` | Attaches the **Java** jar to the GitHub Release |
+| `release.yml` → `c-tarball` | Attaches `lians-c-<version>.tar.gz` (the **C** source) to the Release |
+| `release.yml` → `go-tag` | Mirrors the tag to `agentmem/sdk/go/vX.Y.Z` so `go get …@vX.Y.Z` resolves |
+| `release.yml` → `maven-central` | Publishes **Java** to Maven Central — only when opted in (below) |
+
+## Version locations (keep in sync)
+
+- Python: `agentmem/sdk/python/pyproject.toml` → `version`
+- TypeScript: `agentmem/sdk/typescript/package.json` → `version`
+- Java: `agentmem/sdk/java/pom.xml` → `<version>`
+- C: `agentmem/sdk/c/src/lians.c` user-agent string
+- MCP: `server.json`; Claude plugin: `.claude-plugin/marketplace.json` + `integrations/lians-plugin/.claude-plugin/plugin.json`
+- Go: no file — the tag *is* the version
+
+## Required secrets / setup (one-time)
+
+| Registry | Setup |
+|----------|-------|
+| **PyPI** | Configure a *Trusted Publisher* for `lians-sdk` pointing at `publish-lian.yml` (no token needed). |
+| **npm** | Create the `@lians-ai` org (or your chosen scope), add repo secret `NPM_TOKEN` with publish rights. |
+| **Maven Central** | Create a [Central Portal](https://central.sonatype.com) account for `dev.lians`; add secrets `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `MAVEN_GPG_KEY` (ASCII-armored private key), `MAVEN_GPG_PASSPHRASE`; set repo **variable** `PUBLISH_MAVEN_CENTRAL=true`. Until then, the jar is attached to the GitHub Release. |
+| **Go / pkg.go.dev** | Nothing — `go-tag` creates the resolvable tag automatically. |
+
+## After a release
+
+- Verify: `pip install lians-sdk==X.Y.Z`, `npm view @lians-ai/lians`, `go get github.com/Lians-ai/Lians/agentmem/sdk/go@vX.Y.Z`, and the Maven Central listing.
+- Update the npm scope decision if `@lians-ai` isn't your final choice — it's referenced in `package.json`, `README.md`, `docs/`, and `integrations/lians-plugin/CLAUDE.md`.

--- a/agentmem/sdk/c/src/lians.c
+++ b/agentmem/sdk/c/src/lians.c
@@ -121,7 +121,7 @@ static lians_response_t do_request(lians_client_t *c, const char *method,
     curl_easy_setopt(h, CURLOPT_WRITEFUNCTION, write_cb);
     curl_easy_setopt(h, CURLOPT_WRITEDATA, &mb);
     curl_easy_setopt(h, CURLOPT_TIMEOUT_MS, c->timeout_ms);
-    curl_easy_setopt(h, CURLOPT_USERAGENT, "lians-c-sdk/0.2.0");
+    curl_easy_setopt(h, CURLOPT_USERAGENT, "lians-c-sdk/0.3.0");
     if (body) {
         curl_easy_setopt(h, CURLOPT_POSTFIELDS, body);
         curl_easy_setopt(h, CURLOPT_POSTFIELDSIZE, (long)strlen(body));

--- a/agentmem/sdk/java/pom.xml
+++ b/agentmem/sdk/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>dev.lians</groupId>
   <artifactId>lians-sdk</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <packaging>jar</packaging>
 
   <name>Lians SDK</name>
@@ -19,6 +19,21 @@
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
+
+  <developers>
+    <developer>
+      <name>Lians</name>
+      <email>support@lians.dev</email>
+      <organization>Lians</organization>
+      <organizationUrl>https://github.com/Lians-ai</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/Lians-ai/Lians.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/Lians-ai/Lians.git</developerConnection>
+    <url>https://github.com/Lians-ai/Lians</url>
+  </scm>
 
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
@@ -52,4 +67,61 @@
       </plugin>
     </plugins>
   </build>
+
+  <!-- Activated with `-P release` by the maven-central CI job. Builds sources +
+       javadoc, GPG-signs everything, and publishes to Maven Central via the
+       Central Portal. Requires the OSSRH_* / MAVEN_GPG_* secrets. -->
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals><goal>jar-no-fork</goal></goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.7.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals><goal>jar</goal></goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.4</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals><goal>sign</goal></goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.5.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/agentmem/sdk/python/pyproject.toml
+++ b/agentmem/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lians-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Financial-grade AI memory — bitemporal facts, SEC 17a-4 audit chain, GDPR crypto-shred"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/agentmem/sdk/typescript/package.json
+++ b/agentmem/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ebeirne/lians",
-  "version": "0.2.0",
+  "name": "@lians-ai/lians",
+  "version": "0.3.0",
   "description": "TypeScript/JavaScript SDK for Lians — financial-grade AI memory with bitemporal model, SEC 17a-4 audit chain, and GDPR crypto-shred",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agentmem/sdk/typescript/src/langchain.ts
+++ b/agentmem/sdk/typescript/src/langchain.ts
@@ -5,7 +5,7 @@
  *   npm install @langchain/core
  *
  * @example
- * import { LiansClient } from "@ebeirne/lians";
+ * import { LiansClient } from "@lians-ai/lians";
  * import { createRecallTool, createRememberTool } from "lians/langchain";
  *
  * const client = new LiansClient({ baseUrl: "...", apiKey: "..." });

--- a/docs/migrate-from-zep.md
+++ b/docs/migrate-from-zep.md
@@ -39,7 +39,7 @@ pip install lians-sdk[local]     # local SQLite mode — instant start
 pip install lians-sdk            # connects to a Lians server
 
 # TypeScript
-npm install @ebeirne/lians
+npm install @lians-ai/lians
 ```
 
 ## Code comparison
@@ -76,7 +76,7 @@ await client.memory.add("session-123", { messages: [...] });
 
 **Lians (TypeScript):**
 ```typescript
-import { LiansClient } from "@ebeirne/lians";
+import { LiansClient } from "@lians-ai/lians";
 const mem = new LiansClient({ baseUrl: "https://api.lians.dev", apiKey: "lians_..." });
 await mem.add({ agentId: "session-123", content: "...", eventTime: new Date() });
 ```

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -12,37 +12,36 @@ git push origin v0.2.1
 | SDK | Registry | How it's published | Secret(s) needed |
 |-----|----------|--------------------|------------------|
 | **Python** | [PyPI](https://pypi.org/project/lians-sdk) | `publish-lian.yml` builds sdist+wheel and uploads via `twine` | `PYPI_API_TOKEN` |
-| **TypeScript** | [npm](https://www.npmjs.com/package/@ebeirne/lians) | `publish-lian-npm.yml` runs `npm publish` | `NPM_TOKEN` |
-| **Go** | proxy.golang.org / pkg.go.dev | **No build step** — a module tag *is* the release (see below) | none |
-| **Java** | Maven Central / GitHub Packages | `mvn deploy` (or jar attached to the Release) | `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `MAVEN_GPG_KEY`, `MAVEN_GPG_PASSPHRASE` |
+| **TypeScript** | [npm](https://www.npmjs.com/package/@lians-ai/lians) | `publish-lian-npm.yml` runs `npm publish` | `NPM_TOKEN` |
+| **Go** | proxy.golang.org / pkg.go.dev | `release.yml` → `go-tag` auto-mirrors the tag to the module path (see below) | none |
+| **Java** | Maven Central (gated) / GitHub Release jar | `release.yml` → `maven-central` (`mvn deploy -P release`) when opted in; else jar on the Release | `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `MAVEN_GPG_KEY`, `MAVEN_GPG_PASSPHRASE` + var `PUBLISH_MAVEN_CENTRAL=true` |
 | **C** | source tarball on the GitHub Release | packaged by `release.yml` (vendored into the consumer build) | none |
 
-## Go module tags
+## Go module tags (automatic)
 
-Because the Go module lives in a subdirectory, `go get` resolves a version from a
-tag **prefixed with the module path**:
+The Go module lives in a subdirectory, so `go get` resolves a version from a tag
+**prefixed with the module path**. The `go-tag` job in `release.yml` creates this
+automatically when you push a `vX.Y.Z` tag — no manual step:
 
-```bash
-git tag agentmem/sdk/go/v0.2.1
-git push origin agentmem/sdk/go/v0.2.1
+```
+v0.3.0  ──(release.yml go-tag)──▶  agentmem/sdk/go/v0.3.0
 ```
 
-Then consumers use:
+Consumers then use:
 
 ```bash
-go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.2.1
+go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.3.0
 ```
-
-The plain `v0.2.1` release tag covers Python/TS/Java/C; the prefixed tag covers Go.
 
 ## Java → Maven Central
 
-`release.yml` attaches the built jar to the GitHub Release out of the box (no
-secrets). To publish to **Maven Central** instead, add the OSSRH + GPG secrets
-above and switch the Java job to `mvn -B deploy -P release` with a
-`distributionManagement` block and the `maven-gpg-plugin` in `pom.xml`. To publish
-to **GitHub Packages** (simpler, no GPG), point `distributionManagement` at
-`https://maven.pkg.github.com/Lians-ai/Lians` and authenticate with `GITHUB_TOKEN`.
+Out of the box, `release.yml` attaches the built jar to the GitHub Release (no
+secrets). To publish to **Maven Central**: add the `OSSRH_*` / `MAVEN_GPG_*`
+secrets, set the repository **variable** `PUBLISH_MAVEN_CENTRAL=true`, and the
+`maven-central` job runs `mvn -B deploy -P release` — the `release` profile in
+`pom.xml` builds sources + javadoc, GPG-signs, and publishes via the Sonatype
+Central Portal. (GitHub Packages is an alternative: point `distributionManagement`
+at `https://maven.pkg.github.com/Lians-ai/Lians` and use `GITHUB_TOKEN`.)
 
 ## C
 

--- a/integrations/lians-plugin/.claude-plugin/plugin.json
+++ b/integrations/lians-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lians",
   "description": "Financial-grade agent memory for Claude Code — bitemporal recall, SEC 17a-4 audit chain, GDPR/HIPAA crypto-shred, and information barriers. Built for finance, healthcare, and legal teams.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Lians",
     "email": "support@lians.dev",

--- a/integrations/lians-plugin/CLAUDE.md
+++ b/integrations/lians-plugin/CLAUDE.md
@@ -109,7 +109,7 @@ if issues:
 ## TypeScript quick reference
 
 ```typescript
-import { LiansClient } from "@ebeirne/lians";
+import { LiansClient } from "@lians-ai/lians";
 
 const mem = new LiansClient({
   baseUrl: process.env.LIANS_URL!,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.ebeirne/lians",
   "title": "Lians — Financial-Grade Agent Memory",
   "description": "Bitemporal memory for AI agents. SEC 17a-4 audit chain, GDPR crypto-shred, information barriers.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "websiteUrl": "https://github.com/Lians-ai/Lians",
   "repository": {
     "url": "https://github.com/Lians-ai/Lians",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "lians-sdk",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {


### PR DESCRIPTION
The published SDKs were **stale at 0.2.0** (Jun 24) — before the harness, graph, `context()`, idempotency, retries, RBAC, etc. — and **Java/Go weren't on their registries at all**. This stages a clean **v0.3.0** so a single tag publishes the current product across all five languages.

## Changes
- **Version bump 0.2.0 → 0.3.0** everywhere (Python/TS/Java manifests, C user-agent, `server.json`, Claude plugin marketplace + `plugin.json`).
- **npm rescope** `@ebeirne/lians` → `@lians-ai/lians` (org-consistent) across `package.json`, README badges/install, docs, plugin `CLAUDE.md`.
  - ⚠️ **Veto-able:** needs the `@lians-ai` npm org. If you'd prefer a different scope (or to keep `@ebeirne`), it's a one-line search-replace revert.
- **`release.yml`**: new `go-tag` job auto-mirrors `vX.Y.Z` → `agentmem/sdk/go/vX.Y.Z` so `go get …@version` resolves; new **gated** `maven-central` job (opt-in via repo var `PUBLISH_MAVEN_CENTRAL` + `OSSRH_*`/`MAVEN_GPG_*` secrets).
- **`pom.xml`**: `developers` + `scm` (Maven Central requirements) and a `release` profile (sources + javadoc + GPG + Sonatype central-publishing). Inert unless `-P release`.
- **`RELEASING.md`** (one-command release + required secrets) and **`CHANGELOG.md`**.
- `docs/publishing.md` updated to the automated pipeline.

## Notes
No application/test code changed — `test.yml` CI is unaffected. Actual publishing needs the registry credentials configured (see `RELEASING.md`), then:

```bash
git tag v0.3.0 && git push origin v0.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)