### PR TITLE
Unify cross-language release + one-page install

### DIFF
--- a/.github/workflows/publish-lian-npm.yml
+++ b/.github/workflows/publish-lian-npm.yml
@@ -3,7 +3,8 @@ name: Publish lians to npm
 on:
   push:
     tags:
-      - "lians-ts-v*"
+      - "v*"            # unified release tag — one `vX.Y.Z` ships every language
+      - "lians-ts-v*"   # TypeScript-only tag (kept for back-compat)
 
 jobs:
   publish:

--- a/.github/workflows/publish-lian.yml
+++ b/.github/workflows/publish-lian.yml
@@ -3,7 +3,8 @@ name: Publish lians to PyPI
 on:
   push:
     tags:
-      - "lians-v*"
+      - "v*"         # unified release tag — one `vX.Y.Z` ships every language
+      - "lians-v*"   # Python-only tag (kept for back-compat)
 
 jobs:
   build:
@@ -44,3 +45,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true   # re-running a release tag is a no-op, not a failure

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
   -
   <a href="https://github.com/Lians-ai/Lians/tree/main/docs">Docs</a>
   -
+  <a href="docs/install.md">Install</a>
+  -
   <a href="https://github.com/Lians-ai/Lians#self-hosted-quickstart">Quickstart</a>
 </p>
 
@@ -344,10 +346,12 @@ healthcare/legal stacks.
 | **Python** | `pip install lians-sdk` | `from lians import LiansClient` | [sdk/python](agentmem/sdk/python) |
 | **TypeScript / Node** | `npm install @lians-ai/lians` | `import { LiansClient } from "@lians-ai/lians"` | [sdk/typescript](agentmem/sdk/typescript) |
 | **Go** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go` | `lians.NewClient(url, key)` | [sdk/go](agentmem/sdk/go) |
-| **Java** (JVM 11+) | `dev.lians:lians-sdk:0.2.0` (Maven) | `new LiansClient(opts)` | [sdk/java](agentmem/sdk/java) |
+| **Java** (JVM 11+) | `dev.lians:lians-sdk:0.3.0` (Maven) | `new LiansClient(opts)` | [sdk/java](agentmem/sdk/java) |
 | **C** (C99 + libcurl) | `cmake --build build` | `lians_client_new(...)` | [sdk/c](agentmem/sdk/c) |
 
-All four cover the same REST API: recall, point-in-time `recall_at`, snapshot,
+→ **One-page install + 30-second quickstart for every language: [docs/install.md](docs/install.md)**
+
+All five cover the same REST API: recall, point-in-time `recall_at`, snapshot,
 backtest, crypto-shred erasure, audit-chain verify, and the relationship graph
 (`relate` / `neighbors` / `path`).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,9 +25,9 @@ Pushing a `vX.Y.Z` tag triggers:
 - Python: `agentmem/sdk/python/pyproject.toml` → `version`
 - TypeScript: `agentmem/sdk/typescript/package.json` → `version`
 - Java: `agentmem/sdk/java/pom.xml` → `<version>`
-- C: `agentmem/sdk/c/src/lians.c` user-agent string
+- C: `agentmem/sdk/c/CMakeLists.txt` → `project(... VERSION ...)` **and** `src/lians.c` user-agent string
 - MCP: `server.json`; Claude plugin: `.claude-plugin/marketplace.json` + `integrations/lians-plugin/.claude-plugin/plugin.json`
-- Go: no file — the tag *is* the version
+- Go: `agentmem/sdk/go/version.go` → `Version` const (the resolvable version is still the git tag)
 
 ## Required secrets / setup (one-time)
 

--- a/agentmem/sdk/c/CMakeLists.txt
+++ b/agentmem/sdk/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(lians_c_sdk C)
+project(lians_c_sdk VERSION 0.3.0 LANGUAGES C)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/agentmem/sdk/go/version.go
+++ b/agentmem/sdk/go/version.go
@@ -1,0 +1,6 @@
+package lians
+
+// Version is the Lians Go SDK release, kept in lock-step with the other language
+// SDKs. The canonical version is the git tag (agentmem/sdk/go/vX.Y.Z); this
+// constant lets programs report the client version at runtime.
+const Version = "0.3.0"

--- a/agentmem/sdk/typescript/README.md
+++ b/agentmem/sdk/typescript/README.md
@@ -1,0 +1,71 @@
+# @lians-ai/lians
+
+**Financial-grade AI memory for TypeScript/Node** — bitemporal facts, SEC 17a-4
+audit chain, GDPR crypto-shred, information barriers. The TypeScript client for
+[Lians](https://github.com/Lians-ai/Lians).
+
+## Install
+
+```bash
+npm install @lians-ai/lians
+# or: pnpm add @lians-ai/lians   /   yarn add @lians-ai/lians
+```
+
+Requires a running Lians server (`docker compose up --build`, or a managed
+endpoint). For zero-setup local prototyping without a server, the Python SDK's
+`LocalLiansClient` (SQLite) is the fastest path.
+
+## Quickstart
+
+```ts
+import { LiansClient } from "@lians-ai/lians";
+
+const client = new LiansClient({
+  baseUrl: "https://mem.yourfirm.internal",
+  apiKey: process.env.LIANS_API_KEY!,
+});
+
+// Write a fact with its event time
+await client.addMemory({
+  agent_id: "equity-desk",
+  content: "NVDA FY2026 revenue guidance raised to $40B",
+  event_time: "2025-11-19T16:00:00Z",
+  metadata: { ticker: "NVDA", metric: "revenue_guidance" },
+});
+
+// Recall — superseded facts are excluded at the DB layer, never reach the LLM
+const { memories } = await client.recall({
+  agent_id: "equity-desk",
+  query: "NVDA revenue guidance",
+});
+
+// GDPR Art. 17 crypto-shred — content becomes unreadable, audit trail survives
+await client.eraseSubject({ subject_id: "subj-123", reason: "GDPR-REQ-1" });
+
+// Point-in-time audit snapshot — what did we know on a past date?
+const snap = await client.snapshot({ agent_id: "equity-desk", as_of: "2025-03-01T00:00:00Z" });
+
+// Backtest lookahead-bias guard — flag facts unknowable at the simulation date
+const report = await client.backtestCheck({ agent_id: "equity-desk", as_of: "2025-01-01T00:00:00Z" });
+```
+
+## What makes Lians different
+
+| Feature | Lians | mem0 | Graphiti/Zep |
+|---------|:----:|:----:|:-----------:|
+| Bitemporal model (event + ingestion time) | ✓ | ✗ | ✓ |
+| Supersession (stale facts excluded at DB layer) | ✓ | ✗ | Partial |
+| SEC 17a-4 tamper-evident audit chain | ✓ | ✗ | ✗ |
+| GDPR crypto-shred with audit survival | ✓ | ✗ | ✗ |
+| Information barriers (PostgreSQL RLS) | ✓ | ✗ | ✗ |
+| Backtest contamination detection | ✓ | ✗ | ✗ |
+
+See the [regulated-eval head-to-head](https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md).
+
+## TypeScript-first
+
+Fully typed: every request and response is a named interface (`MemoryAdd`,
+`RecallRequest`, `RecallResult`, `EraseRequest`, `KnowledgeSnapshot`, …), exported
+from the package root. Errors throw a typed `LiansError` with the HTTP status.
+
+Full documentation: [github.com/Lians-ai/Lians](https://github.com/Lians-ai/Lians)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,124 @@
+# Install Lians
+
+One memory API, five native SDKs, and a self-hostable server. Pick your language —
+every client speaks the same REST API (recall, point-in-time `recall_at`, snapshot,
+backtest, crypto-shred erasure, audit-chain verify, relationship graph).
+
+> **Just want to try it?** The fastest path is Python local mode — no server, no
+> Docker, no API key:
+> ```bash
+> pip install lians-sdk[local]
+> ```
+
+## Install matrix
+
+| Language | Install | Import / entry point |
+|----------|---------|----------------------|
+| **Python** | `pip install lians-sdk` | `from lians import LiansClient` |
+| **Python (local, no server)** | `pip install lians-sdk[local]` | `from lians import LocalLiansClient` |
+| **TypeScript / Node** | `npm install @lians-ai/lians` | `import { LiansClient } from "@lians-ai/lians"` |
+| **Go** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.3.0` | `lians.NewClient(url, key)` |
+| **Java** (JVM 11+) | Maven `dev.lians:lians-sdk:0.3.0` | `new LiansClient(opts)` |
+| **C** (C99 + libcurl) | `cmake -B build && cmake --build build` | `lians_client_new(...)` |
+
+All SDKs are released in lock-step at the **same version** (currently `0.3.0`).
+
+## Run the server
+
+The SDKs (except Python local mode) talk to a Lians server. Self-host it:
+
+```bash
+git clone https://github.com/Lians-ai/Lians
+cd Lians
+docker compose up --build        # Postgres + pgvector + API on :8000
+```
+
+Health check: `curl localhost:8000/livez`. See [DEPLOY.md](../DEPLOY.md) for
+production (KMS, non-superuser DB role for RLS, air-gap mode, WORM storage).
+
+## 30-second hello, by language
+
+### Python (local — no server)
+```python
+from lians import LocalLiansClient
+from datetime import datetime, timezone
+
+mem = LocalLiansClient()
+mem.add(agent_id="desk", content="NVDA guidance raised to $40B",
+        event_time=datetime(2025, 11, 19, tzinfo=timezone.utc),
+        metadata={"ticker": "NVDA", "metric": "guidance"})
+print(mem.recall(agent_id="desk", query="NVDA guidance")["memories"])
+```
+
+### Python (server)
+```python
+from lians import LiansClient
+mem = LiansClient(base_url="https://mem.yourfirm.internal", api_key="...")
+```
+
+### TypeScript / Node
+```ts
+import { LiansClient } from "@lians-ai/lians";
+const client = new LiansClient({ baseUrl: "http://localhost:8000", apiKey: process.env.LIANS_API_KEY! });
+await client.addMemory({ agent_id: "desk", content: "NVDA guidance raised to $40B",
+                         event_time: "2025-11-19T16:00:00Z", metadata: { ticker: "NVDA" } });
+const { memories } = await client.recall({ agent_id: "desk", query: "NVDA guidance" });
+```
+
+### Go
+```go
+import "github.com/Lians-ai/Lians/agentmem/sdk/go"
+
+c := lians.NewClient("http://localhost:8000", os.Getenv("LIANS_API_KEY"))
+_, _ = c.AddMemory(ctx, lians.AddMemoryRequest{
+    AgentID: "desk", Content: "NVDA guidance raised to $40B",
+    EventTime: time.Date(2025, 11, 19, 16, 0, 0, 0, time.UTC),
+    Metadata: map[string]any{"ticker": "NVDA"},
+})
+```
+
+### Java
+```xml
+<dependency>
+  <groupId>dev.lians</groupId>
+  <artifactId>lians-sdk</artifactId>
+  <version>0.3.0</version>
+</dependency>
+```
+```java
+var client = new LiansClient(LiansOptions.builder()
+        .baseUrl("http://localhost:8000").apiKey(System.getenv("LIANS_API_KEY")).build());
+```
+
+### C
+```bash
+cd agentmem/sdk/c && cmake -B build && cmake --build build   # needs libcurl
+```
+```c
+#include "lians.h"
+lians_client *c = lians_client_new("http://localhost:8000", getenv("LIANS_API_KEY"));
+```
+
+## MCP — use Lians as a native tool
+
+Any MCP host (Claude Desktop, Cursor, Windsurf) can use Lians directly. See the
+[MCP section of the README](../README.md#mcp---native-tool-in-any-ai-client).
+
+## Framework integrations (Python)
+
+```bash
+pip install lians-sdk[langchain]    # LangChain chat history & tools
+pip install lians-sdk[langgraph]    # LangGraph node factories
+pip install lians-sdk[crewai]       # CrewAI tools
+pip install lians-sdk[all]          # everything
+```
+
+## Verify a release
+
+```bash
+pip install lians-sdk==0.3.0
+npm view @lians-ai/lians version
+go list -m github.com/Lians-ai/Lians/agentmem/sdk/go@v0.3.0
+```
+
+Maintainers: see [RELEASING.md](../RELEASING.md) — one `vX.Y.Z` tag ships all five.


### PR DESCRIPTION
## What

**Fixes a release trap.** RELEASING.md claims one `vX.Y.Z` tag ships all five SDKs, but the PyPI/npm publish workflows only triggered on `lians-v*` / `lians-ts-v*`. Pushing `v0.3.0` today would ship Java/C/Go and **silently skip Python and npm**. Now `publish-lian.yml` and `publish-lian-npm.yml` also trigger on `v*` (old tags kept for back-compat), so one tag genuinely releases all five. PyPI gains `skip-existing` so re-tagging is a no-op.

**Version lock-step at 0.3.0.** C `CMakeLists project(VERSION 0.3.0)`; new Go `version.go` const; README table Java `0.2.0 → 0.3.0` and "All four" → "All five"; RELEASING.md version-locations updated.

**Ease of access.** New `docs/install.md` — one-page install matrix + 30-second hello for the server and all five languages, linked from the README header and SDK section. New TypeScript SDK README (the only SDK that lacked one).

## Not in this PR
Does **not** push the actual `v0.3.0` release tag — that publishes to public registries (irreversible) and needs your go-ahead + registry secrets configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)