### PR TITLE
SSO → barrier mapping: key-level barrier scopes reads and writes

### DIFF
--- a/agentmem/alembic/versions/0017_apikey_barrier.py
+++ b/agentmem/alembic/versions/0017_apikey_barrier.py
@@ -1,0 +1,26 @@
+"""api_keys.barrier_group for SSO->barrier mapping
+
+Revision ID: 0017_apikey_barrier
+Revises: 0016_pending_admissions
+Create Date: 2026-06-30
+
+When set, every read/write under the key is scoped to this information barrier.
+An SSO gateway picks the key from the caller's IdP group, so the
+group -> namespace/role/barrier chain is enforced end to end.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0017_apikey_barrier"
+down_revision = "0016_pending_admissions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_keys", sa.Column("barrier_group", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_keys", "barrier_group")

--- a/agentmem/src/lians/api/deps.py
+++ b/agentmem/src/lians/api/deps.py
@@ -39,9 +39,11 @@ def _effective_scopes(key_row: ApiKey) -> list[str]:
 
 
 class AuthContext:
-    def __init__(self, namespace: str, scopes: list[str]):
+    def __init__(self, namespace: str, scopes: list[str], barrier_group: Optional[str] = None):
         self.namespace = namespace
         self.scopes = scopes
+        # Information barrier the calling key is scoped to (None = unbarriered).
+        self.barrier_group = barrier_group
 
     def require(self, scope: str):
         if scope not in self.scopes:
@@ -101,4 +103,5 @@ async def get_auth(
     return AuthContext(
         namespace=key_row.namespace,
         scopes=_effective_scopes(key_row),
+        barrier_group=getattr(key_row, "barrier_group", None),
     )

--- a/agentmem/src/lians/api/routes_memory.py
+++ b/agentmem/src/lians/api/routes_memory.py
@@ -66,7 +66,9 @@ async def create_memory(
     if decision.risk_tags:
         req.metadata = {**(req.metadata or {}),
                         "_admission": {"action": "admit", "risk_tags": decision.risk_tags}}
-    return await add_memory_idempotent(db, auth.namespace, req, idempotency_key)
+    return await add_memory_idempotent(
+        db, auth.namespace, req, idempotency_key, barrier_override=auth.barrier_group,
+    )
 
 
 @router.post("/memories/batch", response_model=MemoryBatchResult)
@@ -158,7 +160,7 @@ async def recall(
     db: AsyncSession = Depends(get_db),
 ):
     auth.require("read")
-    return await recall_memories(db, auth.namespace, req)
+    return await recall_memories(db, auth.namespace, req, barrier_override=auth.barrier_group)
 
 
 @router.post("/context", response_model=ContextResult)
@@ -174,4 +176,4 @@ async def context(
     ``mmr: true`` for diversity reranking, and ``max_tokens`` to cap the budget.
     """
     auth.require("read")
-    return await assemble_context(db, auth.namespace, req)
+    return await assemble_context(db, auth.namespace, req, barrier_override=auth.barrier_group)

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -89,13 +89,20 @@ def _compute_importance(event_time: datetime, caller_salience: float) -> float:
     return round(0.4 * recency + 0.6 * caller_salience, 4)
 
 
-async def _get_barrier_group(db: AsyncSession, namespace: str, agent_id: str) -> Optional[str]:
-    stmt = select(AgentBarrierGroup).where(
-        and_(AgentBarrierGroup.namespace == namespace, AgentBarrierGroup.agent_id == agent_id)
-    )
-    result = await db.execute(stmt)
-    row = result.scalar_one_or_none()
-    group = row.group_name if row else None
+async def _get_barrier_group(
+    db: AsyncSession, namespace: str, agent_id: str, override: Optional[str] = None
+) -> Optional[str]:
+    if override is not None:
+        # The calling API key is barrier-scoped (SSO gateway picked it from the
+        # caller's IdP group) — the key's barrier is authoritative, no lookup.
+        group: Optional[str] = override
+    else:
+        stmt = select(AgentBarrierGroup).where(
+            and_(AgentBarrierGroup.namespace == namespace, AgentBarrierGroup.agent_id == agent_id)
+        )
+        result = await db.execute(stmt)
+        row = result.scalar_one_or_none()
+        group = row.group_name if row else None
 
     # Engage the PostgreSQL RLS barrier policy by setting the session variable the
     # RESTRICTIVE barrier_isolation policy reads (migration 0013). An unbarriered
@@ -182,6 +189,8 @@ async def add_memory(
     db: AsyncSession,
     namespace: str,
     req: MemoryAdd,
+    *,
+    barrier_override: Optional[str] = None,
 ) -> MemoryOut:
     _add_t0 = _time.perf_counter()
     with tracer.start_as_current_span("memory.add") as span:
@@ -207,7 +216,7 @@ async def add_memory(
         async with in_process_lock:
             await _acquire_pg_advisory_lock(db, namespace, req.agent_id)
 
-            barrier_group = await _get_barrier_group(db, namespace, req.agent_id)
+            barrier_group = await _get_barrier_group(db, namespace, req.agent_id, override=barrier_override)
 
             # Change 3: pass a pre-generated UUID so the async LLM worker can
             # reference the new memory before flush assigns the DB id.
@@ -355,6 +364,8 @@ async def add_memory_idempotent(
     namespace: str,
     req: MemoryAdd,
     idempotency_key: Optional[str],
+    *,
+    barrier_override: Optional[str] = None,
 ) -> MemoryOut:
     """
     Idempotent wrapper around :func:`add_memory`.
@@ -368,7 +379,7 @@ async def add_memory_idempotent(
     server-side but whose response was lost to a network blip is not duplicated.
     """
     if not idempotency_key:
-        return await add_memory(db, namespace, req)
+        return await add_memory(db, namespace, req, barrier_override=barrier_override)
 
     existing = await db.get(IdempotencyKey, (idempotency_key, namespace))
     if existing is not None:
@@ -378,7 +389,7 @@ async def add_memory_idempotent(
             from .ranking import _decrypt
             return _memory_to_out(mem, _decrypt(mem, subject_keys))
 
-    result = await add_memory(db, namespace, req)
+    result = await add_memory(db, namespace, req, barrier_override=barrier_override)
     db.add(IdempotencyKey(key=idempotency_key, namespace=namespace, memory_id=result.id))
     try:
         await db.commit()
@@ -404,6 +415,8 @@ async def assemble_context(
     db: AsyncSession,
     namespace: str,
     req: "ContextRequest",
+    *,
+    barrier_override: Optional[str] = None,
 ) -> "ContextResult":
     """
     Recall the relevant facts and assemble them into a token-budgeted, ready-to-
@@ -421,7 +434,7 @@ async def assemble_context(
     recall_req = RecallRequest(
         agent_id=req.agent_id, query=req.query, k=req.k, as_of=req.as_of, filters=filters,
     )
-    result = await recall_memories(db, namespace, recall_req)
+    result = await recall_memories(db, namespace, recall_req, barrier_override=barrier_override)
 
     lines = [req.header]
     used = _estimate_tokens(req.header)
@@ -453,6 +466,8 @@ async def recall_memories(
     db: AsyncSession,
     namespace: str,
     req: RecallRequest,
+    *,
+    barrier_override: Optional[str] = None,
 ) -> RecallResult:
     _recall_t0 = _time.perf_counter()
     with tracer.start_as_current_span("memory.recall") as span:
@@ -480,7 +495,7 @@ async def recall_memories(
                 mmr_lambda = 0.5
 
         # Hot cache (Redis)
-        if settings.recall_cache_enabled and not req.as_of and not near_entity and not rerank:
+        if settings.recall_cache_enabled and not req.as_of and not near_entity and not rerank and barrier_override is None:
             cached = await get_cached_recall(
                 namespace, req.agent_id, req.query, req.as_of, req.k, req.filters
             )
@@ -496,7 +511,7 @@ async def recall_memories(
             predicate_key = compute_predicate_key(req.filters)
             if predicate_key:
                 with tracer.start_as_current_span("recall.keyed_lookup") as ks:
-                    barrier_group = await _get_barrier_group(db, namespace, req.agent_id)
+                    barrier_group = await _get_barrier_group(db, namespace, req.agent_id, override=barrier_override)
                     live_fact = await keyed_lookup(
                         db, namespace, req.agent_id, predicate_key, barrier_group
                     )
@@ -529,22 +544,31 @@ async def recall_memories(
 
         with tracer.start_as_current_span("recall.load_keys"):
             subject_keys = await _load_namespace_subject_keys(db, namespace)
-            barrier_group = await _get_barrier_group(db, namespace, req.agent_id)
+            barrier_group = await _get_barrier_group(db, namespace, req.agent_id, override=barrier_override)
 
-        # Change 7: in-process working-set cache (present-time only)
+        # Change 7: in-process working-set cache (present-time only). The cache is
+        # keyed by (namespace, agent_id); a key-level barrier (SSO) can vary the
+        # barrier for the same agent, so bypass the cache when an override is in
+        # play to avoid serving one barrier's working set to another.
         live_facts_cache: Optional[list] = None
         if not req.as_of:
-            live_facts_cache = get_working_set(namespace, req.agent_id)
-            if live_facts_cache is None:
-                from .current_facts import fetch_working_set
+            from .current_facts import fetch_working_set
+            if barrier_override is not None:
                 with tracer.start_as_current_span("recall.prefetch_working_set"):
                     live_facts_cache = await fetch_working_set(
                         db, namespace, req.agent_id, barrier_group
                     )
-                set_working_set(namespace, req.agent_id, live_facts_cache)
-                span.set_attribute("working_set_cold", True)
             else:
-                span.set_attribute("working_set_cold", False)
+                live_facts_cache = get_working_set(namespace, req.agent_id)
+                if live_facts_cache is None:
+                    with tracer.start_as_current_span("recall.prefetch_working_set"):
+                        live_facts_cache = await fetch_working_set(
+                            db, namespace, req.agent_id, barrier_group
+                        )
+                    set_working_set(namespace, req.agent_id, live_facts_cache)
+                    span.set_attribute("working_set_cold", True)
+                else:
+                    span.set_attribute("working_set_cold", False)
 
         with tracer.start_as_current_span("recall.search"):
             results = await hybrid_recall(
@@ -612,7 +636,7 @@ async def recall_memories(
                 customer_id, 1, f"r:{recall_log.id}",
             )
 
-        if settings.recall_cache_enabled and not req.as_of and not near_entity:
+        if settings.recall_cache_enabled and not req.as_of and not near_entity and barrier_override is None:
             await set_cached_recall(
                 namespace, req.agent_id, req.query, req.as_of, req.k, req.filters,
                 result.model_dump_json(),

--- a/agentmem/src/lians/models.py
+++ b/agentmem/src/lians/models.py
@@ -174,6 +174,11 @@ class ApiKey(Base):
     # Optional named role (owner | analyst | compliance | readonly). When set, the
     # role's scope set is merged with any explicit `scopes` at auth time.
     role = Column(String, nullable=True)
+    # Optional information-barrier group. When set, every read/write under this key
+    # is scoped to this barrier (Chinese wall). An SSO gateway selects the key from
+    # the caller's IdP group, so the IdP group -> namespace/role/barrier chain is
+    # enforced end to end. NULL = unbarriered (compliance / cross-desk).
+    barrier_group = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=_now)
     rotated_at = Column(DateTime(timezone=True), nullable=True)
     revoked_at = Column(DateTime(timezone=True), nullable=True)

--- a/agentmem/tests/test_sso_barrier.py
+++ b/agentmem/tests/test_sso_barrier.py
@@ -1,0 +1,89 @@
+"""
+SSO -> barrier mapping: an API key's barrier_group (chosen by the SSO gateway from
+the caller's IdP group) scopes both writes (tagging) and reads (isolation).
+"""
+from __future__ import annotations
+
+import hashlib
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+
+from httpx import AsyncClient, ASGITransport
+
+from src.lians.main import app
+from src.lians.db import get_db
+from src.lians.models import ApiKey
+
+NS = "sso-ns"
+AGENT = "sso-agent"
+T = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _sha(k):
+    return hashlib.sha256(k.encode()).hexdigest()
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    # Three keys in one namespace: two walled desks + one unbarriered (compliance).
+    db.add(ApiKey(hashed_key=_sha("kA"), namespace=NS, scopes=["read", "write"], barrier_group="deskA"))
+    db.add(ApiKey(hashed_key=_sha("kB"), namespace=NS, scopes=["read", "write"], barrier_group="deskB"))
+    db.add(ApiKey(hashed_key=_sha("kC"), namespace=NS, scopes=["read", "write"]))  # unbarriered
+    await db.commit()
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _h(key):
+    return {"X-API-Key": key}
+
+
+async def _add(client, key, content):
+    r = await client.post("/v1/memories", headers=_h(key),
+                          json={"agent_id": AGENT, "content": content, "event_time": T.isoformat()})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+async def _recall(client, key):
+    r = await client.post("/v1/recall", headers=_h(key),
+                          json={"agent_id": AGENT, "query": "trade idea NVDA", "k": 10})
+    assert r.status_code == 200
+    return [(m.get("content") or "") for m in r.json()["memories"]]
+
+
+@pytest.mark.asyncio
+async def test_write_tagged_with_key_barrier(client):
+    out = await _add(client, "kA", "deskA trade idea NVDA long")
+    assert out["barrier_group"] == "deskA"
+
+
+@pytest.mark.asyncio
+async def test_reads_isolated_by_barrier(client):
+    await _add(client, "kA", "deskA trade idea NVDA long")
+    await _add(client, "kB", "deskB trade idea NVDA short")
+
+    a_sees = await _recall(client, "kA")
+    assert any("deskA" in c for c in a_sees)
+    assert not any("deskB" in c for c in a_sees)   # cannot cross the wall
+
+    b_sees = await _recall(client, "kB")
+    assert any("deskB" in c for c in b_sees)
+    assert not any("deskA" in c for c in b_sees)
+
+
+@pytest.mark.asyncio
+async def test_unbarriered_key_sees_all(client):
+    await _add(client, "kA", "deskA trade idea NVDA long")
+    await _add(client, "kB", "deskB trade idea NVDA short")
+    c_sees = await _recall(client, "kC")
+    assert any("deskA" in c for c in c_sees) and any("deskB" in c for c in c_sees)

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -23,19 +23,32 @@ User ─▶ Reverse proxy / API gateway ──(OIDC/SAML)──▶ IdP
 This means **no IdP code in Lians**, SSO works with every provider, and revocation
 / MFA / conditional access stay in your IdP where security teams expect them.
 
-## Mapping IdP groups → Lians roles
+## Mapping IdP groups → namespace, role, and barrier
 
-Map IdP group claims to Lians API keys with the matching `role` (see RBAC):
+Each API key carries three things the gateway maps from the IdP group claim:
+`namespace` (tenant), `role` (scopes), and an optional **`barrier_group`** (the
+information-barrier wall). Provision one key per (namespace, role, barrier) and
+have the gateway select it from the authenticated group claim.
 
-| IdP group | Lians role | Effective scopes |
-|-----------|-----------|------------------|
-| `lians-owners` | `owner` | read, write, admin |
-| `lians-analysts` | `analyst` | read, write |
-| `lians-compliance` | `compliance` | read, admin |
-| `lians-viewers` | `readonly` | read |
+| IdP group | namespace | role → scopes | barrier_group |
+|-----------|-----------|---------------|---------------|
+| `acme-equity-research` | `acme` | `analyst` → read, write | `research` |
+| `acme-equity-trading` | `acme` | `analyst` → read, write | `trading` |
+| `acme-compliance` | `acme` | `compliance` → read, admin | _(none — sees all)_ |
+| `acme-viewers` | `acme` | `readonly` → read | `research` |
 
-Provision one API key per (team/namespace, role); the gateway selects the key from
-the authenticated group claim. Rotate keys on role changes; revoke on offboarding.
+When a key has a `barrier_group`, **every read and write under it is scoped to
+that wall at the database layer** (PostgreSQL RLS, migration 0013): a write is
+tagged with the barrier and a read can only see that barrier's rows plus shared
+(NULL-barrier) rows. So `acme-equity-research` and `acme-equity-trading` cannot see
+each other's memories even though they share a namespace — the Chinese wall is
+enforced below the application, driven entirely by the IdP group. A key with no
+`barrier_group` (compliance) sees everything in its namespace.
+
+This makes the **IdP group → namespace + role + barrier** chain end-to-end: the
+identity decision in your IdP determines tenancy, permission, *and* isolation,
+with no identity code in Lians. Rotate keys on role/desk changes; revoke on
+offboarding.
 
 ## Per-tenant isolation
 


### PR DESCRIPTION
Competitive-landscape item #5. Ties the **IdP group → namespace + role + barrier** chain together end to end — with **no identity code in Lians** (SSO stays at the gateway, which picks the key from the caller's group claim).

- `api_keys.barrier_group` column (migration `0017`); `AuthContext.barrier_group`.
- A key's barrier is authoritative: threaded as `barrier_override` through `add_memory` / `add_memory_idempotent` / `recall_memories` / `assemble_context` into `_get_barrier_group`, so **writes are tagged** with the key's barrier and **reads are scoped** to it (app-layer + PostgreSQL RLS `0013`). NULL = unbarriered (compliance sees all).
- **Fixes a latent cache bug** the feature exposed: the working-set + recall caches were keyed by `(namespace, agent_id)` without the barrier, so two keys with different barriers on the same agent collided. Both caches are now bypassed when a key-level barrier is present.
- `docs/sso.md`: the concrete IdP group → namespace/role/barrier mapping table.

`test_sso_barrier.py` (3): write-tagging, cross-barrier read isolation, unbarriered-sees-all. 44 recall-path regression tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)