### PR TITLE
WORM / immutable-storage posture (SEC 17a-4) — flag, endpoint, deploy reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ client.erase(subject_id, request_ref)                    # GDPR crypto-shred
 | `AIRGAP_MODE` | `false` | Hard-fails at startup if any config would send data externally |
 | `ADMISSION_MODE` | `monitor` | Admission control: `off` · `monitor` (tag+audit) · `enforce` (reject injection/blocked source, hold PII/PHI/MNPI for review) |
 | `SIEM_URL` | — | Stream every audit event to a SIEM collector (Splunk HEC / Datadog / Elastic) |
+| `WORM_MODE` | `false` | Attest write-once-read-many storage for SEC 17a-4 (object-locked audit, no UPDATE/DELETE on `event_log`) |
 | `STRIPE_API_KEY` | — | Enables per-namespace usage metering |
 
 Full reference: [agentmem/.env.example](agentmem/.env.example)
@@ -447,7 +448,7 @@ Security & procurement docs: [security-whitepaper.md](docs/security-whitepaper.m
 | Information barriers | `barrier_group` column; PostgreSQL RLS |
 | HIPAA §164.312 | Per-subject encryption, audit controls, transmission security |
 
-Full documentation: [compliance.md](docs/compliance.md) · [hipaa.md](docs/hipaa.md) · [security-whitepaper.md](docs/security-whitepaper.md) · [threat-model.md](docs/threat-model.md) · [soc2-hipaa-readiness.md](docs/soc2-hipaa-readiness.md) · [sso.md](docs/sso.md)
+Full documentation: [compliance.md](docs/compliance.md) · [hipaa.md](docs/hipaa.md) · [security-whitepaper.md](docs/security-whitepaper.md) · [threat-model.md](docs/threat-model.md) · [soc2-hipaa-readiness.md](docs/soc2-hipaa-readiness.md) · [sso.md](docs/sso.md) · [worm-storage.md](docs/worm-storage.md)
 
 Access control: namespace-scoped API keys with `read`/`write`/`admin` scopes and RBAC roles (`owner`/`analyst`/`compliance`/`readonly`); SSO via gateway forward-auth (any OIDC/SAML IdP).
 

--- a/agentmem/src/lians/api/routes_compliance.py
+++ b/agentmem/src/lians/api/routes_compliance.py
@@ -97,6 +97,38 @@ class ComplianceReport(BaseModel):
 
 # ── Route ─────────────────────────────────────────────────────────────────────
 
+@router.get("/compliance/worm")
+async def worm_posture(
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Report the deployment's write-once-read-many (WORM) posture for SEC 17a-4
+    examiners. Combines the *logical* WORM guarantee Lians always provides (an
+    append-only, hash-chained audit log) with the *physical* WORM the operator
+    configures (``WORM_MODE`` true ⇒ object-locked storage + a DB role with no
+    UPDATE/DELETE on the audit tables — see docs/worm-storage.md).
+    """
+    from ..config import get_settings
+    auth.require("read")
+    chain = await verify_chain(db, auth.namespace)
+    worm_mode = get_settings().worm_mode
+    return {
+        "namespace": auth.namespace,
+        "worm_mode": worm_mode,
+        "audit_chain_append_only": True,          # Lians never updates/deletes event_log
+        "audit_chain_status": chain.get("status", "unchecked"),
+        "physical_worm_attested": bool(worm_mode),
+        "standard": "SEC 17a-4(f)",
+        "recommendation": (
+            "compliant posture"
+            if worm_mode else
+            "set WORM_MODE=true and back the audit log with object-locked storage "
+            "+ a DB role lacking UPDATE/DELETE on event_log (docs/worm-storage.md)"
+        ),
+    }
+
+
 @router.get("/compliance/report", response_model=ComplianceReport)
 async def compliance_report(
     from_: Optional[str] = Query(None, alias="from", description="ISO-8601 window start (UTC)"),

--- a/agentmem/src/lians/config.py
+++ b/agentmem/src/lians/config.py
@@ -112,6 +112,13 @@ class Settings(BaseSettings):
     # Comma-separated source labels that are never admitted (e.g. "scraped,unverified").
     admission_blocked_sources: str = ""
 
+    # ── WORM / immutable storage posture ──────────────────────────────────────
+    # Set true when the deployment backs the audit log with write-once-read-many
+    # storage (e.g. S3 Object Lock in Compliance mode + app DB role with no
+    # UPDATE/DELETE on event_log). Surfaced via /v1/compliance/worm for examiners.
+    # See docs/worm-storage.md — this asserts intent; physical WORM is a deploy control.
+    worm_mode: bool = False
+
     # ── Performance roadmap (Changes 3 / 7 / 8) ───────────────────────────────
 
     # Change 3: async LLM adjudication worker.  When True, Stage-3 LLM verdicts

--- a/agentmem/tests/test_worm.py
+++ b/agentmem/tests/test_worm.py
@@ -1,0 +1,63 @@
+"""
+WORM posture endpoint — reports the SEC 17a-4 immutability posture.
+"""
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+
+from httpx import AsyncClient, ASGITransport
+
+from src.lians.main import app
+from src.lians.db import get_db
+from src.lians.models import ApiKey
+
+NS = "worm-ns"
+KEY = "worm-key"
+
+
+@pytest_asyncio.fixture
+async def client(db):
+    db.add(ApiKey(hashed_key=hashlib.sha256(KEY.encode()).hexdigest(),
+                  namespace=NS, scopes=["read"]))
+    await db.commit()
+
+    async def _override():
+        yield db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _h():
+    return {"X-API-Key": KEY}
+
+
+@pytest.mark.asyncio
+async def test_worm_posture_default(client):
+    r = await client.get("/v1/compliance/worm", headers=_h())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["audit_chain_append_only"] is True       # always — Lians never mutates event_log
+    assert body["audit_chain_status"] in ("ok", "unchecked")
+    assert body["worm_mode"] is False                     # not attested by default
+    assert body["physical_worm_attested"] is False
+    assert body["standard"] == "SEC 17a-4(f)"
+    assert "WORM_MODE" in body["recommendation"]
+
+
+@pytest.mark.asyncio
+async def test_worm_posture_attested(client, monkeypatch):
+    monkeypatch.setattr("src.lians.config.get_settings", lambda: SimpleNamespace(worm_mode=True))
+    r = await client.get("/v1/compliance/worm", headers=_h())
+    body = r.json()
+    assert body["worm_mode"] is True
+    assert body["physical_worm_attested"] is True
+    assert body["recommendation"] == "compliant posture"

--- a/docs/worm-storage.md
+++ b/docs/worm-storage.md
@@ -1,0 +1,76 @@
+# WORM / Immutable Storage (SEC 17a-4)
+
+SEC Rule 17a-4(f) requires broker-dealers to preserve records in a **non-rewriteable,
+non-erasable (WORM)** format. Lians gives you two complementary layers; this page is
+the deployment reference for turning them on and attesting the posture to an examiner.
+
+## Two layers of immutability
+
+| Layer | What it is | Provided by |
+|-------|------------|-------------|
+| **Logical WORM** | An append-only, SHA-256 hash-chained audit log. Any edit, reorder, or deletion is detectable with `verify_chain`. | **Lians, always.** The app only ever INSERTs into `event_log`; it never UPDATEs or DELETEs it. |
+| **Physical WORM** | The bytes cannot be rewritten or erased, even by a DBA or storage admin. | **The operator**, via object-locked storage + a restricted DB role. |
+
+Logical WORM proves tampering *happened*; physical WORM prevents it. 17a-4 wants
+both. Query the combined posture at `GET /v1/compliance/worm` and set
+`WORM_MODE=true` once the physical controls below are in place.
+
+## 1. Restrict the application DB role
+
+The app role must not be able to mutate the audit tables. As a superuser/owner:
+
+```sql
+-- Append-only audit: the app may INSERT and SELECT, never UPDATE/DELETE.
+REVOKE UPDATE, DELETE, TRUNCATE ON event_log     FROM lians_app;
+REVOKE UPDATE, DELETE, TRUNCATE ON merkle_anchors FROM lians_app;
+GRANT  INSERT, SELECT             ON event_log     TO lians_app;
+GRANT  INSERT, SELECT             ON merkle_anchors TO lians_app;
+```
+
+Run the app as `lians_app` (a **non-superuser, non-BYPASSRLS** role — the same role
+RLS isolation requires). Now even a compromised app cannot rewrite history.
+
+## 2. Object-locked backups & exports
+
+Send audit exports (`/v1/admin/audit/export`) and database backups to storage with
+**immutability enabled**:
+
+- **AWS S3 Object Lock — Compliance mode** with a retention period ≥ your
+  regulatory window (17a-4 is typically 6 years; the first 2 years readily
+  accessible). Compliance mode cannot be shortened or bypassed, even by the root
+  account.
+- **Azure Blob immutable storage** (time-based retention, locked policy).
+- **GCS bucket lock** (retention policy, locked).
+
+```bash
+aws s3api put-object-lock-configuration --bucket lians-audit \
+  --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=COMPLIANCE,Years=6}}'
+```
+
+Schedule the export + PITR backup to that bucket; the Merkle anchors let you prove
+a batch of audit rows existed at a point in time without trusting the database.
+
+## 3. Attest the posture
+
+```bash
+curl -H "X-API-Key: $KEY" https://lians.internal/v1/compliance/worm
+# { "worm_mode": true, "audit_chain_append_only": true,
+#   "audit_chain_status": "ok", "physical_worm_attested": true,
+#   "standard": "SEC 17a-4(f)", "recommendation": "compliant posture" }
+```
+
+Set `WORM_MODE=true` only after §1 and §2 are actually in place — the flag asserts
+the physical control to examiners; it does not create it.
+
+## 17a-4(f) mapping
+
+| Requirement | Control |
+|-------------|---------|
+| Non-rewriteable, non-erasable | Object Lock (Compliance) + revoked UPDATE/DELETE |
+| Verify automatically the quality/accuracy of the recording | `verify_chain` (SHA-256 chain) + Merkle anchors |
+| Serialize and time-date the records | `event_log` ordered hash chain with timestamps |
+| Readily downloadable | `/v1/admin/audit/export` |
+| Duplicate copy stored separately | Object-locked bucket in a second region/account |
+
+See also [compliance.md](compliance.md), [security-whitepaper.md](security-whitepaper.md),
+and [soc2-hipaa-readiness.md](soc2-hipaa-readiness.md).


### PR DESCRIPTION
Competitive-landscape item #4. SEC 17a-4(f) requires non-rewriteable, non-erasable records. Lians always provides **logical WORM** (append-only, hash-chained audit — the app never UPDATE/DELETEs `event_log`); the operator adds **physical WORM** (object-locked storage + a DB role with no UPDATE/DELETE on the audit tables).

- `WORM_MODE` config flag (attests the physical control is in place).
- `GET /v1/compliance/worm` reports the combined posture: `worm_mode`, `audit_chain_append_only` (always true), live chain status, `SEC 17a-4(f)` standard, and a recommendation.
- `docs/worm-storage.md` — the deployment reference: `REVOKE UPDATE/DELETE` on `event_log`/`merkle_anchors`, S3 Object Lock (Compliance mode) for exports/backups, attestation, and the full 17a-4(f) requirement→control mapping.
- README config row + docs link.

`test_worm.py` (2): default (not attested) and attested postures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)