### PR TITLE
Competitor learnings: materiality decay, degraded recall, conflict resurfacing, signed MD export, pre-compaction flush

### DIFF
--- a/agentmem/sdk/python/lians/__init__.py
+++ b/agentmem/sdk/python/lians/__init__.py
@@ -48,6 +48,7 @@ from .sync_client import LiansClient
 from .client import AsyncLiansClient
 from .harness import (
     LiansMemoryHarness,
+    CompactionGuard,
     RecalledMemory,
     TurnResult,
     MemoryClient,
@@ -73,6 +74,7 @@ __all__ = [
     "LocalLiansClient",
     # Agent harness
     "LiansMemoryHarness",
+    "CompactionGuard",
     "RecalledMemory",
     "TurnResult",
     "MemoryClient",

--- a/agentmem/sdk/python/lians/autogen_integration.py
+++ b/agentmem/sdk/python/lians/autogen_integration.py
@@ -43,11 +43,12 @@ Usage — ConversableAgent (AutoGen v0.2 / classic)::
         function_map=function_map,
     )
 
-Three tools are returned by build_autogen_tools():
+Four tools are returned by build_autogen_tools():
 
 - ``agentmem_remember``    — store a fact with event timestamp and metadata
 - ``agentmem_recall``      — retrieve current facts by semantic search
 - ``agentmem_recall_at``   — retrieve facts valid at a specific past date (compliance)
+- ``agentmem_flush``       — batch-persist durable facts before context compaction
 
 The ``agentmem_recall_at`` tool supports AutoGen multi-agent compliance workflows:
 "What did the risk-assessment agent know before the trade was placed?" — with a
@@ -184,10 +185,47 @@ def build_autogen_tools(client: Any, agent_id: str) -> list:
             result = client.recall(agent_id=agent_id, query=query, k=k, as_of=as_of)
         return f"Facts valid as of {as_of_iso[:10]}:\n{_fmt(result.get('memories', []))}"
 
+    async def agentmem_flush(facts_json: str) -> str:
+        """
+        Persist a batch of durable facts NOW, before context compaction.
+
+        Call when the conversation is about to be summarized or truncated —
+        anything not written here may be lost when older turns are compacted
+        away. Extract the facts worth keeping (decisions, constraints, client
+        instructions, corrections, commitments), not chit-chat. Each write is
+        tagged as a pre-compaction flush in the tamper-evident audit chain.
+
+        :param facts_json: JSON array of fact strings.
+            Example: '["Client approved the Q3 rebalance",
+            "Compliance: no tobacco exposure"]'
+        """
+        from datetime import timezone
+        facts = json.loads(facts_json) if isinstance(facts_json, str) else facts_json
+        now = datetime.now(timezone.utc)
+        written = 0
+        for fact in facts or []:
+            text = str(fact).strip()
+            if not text:
+                continue
+            kwargs: dict[str, Any] = dict(
+                agent_id=agent_id,
+                content=text,
+                event_time=now,
+                metadata={"_flush": "pre_compaction"},
+                source="autogen_flush",
+            )
+            if _is_async:
+                await client.add(**kwargs)
+            else:
+                client.add(**kwargs)
+            written += 1
+        return f"Flushed {written} durable fact(s) to memory before compaction."
+
     return [
         FunctionTool(agentmem_remember, description=agentmem_remember.__doc__ or ""),
         FunctionTool(agentmem_recall,   description=agentmem_recall.__doc__ or ""),
         FunctionTool(agentmem_recall_at, description=agentmem_recall_at.__doc__ or ""),
+        FunctionTool(agentmem_flush,    description=agentmem_flush.__doc__ or ""),
     ]
 
 

--- a/agentmem/sdk/python/lians/crewai_integration.py
+++ b/agentmem/sdk/python/lians/crewai_integration.py
@@ -23,11 +23,12 @@ Usage::
         llm=my_llm,
     )
 
-Three tools are returned:
+Four tools are returned:
 
 - ``remember_fact``   — store a financial fact with its event timestamp
 - ``recall_facts``    — retrieve current memories by semantic search
 - ``recall_facts_at`` — retrieve memories valid at a specific past date (compliance)
+- ``flush_memory``    — batch-persist durable facts before context compaction
 
 The ``recall_facts_at`` tool queries memories as they were at a specific past date.
 mem0 has no bitemporal model. Graphiti/Zep has temporal graph queries but no
@@ -209,4 +210,45 @@ def build_crewai_tools(client: Any, agent_id: str) -> list:
             result = client.recall(agent_id=agent_id, query=query, k=k, as_of=as_of)
             return f"Memories valid as of {as_of_iso[:10]}:\n{_fmt(result.get('memories', []))}"
 
-    return [RememberFact(), RecallFacts(), RecallFactsAt()]
+    class _FlushInput(BaseModel):
+        facts_json: str = Field(
+            ...,
+            description=(
+                "JSON array of durable fact strings to persist before compaction. "
+                "Example: '[\"Client approved the Q3 rebalance\", "
+                "\"Compliance: no tobacco exposure\"]'"
+            ),
+        )
+
+    class FlushMemory(BaseTool):
+        name: str = "flush_memory"
+        description: str = (
+            "Persist a batch of durable facts NOW, before the conversation is "
+            "summarized or truncated. Anything not written here may be lost when "
+            "older turns are compacted away. Extract the facts worth keeping — "
+            "decisions, constraints, client instructions, corrections, commitments — "
+            "not chit-chat. Each write is tagged as a pre-compaction flush in the "
+            "tamper-evident audit chain."
+        )
+        args_schema: type[BaseModel] = _FlushInput
+
+        def _run(self, facts_json: str) -> str:
+            from datetime import timezone
+            facts = json.loads(facts_json) if isinstance(facts_json, str) else facts_json
+            now = datetime.now(timezone.utc)
+            written = 0
+            for fact in facts or []:
+                text = str(fact).strip()
+                if not text:
+                    continue
+                client.add(
+                    agent_id=agent_id,
+                    content=text,
+                    event_time=now,
+                    metadata={"_flush": "pre_compaction"},
+                    source="crewai_flush",
+                )
+                written += 1
+            return f"Flushed {written} durable fact(s) to memory before compaction."
+
+    return [RememberFact(), RecallFacts(), RecallFactsAt(), FlushMemory()]

--- a/agentmem/sdk/python/lians/harness.py
+++ b/agentmem/sdk/python/lians/harness.py
@@ -475,6 +475,93 @@ class LiansMemoryHarness:
             raise ValueError("no subject_id to erase (set one on the harness or pass it)")
         return self.client.erase(subject_id=sid, request_ref=request_ref)  # type: ignore[attr-defined]
 
+    # ── Pre-compaction flush ──────────────────────────────────────────────────
+
+    def flush_before_compaction(
+        self,
+        messages: Optional[Sequence[dict[str, Any]]] = None,
+        *,
+        facts: Optional[Sequence[str]] = None,
+        extract: Optional[Callable[[str], Sequence[str]]] = None,
+        roles: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        importance: Optional[float] = None,
+        event_time: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        """
+        Persist durable facts NOW, before the host framework compacts or
+        summarizes the conversation out of existence.
+
+        Long-running agents lose granular facts at the context cliff: the
+        framework summarizes old turns, and whatever the summary drops is gone.
+        Call this when the conversation nears its context limit (see
+        :class:`CompactionGuard` for automatic tracking) so the durable facts
+        cross into governed memory first. Every write is tagged
+        ``_flush: "pre_compaction"``, so the audit chain shows *when* the agent
+        externalized what it knew — the flush itself is evidence.
+
+        Provide exactly one source of facts, checked in this order:
+
+        ``facts``
+            Pre-extracted durable facts — one write per string.
+        ``extract`` + ``messages``
+            ``extract(transcript_text)`` returns the facts to write. Pass an
+            LLM-backed extractor here to reproduce OpenClaw's "silent agentic
+            turn" with your own model.
+        ``messages``
+            Fallback: persists messages whose role is in ``roles`` (default:
+            assistant) via :meth:`remember_messages`, or one :meth:`remember`
+            per message when the client lacks ``add_from_messages``.
+
+        Returns ``{"flushed": <n writes>, "mode": <facts|extract|messages>}``.
+        """
+        meta = dict(metadata or {})
+        meta.setdefault("_flush", "pre_compaction")
+
+        if facts is not None:
+            written = 0
+            for fact in facts:
+                if fact and str(fact).strip():
+                    self.remember(
+                        str(fact), metadata=meta,
+                        importance=importance, event_time=event_time,
+                    )
+                    written += 1
+            return {"flushed": written, "mode": "facts"}
+
+        if messages is None:
+            raise ValueError("flush_before_compaction needs `facts` or `messages`")
+
+        if extract is not None:
+            transcript = "\n".join(
+                f"{m.get('role', '?')}: {m.get('content', '')}" for m in messages
+            )
+            extracted = [f for f in (extract(transcript) or []) if f and str(f).strip()]
+            for fact in extracted:
+                self.remember(
+                    str(fact), metadata=meta,
+                    importance=importance, event_time=event_time,
+                )
+            return {"flushed": len(extracted), "mode": "extract"}
+
+        wanted = roles or ["assistant"]
+        if hasattr(self.client, "add_from_messages"):
+            self.remember_messages(
+                messages, metadata=meta, importance=importance,
+                event_time=event_time, roles=wanted,
+            )
+            written = sum(1 for m in messages if m.get("role") in wanted and m.get("content"))
+        else:
+            written = 0
+            for m in messages:
+                if m.get("role") in wanted and m.get("content"):
+                    self.remember(
+                        str(m["content"]), metadata=meta,
+                        importance=importance, event_time=event_time,
+                    )
+                    written += 1
+        return {"flushed": written, "mode": "messages"}
+
     # ── Internal ──────────────────────────────────────────────────────────────
 
     def _scoped_metadata(self, extra: Optional[dict[str, Any]]) -> dict[str, Any]:
@@ -503,6 +590,104 @@ class LiansMemoryHarness:
             raise AttributeError(
                 f"client does not support `{attr}` — use a hosted/local Lians client"
             )
+
+
+# ── Compaction guard ───────────────────────────────────────────────────────────
+
+
+def _estimate_tokens(text: str) -> int:
+    """Cheap token estimate (~4 chars/token) — matches the server's budgeting."""
+    return max(1, len(text) // 4)
+
+
+class CompactionGuard:
+    """
+    Track conversation size and flush durable facts before the context cliff.
+
+    Wire it into any agent loop: call :meth:`observe` with each turn's text (or
+    :meth:`observe_messages` with the running message list), and when the
+    estimated usage crosses ``threshold`` × ``context_limit_tokens`` the guard
+    fires :meth:`LiansMemoryHarness.flush_before_compaction` — once — then
+    waits for :meth:`reset` (call it after the host framework actually
+    compacts/summarizes).
+
+    Example::
+
+        guard = CompactionGuard(harness, context_limit_tokens=128_000)
+
+        for turn in conversation:
+            ...
+            flushed = guard.observe_and_maybe_flush(messages)
+            if flushed:
+                log.info("pre-compaction flush wrote %s facts", flushed["flushed"])
+    """
+
+    def __init__(
+        self,
+        harness: LiansMemoryHarness,
+        *,
+        context_limit_tokens: int,
+        threshold: float = 0.8,
+        estimate: Callable[[str], int] = _estimate_tokens,
+        extract: Optional[Callable[[str], Sequence[str]]] = None,
+        roles: Optional[list[str]] = None,
+    ) -> None:
+        if context_limit_tokens <= 0:
+            raise ValueError("context_limit_tokens must be positive")
+        if not 0.0 < threshold <= 1.0:
+            raise ValueError("threshold must be in (0, 1]")
+        self.harness = harness
+        self.context_limit_tokens = context_limit_tokens
+        self.threshold = threshold
+        self.estimate = estimate
+        self.extract = extract
+        self.roles = roles
+        self.used_tokens = 0
+        self._flushed_this_window = False
+
+    def observe(self, *texts: str) -> None:
+        """Accumulate token usage for ad-hoc text (prompts, responses, tools)."""
+        for t in texts:
+            if t:
+                self.used_tokens += self.estimate(str(t))
+
+    def observe_messages(self, messages: Sequence[dict[str, Any]]) -> None:
+        """Set usage from a full running message list (idempotent per call)."""
+        self.used_tokens = sum(
+            self.estimate(str(m.get("content", ""))) for m in messages if m.get("content")
+        )
+
+    def should_flush(self) -> bool:
+        return (
+            not self._flushed_this_window
+            and self.used_tokens >= self.threshold * self.context_limit_tokens
+        )
+
+    def observe_and_maybe_flush(
+        self,
+        messages: Sequence[dict[str, Any]],
+        **flush_kwargs: Any,
+    ) -> Optional[dict[str, Any]]:
+        """
+        One-call loop hook: update usage from ``messages`` and flush if the
+        window crossed the threshold. Returns the flush result, or None.
+        """
+        self.observe_messages(messages)
+        if not self.should_flush():
+            return None
+        result = self.harness.flush_before_compaction(
+            messages,
+            extract=flush_kwargs.pop("extract", self.extract),
+            roles=flush_kwargs.pop("roles", self.roles),
+            **flush_kwargs,
+        )
+        self._flushed_this_window = True
+        return result
+
+    def reset(self) -> None:
+        """Call after the host framework compacts — starts a fresh window."""
+        self.used_tokens = 0
+        self._flushed_this_window = False
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────

--- a/agentmem/sdk/python/lians/langgraph_integration.py
+++ b/agentmem/sdk/python/lians/langgraph_integration.py
@@ -244,6 +244,85 @@ def create_batch_remember_node(
     return _batch_node
 
 
+def create_flush_node(
+    client: Any,
+    agent_id: str,
+    *,
+    messages_key: str = "messages",
+    context_limit_tokens: int = 128_000,
+    threshold: float = 0.8,
+    roles: tuple = ("assistant",),
+    result_key: str = "compaction_flush",
+):
+    """
+    Create a LangGraph node that flushes durable facts before context compaction.
+
+    Long-running graphs lose granular facts at the context cliff: the framework
+    summarizes old turns and whatever the summary drops is gone. Insert this
+    node before your summarize/compact step (or on every loop iteration — it
+    only fires past the threshold). It estimates token usage of
+    ``state[messages_key]``; once usage crosses ``threshold × context_limit_
+    tokens``, each not-yet-empty message with a role in ``roles`` is persisted,
+    tagged ``_flush: "pre_compaction"`` so the audit chain shows when the agent
+    externalized what it knew.
+
+    Writes ``state[result_key]`` with ``{"flushed": n}`` (``{"flushed": 0}``
+    when under the threshold).
+
+    Works with both sync and async Lians clients. Messages may be dicts
+    (``{"role", "content"}``) or LangChain message objects (``.type``/
+    ``.content``).
+    """
+    _add_is_async = asyncio.iscoroutinefunction(getattr(client, "add", None))
+
+    def _role(m: Any) -> str:
+        if isinstance(m, dict):
+            return str(m.get("role", ""))
+        # LangChain message objects: .type is "ai" / "human" / "system"
+        t = str(getattr(m, "type", ""))
+        return {"ai": "assistant", "human": "user"}.get(t, t)
+
+    def _content(m: Any) -> str:
+        raw = m.get("content", "") if isinstance(m, dict) else getattr(m, "content", "")
+        return raw if isinstance(raw, str) else str(raw)
+
+    async def _flush_node(state: dict) -> dict:
+        messages = state.get(messages_key) or []
+        used = sum(max(1, len(_content(m)) // 4) for m in messages if _content(m))
+        if used < threshold * context_limit_tokens:
+            return {result_key: {"flushed": 0}}
+
+        now = datetime.now(timezone.utc)
+        flushed = 0
+        for m in messages:
+            if _role(m) not in roles:
+                continue
+            content = _content(m)
+            if not content.strip():
+                continue
+            kwargs: dict[str, Any] = dict(
+                agent_id=agent_id,
+                content=content,
+                event_time=now,
+                metadata={"_flush": "pre_compaction"},
+                source="langgraph_flush",
+            )
+            if _add_is_async:
+                await client.add(**kwargs)
+            else:
+                # Sync clients (e.g. LocalLiansClient) drive their own event
+                # loop internally — calling them on this thread would raise
+                # "Cannot run the event loop while another loop is running".
+                await asyncio.get_event_loop().run_in_executor(
+                    None, lambda kw=kwargs: client.add(**kw)
+                )
+            flushed += 1
+
+        return {result_key: {"flushed": flushed}}
+
+    return _flush_node
+
+
 # ── Typed state helper ────────────────────────────────────────────────────────
 
 def format_memories_for_prompt(memories: list[dict]) -> str:

--- a/agentmem/sdk/python/lians/openai_agents_integration.py
+++ b/agentmem/sdk/python/lians/openai_agents_integration.py
@@ -26,11 +26,12 @@ Usage::
     )
     result = await Runner.run(agent, "What guidance did NVDA give last quarter?")
 
-Three tools are returned:
+Four tools are returned:
 
 - ``agentmem_remember``       — store a fact with its event timestamp and metadata
 - ``agentmem_recall``         — retrieve current facts by semantic search
 - ``agentmem_recall_at``      — retrieve facts valid at a specific past date (compliance)
+- ``agentmem_flush``          — batch-persist durable facts before context compaction
 
 The ``agentmem_recall_at`` tool is the compliance differentiator:
 it answers "what did the model know before the trade?" with a verifiable,
@@ -177,4 +178,43 @@ def build_openai_agent_tools(client: Any, agent_id: str) -> list:
         result = client.recall(agent_id=agent_id, query=query, k=k, as_of=as_of)
         return f"Facts valid as of {as_of_iso[:10]}:\n{_fmt(result.get('memories', []))}"
 
-    return [agentmem_remember, agentmem_recall, agentmem_recall_at]
+    @function_tool
+    def agentmem_flush(facts_json: str) -> str:
+        """
+        Persist a batch of durable facts NOW, before context compaction.
+
+        Call this when the conversation is about to be summarized or truncated
+        (or when instructed that the context window is nearly full). Anything
+        not written here may be lost when older turns are compacted away.
+        Review the conversation and extract the facts worth keeping: decisions
+        made, constraints learned, client instructions, corrections, and
+        commitments — not chit-chat.
+
+        Each write is tagged as a pre-compaction flush in the tamper-evident
+        audit chain, so it is provable when the agent externalized what it knew.
+
+        Parameters
+        ----------
+        facts_json:
+            JSON array of fact strings.
+            Example: '["Client approved the Q3 rebalance on 2026-07-01",
+            "Compliance: no tobacco exposure in any account"]'
+        """
+        facts = json.loads(facts_json) if isinstance(facts_json, str) else facts_json
+        now = datetime.now(timezone.utc)
+        written = 0
+        for fact in facts or []:
+            text = str(fact).strip()
+            if not text:
+                continue
+            client.add(
+                agent_id=agent_id,
+                content=text,
+                event_time=now,
+                metadata={"_flush": "pre_compaction"},
+                source="openai_agents_flush",
+            )
+            written += 1
+        return f"Flushed {written} durable fact(s) to memory before compaction."
+
+    return [agentmem_remember, agentmem_recall, agentmem_recall_at, agentmem_flush]

--- a/agentmem/src/lians/api/routes_snapshot.py
+++ b/agentmem/src/lians/api/routes_snapshot.py
@@ -10,13 +10,16 @@ Different from /v1/recall (vector search → top-k relevant):
   SEC examiners don't want "the most relevant 5 memories" — they want everything.
 """
 from datetime import datetime, timezone
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import PlainTextResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import get_db
-from ..schemas import KnowledgeSnapshot
+from ..schemas import KnowledgeSnapshot, MarkdownExportResult
 from ..memory_service import get_knowledge_snapshot
+from ..export_markdown import export_memory_markdown
 from .deps import get_auth, AuthContext
 
 router = APIRouter(prefix="/v1", tags=["snapshot"])
@@ -66,3 +69,38 @@ async def knowledge_snapshot(
         total=len(items),
         items=items,
     )
+
+
+@router.get("/snapshot/markdown")
+async def snapshot_markdown(
+    agent_id: str = Query(..., description="Agent whose memory statement to render"),
+    as_of: Optional[datetime] = Query(
+        None,
+        description="Point-in-time checkpoint (ISO 8601 UTC). Default: now.",
+    ),
+    limit: int = Query(1000, ge=1, le=10000),
+    raw: bool = Query(
+        False,
+        description="Return the bare Markdown document (text/markdown) instead of JSON.",
+    ),
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Render the agent's complete point-in-time knowledge state as a signed,
+    human-readable Markdown document.
+
+    Same exhaustive fact set as `/v1/snapshot`, formatted for humans: YAML
+    frontmatter, one section per fact with provenance, validity window, and
+    materiality; erased facts appear as explicit erasure markers. The document's
+    SHA-256 is written into the tamper-evident audit chain as an
+    `export_markdown` event, and the footer states the hash, the anchoring
+    event, and the verification procedure — an examiner (or a skeptical
+    developer) can read exactly what the system knows and prove the statement
+    was not altered after generation.
+    """
+    auth.require("read")
+    result = await export_memory_markdown(db, auth.namespace, agent_id, as_of, limit)
+    if raw:
+        return PlainTextResponse(result.markdown, media_type="text/markdown; charset=utf-8")
+    return MarkdownExportResult.model_validate(result)

--- a/agentmem/src/lians/export_markdown.py
+++ b/agentmem/src/lians/export_markdown.py
@@ -1,0 +1,169 @@
+"""
+Signed human-readable memory export.
+
+Renders an agent's complete point-in-time knowledge state (the same exhaustive
+set /v1/snapshot returns) as a Markdown document with YAML frontmatter — the
+transparency developers love about file-based memory systems, produced from a
+store that keeps encryption, barriers, and bitemporal correctness underneath.
+
+The document is anchored in the tamper-evident audit chain: its SHA-256 is
+written as the ``content_hash`` of an ``export_markdown`` event, so the hash is
+part of the chain's canonical fields and any later edit to the document (or to
+the event) is detectable by ``verify_chain``. A footer states the hash, the
+anchoring event, and the verification procedure.
+
+Verification procedure (also stated in the footer):
+  1. Remove the final integrity comment block (everything from the line
+     ``<!-- lians:integrity`` to the end of the file).
+  2. SHA-256 the remaining bytes (UTF-8) — must equal ``document_sha256``.
+  3. Confirm the audit chain holds an ``export_markdown`` event whose
+     ``content_hash`` equals ``document_sha256`` and whose ``row_hash`` matches.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .audit_chain import chain_log
+from .schemas import MarkdownExportResult, MemoryOut
+
+_FORMAT = "lians-memory-export/v1"
+_INTEGRITY_MARK = "<!-- lians:integrity"
+
+
+def _stamp(dt: Optional[datetime]) -> str:
+    if dt is None:
+        return "null"
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _render_memory(m: MemoryOut) -> list[str]:
+    lines = [f"## {_stamp(m.event_time)}" + (f" — {m.source}" if m.source else "")]
+    if m.content is not None:
+        lines.append("")
+        lines.append(m.content)
+    elif m.erased_at is not None:
+        lines.append("")
+        lines.append("*[ERASED — content crypto-shredded; existence and metadata preserved]*")
+    else:
+        lines.append("")
+        lines.append("*[content unavailable — subject key not accessible]*")
+    lines.append("")
+    lines.append(f"- id: `{m.id}`")
+    lines.append(f"- content_hash: `{m.content_hash}`")
+    valid_to = _stamp(m.valid_to) if m.valid_to else "(open)"
+    lines.append(f"- valid: {_stamp(m.valid_from)} → {valid_to}")
+    if m.subject_id:
+        lines.append(f"- subject: `{m.subject_id}`")
+    if m.barrier_group:
+        lines.append(f"- barrier_group: `{m.barrier_group}`")
+    materiality = (m.metadata or {}).get("materiality")
+    if materiality:
+        lines.append(f"- materiality: {materiality}")
+    if m.superseded_by:
+        lines.append(f"- superseded_by: `{m.superseded_by}`")
+    if m.erased_at:
+        lines.append(f"- erased_at: {_stamp(m.erased_at)}")
+    lines.append("")
+    return lines
+
+
+async def export_memory_markdown(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    as_of: Optional[datetime] = None,
+    limit: int = 1000,
+) -> MarkdownExportResult:
+    """Render, hash, chain-anchor, and return the memory statement."""
+    from .memory_service import get_knowledge_snapshot
+
+    generated_at = datetime.now(timezone.utc)
+    effective_as_of = as_of or generated_at
+    items = await get_knowledge_snapshot(db, namespace, agent_id, effective_as_of, limit)
+
+    lines: list[str] = [
+        "---",
+        f"format: {_FORMAT}",
+        f"namespace: {namespace}",
+        f"agent_id: {agent_id}",
+        f"as_of: {_stamp(effective_as_of)}",
+        f"generated_at: {_stamp(generated_at)}",
+        f"memory_count: {len(items)}",
+        "---",
+        "",
+        f"# Memory statement — `{agent_id}` as of {_stamp(effective_as_of)}",
+        "",
+        f"Every fact valid at the stated time, oldest first ({len(items)} total). "
+        "Erased facts appear as erasure markers — existence is preserved, content is unrecoverable.",
+        "",
+    ]
+    for m in items:
+        lines.extend(_render_memory(m))
+
+    body = "\n".join(lines)
+    document_sha256 = hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    event = await chain_log(
+        db, namespace=namespace, agent_id=agent_id,
+        op="export_markdown",
+        content_hash=document_sha256,
+        payload={
+            "format": _FORMAT,
+            "as_of": _stamp(effective_as_of),
+            "memory_count": len(items),
+        },
+    )
+    await db.commit()
+
+    footer = "\n".join([
+        "",
+        _INTEGRITY_MARK,
+        f"document_sha256: {document_sha256}",
+        f"audit_event_id: {event.id}",
+        f"audit_row_hash: {event.row_hash}",
+        "verify: remove this comment block (from the '" + _INTEGRITY_MARK + "' line to EOF),",
+        "SHA-256 the remaining UTF-8 bytes, compare with document_sha256, then confirm the",
+        "audit chain holds an export_markdown event with this content_hash and row_hash.",
+        "-->",
+        "",
+    ])
+
+    return MarkdownExportResult(
+        markdown=body + footer,
+        document_sha256=document_sha256,
+        audit_event_id=event.id,
+        audit_row_hash=event.row_hash or "",
+        namespace=namespace,
+        agent_id=agent_id,
+        as_of=effective_as_of,
+        generated_at=generated_at,
+        memory_count=len(items),
+    )
+
+
+def strip_integrity_footer(markdown: str) -> str:
+    """Return the hashable body — everything before the integrity comment."""
+    idx = markdown.rfind("\n" + _INTEGRITY_MARK)
+    return markdown[:idx] if idx != -1 else markdown
+
+
+def verify_export_document(markdown: str) -> tuple[str, Optional[str]]:
+    """
+    Recompute the document hash and read the stated one from the footer.
+
+    Returns ``(recomputed_sha256, stated_sha256)`` — equal for an untampered
+    document. Chain-side confirmation still requires the audit log.
+    """
+    body = strip_integrity_footer(markdown)
+    recomputed = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    stated: Optional[str] = None
+    for line in markdown.splitlines():
+        if line.startswith("document_sha256:"):
+            stated = line.split(":", 1)[1].strip()
+    return recomputed, stated

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -433,6 +433,60 @@ def _estimate_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
 
+async def _agent_open_conflicts(
+    db: AsyncSession,
+    namespace: str,
+    agent_id: str,
+    limit: int,
+) -> tuple[list[ConflictFlagOut], int]:
+    """
+    Open conflicts for one agent, oldest first (the longest-unresolved conflict
+    is the most overdue), plus the total open count. Backs the active-resurfacing
+    section of ``assemble_context``.
+    """
+    from sqlalchemy import func
+
+    conds = and_(
+        ConflictFlag.namespace == namespace,
+        ConflictFlag.agent_id == agent_id,
+        ConflictFlag.status == "open",
+    )
+    total = (await db.execute(select(func.count()).select_from(ConflictFlag).where(conds))).scalar() or 0
+    if total == 0:
+        return [], 0
+
+    flags = (await db.execute(
+        select(ConflictFlag).where(conds).order_by(ConflictFlag.detected_at.asc()).limit(limit)
+    )).scalars().all()
+
+    subject_keys = await _load_namespace_subject_keys(db, namespace)
+    from .ranking import _decrypt
+
+    out: list[ConflictFlagOut] = []
+    for flag in flags:
+        mem_a = await db.get(Memory, flag.memory_a_id)
+        mem_b = await db.get(Memory, flag.memory_b_id)
+        out.append(ConflictFlagOut(
+            id=flag.id,
+            namespace=flag.namespace,
+            agent_id=flag.agent_id,
+            memory_a_id=flag.memory_a_id,
+            memory_b_id=flag.memory_b_id,
+            memory_a_content=_decrypt(mem_a, subject_keys) if mem_a else None,
+            memory_b_content=_decrypt(mem_b, subject_keys) if mem_b else None,
+            memory_a_source=mem_a.source if mem_a else None,
+            memory_b_source=mem_b.source if mem_b else None,
+            memory_a_event_time=mem_a.event_time if mem_a else flag.detected_at,
+            memory_b_event_time=mem_b.event_time if mem_b else flag.detected_at,
+            confidence=flag.confidence,
+            detected_at=flag.detected_at,
+            status=flag.status,
+            resolved_at=flag.resolved_at,
+            resolver_note=flag.resolver_note,
+        ))
+    return out, int(total)
+
+
 async def assemble_context(
     db: AsyncSession,
     namespace: str,
@@ -448,6 +502,11 @@ async def assemble_context(
     Facts are included in relevance order until ``max_tokens`` is reached; each
     line carries event-time and source so the model can reason about recency and
     provenance. Erased (crypto-shredded) facts are skipped.
+
+    Active resurfacing: open conflicts for this agent push to the top of the
+    block (oldest first — they cannot silently age out) until a human
+    adjudicates them, so the model treats contested facts as contested rather
+    than confidently using whichever version recall happened to rank higher.
     """
     from .schemas import ContextResult
     filters: dict[str, Any] = {}
@@ -460,6 +519,32 @@ async def assemble_context(
 
     lines = [req.header]
     used = _estimate_tokens(req.header)
+
+    open_conflicts: list[ConflictFlagOut] = []
+    open_conflicts_total = 0
+    if req.surface_conflicts and req.max_conflicts > 0:
+        open_conflicts, open_conflicts_total = await _agent_open_conflicts(
+            db, namespace, req.agent_id, req.max_conflicts
+        )
+    if open_conflicts:
+        banner = "⚠ UNRESOLVED MEMORY CONFLICTS — contested facts, pending adjudication:"
+        lines.append(banner)
+        used += _estimate_tokens(banner)
+        for c in open_conflicts:
+            a_stamp = c.memory_a_event_time.isoformat()[:16].replace("T", " ")
+            b_stamp = c.memory_b_event_time.isoformat()[:16].replace("T", " ")
+            a_src = f" [{c.memory_a_source}]" if c.memory_a_source else ""
+            b_src = f" [{c.memory_b_source}]" if c.memory_b_source else ""
+            line = (
+                f"- ({a_stamp}){a_src} \"{c.memory_a_content}\" DISAGREES WITH "
+                f"({b_stamp}){b_src} \"{c.memory_b_content}\""
+            )
+            lines.append(line)
+            used += _estimate_tokens(line)
+        if open_conflicts_total > len(open_conflicts):
+            more = f"  (+{open_conflicts_total - len(open_conflicts)} more open conflicts not shown)"
+            lines.append(more)
+            used += _estimate_tokens(more)
     included: list = []
     truncated = False
     for m in result.memories:
@@ -482,6 +567,8 @@ async def assemble_context(
         token_estimate=used,
         truncated=truncated,
         retrieval_degraded=result.retrieval_degraded,
+        open_conflicts=open_conflicts,
+        open_conflicts_total=open_conflicts_total,
     )
 
 

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import logging
 import math
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -46,6 +47,8 @@ from .config import get_settings
 from .current_facts import compute_predicate_key, upsert_live_fact, remove_live_facts, keyed_lookup
 from .dek_cache import get_cached_dek, cache_dek, evict_dek
 from .session_cache import get_working_set, set_working_set, invalidate_working_set
+
+logger = logging.getLogger("agentmem.memory_service")
 
 _IMPORTANCE_RECENCY_HALF_LIFE_DAYS = 90.0
 
@@ -478,6 +481,7 @@ async def assemble_context(
         memories=included,
         token_estimate=used,
         truncated=truncated,
+        retrieval_degraded=result.retrieval_degraded,
     )
 
 
@@ -558,9 +562,28 @@ async def recall_memories(
         span.set_attribute("router", "semantic")
 
         # Change 10: sub-spans for each recall stage
-        with tracer.start_as_current_span("recall.embed"):
+        #
+        # Degraded-retrieval mode: an unavailable embedding provider must not
+        # take recall down with it. On embed failure the query proceeds
+        # lexical-only (BM25 + recency + importance — semantic weight scores 0)
+        # and the degradation is carried on the result AND into the audit
+        # chain: a decision made under degraded recall is a fact an examiner
+        # needs, not something to silently absorb. Keyed lookups above never
+        # embed, so they never degrade.
+        retrieval_degraded = False
+        with tracer.start_as_current_span("recall.embed") as embed_span:
             provider = get_embedding_provider()
-            query_embedding = await provider.embed_one(req.query)
+            try:
+                query_embedding = await provider.embed_one(req.query)
+            except Exception as exc:
+                query_embedding = []
+                retrieval_degraded = True
+                embed_span.set_attribute("retrieval_degraded", True)
+                logger.warning(
+                    "embedding provider failed (%s: %s) — recall degrading to lexical-only",
+                    type(exc).__name__, exc,
+                )
+        span.set_attribute("retrieval_degraded", retrieval_degraded)
 
         with tracer.start_as_current_span("recall.load_keys"):
             subject_keys = await _load_namespace_subject_keys(db, namespace)
@@ -631,16 +654,19 @@ async def recall_memories(
                 mem_out.score = _score
                 memories_out.append(mem_out)
 
+        audit_payload = {
+            "query_hash": _content_hash(req.query),
+            "k": req.k,
+            "as_of": req.as_of.isoformat() if req.as_of else None,
+            "filters": req.filters,
+            "result_ids": [str(m.id) for m in memories_out],
+        }
+        if retrieval_degraded:
+            audit_payload["retrieval_degraded"] = True
         recall_log = await chain_log(
             db, namespace=namespace, agent_id=req.agent_id,
             op="recall",
-            payload={
-                "query_hash": _content_hash(req.query),
-                "k": req.k,
-                "as_of": req.as_of.isoformat() if req.as_of else None,
-                "filters": req.filters,
-                "result_ids": [str(m.id) for m in memories_out],
-            },
+            payload=audit_payload,
         )
         await db.commit()
 
@@ -648,6 +674,7 @@ async def recall_memories(
             memories=memories_out,
             as_of=req.as_of,
             total_candidates=len(results),
+            retrieval_degraded=retrieval_degraded,
         )
 
         from .metering import get_customer_id, queue_usage_event
@@ -658,14 +685,23 @@ async def recall_memories(
                 customer_id, 1, f"r:{recall_log.id}",
             )
 
-        if settings.recall_cache_enabled and not req.as_of and not near_entity and barrier_override is None:
+        # Never cache a degraded result — it would keep serving lexical-only
+        # recall after the embedding provider recovers.
+        if (
+            settings.recall_cache_enabled and not req.as_of and not near_entity
+            and barrier_override is None and not retrieval_degraded
+        ):
             await set_cached_recall(
                 namespace, req.agent_id, req.query, req.as_of, req.k, req.filters,
                 result.model_dump_json(),
                 settings.recall_cache_ttl_seconds,
             )
 
-        record_recall(namespace, router="semantic", cache_hit=False)
+        record_recall(
+            namespace,
+            router="semantic_degraded" if retrieval_degraded else "semantic",
+            cache_hit=False,
+        )
         observe_recall(namespace, _time.perf_counter() - _recall_t0)
         return result
 

--- a/agentmem/src/lians/metrics.py
+++ b/agentmem/src/lians/metrics.py
@@ -150,7 +150,9 @@ def record_recall(namespace: str, router: str, cache_hit: bool) -> None:
     """
     Increment the recall counter.
 
-    *router* is one of ``"cache"``, ``"keyed"``, ``"semantic"``.
+    *router* is one of ``"cache"``, ``"keyed"``, ``"semantic"``,
+    ``"semantic_degraded"`` (embedding provider down — lexical-only recall;
+    alert on this label).
     *cache_hit* is True when the Redis cache was hit (router=="cache").
     """
     _recalls.labels(

--- a/agentmem/src/lians/ranking.py
+++ b/agentmem/src/lians/ranking.py
@@ -41,6 +41,27 @@ W_IMP = 0.15
 
 RECENCY_HALF_LIFE_DAYS = 30.0
 
+# Materiality-weighted decay: a fact's retrieval half-life scales with its
+# stated materiality, so a client instruction or compliance flag stays
+# retrievable long after a passing preference has faded. This is a *ranking*
+# policy only — storage is never decayed; facts persist until superseded or
+# provably erased. The tag is deterministic caller/adapter metadata
+# (``metadata.materiality``), never model-inferred at recall time, so the same
+# query over the same corpus always ranks the same way.
+MATERIALITY_HALF_LIFE_DAYS: dict[str, float] = {
+    "low": 7.0,
+    "standard": RECENCY_HALF_LIFE_DAYS,
+    "high": 120.0,
+    "critical": 365.0,
+}
+
+
+def _materiality_half_life(metadata: Optional[dict]) -> float:
+    tag = (metadata or {}).get("materiality")
+    if isinstance(tag, str):
+        return MATERIALITY_HALF_LIFE_DAYS.get(tag.strip().lower(), RECENCY_HALF_LIFE_DAYS)
+    return RECENCY_HALF_LIFE_DAYS
+
 
 def _cosine(a: list[float], b: list[float]) -> float:
     dot = sum(x * y for x, y in zip(a, b))
@@ -160,12 +181,12 @@ def _bm25_score(query: str, content: str) -> float:
     return score / len(q_tokens)
 
 
-def _recency_decay(event_time: datetime) -> float:
+def _recency_decay(event_time: datetime, half_life_days: float = RECENCY_HALF_LIFE_DAYS) -> float:
     now = datetime.now(timezone.utc)
     if event_time.tzinfo is None:
         event_time = event_time.replace(tzinfo=timezone.utc)
     age_days = (now - event_time).total_seconds() / 86400
-    return math.exp(-math.log(2) * age_days / RECENCY_HALF_LIFE_DAYS)
+    return math.exp(-math.log(2) * age_days / half_life_days)
 
 
 # ── Change 1: present-time recall uses live_facts ────────────────────────────
@@ -290,7 +311,7 @@ def _score_live(
     emb = list(fact.embedding) if fact.embedding is not None else None
     sem = _cosine(query_embedding, emb) if emb else 0.0
     lex = _bm25_score(query, content or "") if content else 0.0
-    rec = _recency_decay(fact.event_time)
+    rec = _recency_decay(fact.event_time, _materiality_half_life(fact.metadata_))
     score = W_SEM * sem + W_LEX * lex + W_REC * rec + W_IMP * fact.importance
     return score, content
 
@@ -305,7 +326,7 @@ def _score_historical(
     emb = list(mem.embedding) if mem.embedding is not None else None
     sem = _cosine(query_embedding, emb) if emb else 0.0
     lex = _bm25_score(query, content or "") if content else 0.0
-    rec = _recency_decay(mem.event_time)
+    rec = _recency_decay(mem.event_time, _materiality_half_life(mem.metadata_))
     score = W_SEM * sem + W_LEX * lex + W_REC * rec + W_IMP * mem.importance
     return score, content
 

--- a/agentmem/src/lians/schemas.py
+++ b/agentmem/src/lians/schemas.py
@@ -489,6 +489,11 @@ class ContextRequest(BaseModel):
     max_tokens: int = Field(default=1500, ge=64, le=32000)
     header: str = "Relevant facts from memory (most recent, non-stale):"
     mmr: bool = False                     # diversity reranking before assembly
+    # Active resurfacing: open conflicts push to the top of every context block
+    # until adjudicated — an unresolved conflict must not silently age out.
+    # Opt out per-call for surfaces where contested facts are handled elsewhere.
+    surface_conflicts: bool = True
+    max_conflicts: int = Field(default=5, ge=0, le=50)
 
 
 class ContextResult(BaseModel):
@@ -497,6 +502,11 @@ class ContextResult(BaseModel):
     token_estimate: int
     truncated: bool                       # True if the budget cut off some facts
     retrieval_degraded: bool = False      # recall ran lexical-only (see RecallResult)
+    # Open conflicts surfaced into the block (oldest first) + the total count
+    # still open for this agent, so callers can alert when the backlog grows
+    # beyond what the block shows.
+    open_conflicts: list[ConflictFlagOut] = Field(default_factory=list)
+    open_conflicts_total: int = 0
 
 
 # ── Graph extraction ────────────────────────────────────────────────────────────

--- a/agentmem/src/lians/schemas.py
+++ b/agentmem/src/lians/schemas.py
@@ -53,6 +53,11 @@ class RecallResult(BaseModel):
     memories: list[MemoryOut]
     as_of: Optional[datetime]
     total_candidates: int
+    # True when the embedding provider was unavailable and recall proceeded
+    # lexical-only (BM25 + recency + importance). The same flag is written to
+    # the audit chain, so a decision made under degraded recall is
+    # reconstructable as such.
+    retrieval_degraded: bool = False
 
 
 class AuditReconstructRequest(BaseModel):
@@ -491,6 +496,7 @@ class ContextResult(BaseModel):
     memories: list[MemoryOut]             # the facts that fit the budget
     token_estimate: int
     truncated: bool                       # True if the budget cut off some facts
+    retrieval_degraded: bool = False      # recall ran lexical-only (see RecallResult)
 
 
 # ── Graph extraction ────────────────────────────────────────────────────────────

--- a/agentmem/src/lians/schemas.py
+++ b/agentmem/src/lians/schemas.py
@@ -320,6 +320,19 @@ class KnowledgeSnapshot(BaseModel):
     items: list[MemoryOut]
 
 
+class MarkdownExportResult(BaseModel):
+    """A chain-anchored, human-readable memory statement (see export_markdown.py)."""
+    markdown: str                 # full document including the integrity footer
+    document_sha256: str          # SHA-256 of the document body (footer excluded)
+    audit_event_id: UUID          # export_markdown event anchoring the hash
+    audit_row_hash: str           # that event's position in the tamper-evident chain
+    namespace: str
+    agent_id: str
+    as_of: datetime
+    generated_at: datetime
+    memory_count: int
+
+
 class ContaminationFlagOut(BaseModel):
     """Single lookahead-bias flag from a backtest contamination check."""
     memory_id: UUID

--- a/agentmem/tests/conftest.py
+++ b/agentmem/tests/conftest.py
@@ -62,24 +62,33 @@ def pytest_configure(config):
     if not compose_file.exists():
         return
 
-    # Bring up only the postgres service (idempotent if already running)
-    subprocess.run(
-        ["docker", "compose", "-f", str(compose_file), "up", "-d", "postgres"],
-        capture_output=True,
-        timeout=60,
-        cwd=str(_COMPOSE_DIR),
-    )
+    # Bring up only the postgres service (idempotent if already running).
+    # A half-started Docker daemon can hang any of these calls — treat every
+    # failure (including TimeoutExpired) as "no Docker" and skip provisioning
+    # rather than crashing collection with an INTERNALERROR.
+    try:
+        subprocess.run(
+            ["docker", "compose", "-f", str(compose_file), "up", "-d", "postgres"],
+            capture_output=True,
+            timeout=60,
+            cwd=str(_COMPOSE_DIR),
+        )
+    except Exception:
+        return
 
     # Wait up to 30 s for Postgres to accept connections
     deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
-        r = subprocess.run(
-            ["docker", "compose", "-f", str(compose_file),
-             "exec", "-T", "postgres", "pg_isready", "-U", "agentmem"],
-            capture_output=True,
-            timeout=5,
-            cwd=str(_COMPOSE_DIR),
-        )
+        try:
+            r = subprocess.run(
+                ["docker", "compose", "-f", str(compose_file),
+                 "exec", "-T", "postgres", "pg_isready", "-U", "agentmem"],
+                capture_output=True,
+                timeout=5,
+                cwd=str(_COMPOSE_DIR),
+            )
+        except Exception:
+            return
         if r.returncode == 0:
             break
         time.sleep(1)

--- a/agentmem/tests/test_compaction_flush.py
+++ b/agentmem/tests/test_compaction_flush.py
@@ -1,0 +1,142 @@
+"""
+Pre-compaction memory flush.
+
+Long-running agents lose granular facts at the context cliff: the host
+framework summarizes old turns and whatever the summary drops is gone. The
+harness flushes durable facts into governed memory BEFORE that happens, tagged
+``_flush: "pre_compaction"`` so the audit chain shows when the agent
+externalized what it knew.
+"""
+import asyncio
+import sys
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk" / "python"))
+
+from lians import LocalLiansClient, LiansMemoryHarness, CompactionGuard
+
+
+def _harness(mem, **kw):
+    return LiansMemoryHarness(mem, agent_id="flush-desk", source="test-agent", **kw)
+
+
+MESSAGES = [
+    {"role": "user", "content": "should we rebalance the growth book?"},
+    {"role": "assistant", "content": "Client approved the Q3 rebalance on 2026-07-01"},
+    {"role": "user", "content": "and the tobacco names?"},
+    {"role": "assistant", "content": "Compliance: no tobacco exposure in any account"},
+]
+
+
+class TestFlushBeforeCompaction:
+    def test_explicit_facts_are_persisted_and_tagged(self):
+        with LocalLiansClient() as mem:
+            h = _harness(mem)
+            result = h.flush_before_compaction(facts=[
+                "Client approved the Q3 rebalance",
+                "  ",  # blank facts are skipped, not written
+                "Compliance: no tobacco exposure",
+            ])
+            assert result == {"flushed": 2, "mode": "facts"}
+
+            recalled = h.recall("tobacco compliance")
+            assert any(
+                m.metadata.get("_flush") == "pre_compaction" for m in recalled
+            ), "flush writes must carry the pre_compaction audit tag"
+
+    def test_messages_fallback_persists_assistant_turns(self):
+        with LocalLiansClient() as mem:
+            h = _harness(mem)
+            result = h.flush_before_compaction(MESSAGES)
+            assert result["mode"] == "messages"
+            assert result["flushed"] == 2  # two assistant messages
+
+            recalled = h.recall("Q3 rebalance approval")
+            assert any("Q3 rebalance" in (m.content or "") for m in recalled)
+            # User turns were not persisted
+            all_facts = h.recall("tobacco rebalance growth book", k=20)
+            assert not any("should we rebalance" in (m.content or "") for m in all_facts)
+
+    def test_extractor_reproduces_the_silent_agentic_turn(self):
+        seen: list[str] = []
+
+        def extract(transcript: str):
+            seen.append(transcript)
+            return ["Distilled: client wants quarterly rebalancing only"]
+
+        with LocalLiansClient() as mem:
+            h = _harness(mem)
+            result = h.flush_before_compaction(MESSAGES, extract=extract)
+            assert result == {"flushed": 1, "mode": "extract"}
+            assert "assistant: Client approved" in seen[0]
+
+            recalled = h.recall("quarterly rebalancing")
+            assert any("Distilled" in (m.content or "") for m in recalled)
+
+    def test_requires_facts_or_messages(self):
+        with LocalLiansClient() as mem:
+            with pytest.raises(ValueError):
+                _harness(mem).flush_before_compaction()
+
+
+class TestCompactionGuard:
+    def test_no_flush_under_threshold(self):
+        with LocalLiansClient() as mem:
+            guard = CompactionGuard(_harness(mem), context_limit_tokens=100_000)
+            assert guard.observe_and_maybe_flush(MESSAGES) is None
+            assert not guard.should_flush()
+
+    def test_flushes_once_when_crossing_threshold(self):
+        with LocalLiansClient() as mem:
+            h = _harness(mem)
+            # Tiny window: MESSAGES easily exceeds 80% of 40 tokens
+            guard = CompactionGuard(h, context_limit_tokens=40)
+
+            first = guard.observe_and_maybe_flush(MESSAGES)
+            assert first is not None and first["flushed"] == 2
+
+            # Same window: no double-flush while waiting for the host to compact
+            assert guard.observe_and_maybe_flush(MESSAGES) is None
+
+            # After the host compacts, reset opens a fresh window
+            guard.reset()
+            assert guard.used_tokens == 0
+            again = guard.observe_and_maybe_flush(MESSAGES)
+            assert again is not None
+
+    def test_observe_accumulates_ad_hoc_text(self):
+        with LocalLiansClient() as mem:
+            guard = CompactionGuard(_harness(mem), context_limit_tokens=10, threshold=0.5)
+            guard.observe("x" * 100)  # ~25 tokens > 5-token trigger
+            assert guard.should_flush()
+
+    def test_validates_configuration(self):
+        with LocalLiansClient() as mem:
+            h = _harness(mem)
+            with pytest.raises(ValueError):
+                CompactionGuard(h, context_limit_tokens=0)
+            with pytest.raises(ValueError):
+                CompactionGuard(h, context_limit_tokens=100, threshold=1.5)
+
+
+class TestLangGraphFlushNode:
+    def test_node_flushes_past_threshold_and_not_under(self):
+        from lians.langgraph_integration import create_flush_node
+
+        with LocalLiansClient() as mem:
+            # Huge limit: nothing to do
+            idle = create_flush_node(mem, "flush-desk", context_limit_tokens=1_000_000)
+            out = asyncio.run(idle({"messages": MESSAGES}))
+            assert out["compaction_flush"] == {"flushed": 0}
+
+            # Tiny limit: assistant turns are persisted
+            node = create_flush_node(mem, "flush-desk", context_limit_tokens=40)
+            out = asyncio.run(node({"messages": MESSAGES}))
+            assert out["compaction_flush"]["flushed"] == 2
+
+            recalled = mem.recall(agent_id="flush-desk", query="tobacco compliance", k=5)
+            mems = recalled.get("memories", [])
+            assert any(
+                (m.get("metadata") or {}).get("_flush") == "pre_compaction" for m in mems
+            )

--- a/agentmem/tests/test_conflict_resurfacing.py
+++ b/agentmem/tests/test_conflict_resurfacing.py
@@ -1,0 +1,121 @@
+"""
+Active resurfacing of unresolved conflicts.
+
+Open conflicts push to the top of every /v1/context block (oldest first) until
+a human adjudicates them — an unresolved conflict must not silently age out,
+and the model must treat contested facts as contested rather than confidently
+using whichever version recall ranked higher.
+"""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+
+from src.lians.schemas import MemoryAdd, ContextRequest, ConflictResolveRequest
+from src.lians.memory_service import (
+    add_memory, assemble_context, list_conflicts, resolve_conflict,
+)
+
+NS = "resurface-ns"
+AGENT = "resurface-agent"
+T_SAME = datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+async def _seed_conflict(db) -> None:
+    """Same event_time + same structured keys + different content → conflict."""
+    for content, source in [
+        ("NVDA EPS is 5.20 for Q1", "vendor-feed-A"),
+        ("NVDA EPS is 4.80 for Q1", "vendor-feed-B"),
+    ]:
+        await add_memory(db, NS, MemoryAdd(
+            agent_id=AGENT,
+            content=content,
+            event_time=T_SAME,
+            source=source,
+            metadata={"ticker": "NVDA", "metric": "eps"},
+        ))
+
+
+@pytest.mark.asyncio
+async def test_open_conflict_surfaces_in_context_block(db):
+    await _seed_conflict(db)
+
+    ctx = await assemble_context(db, NS, ContextRequest(
+        agent_id=AGENT, query="anything at all, even unrelated",
+    ))
+
+    assert ctx.open_conflicts_total == 1
+    assert len(ctx.open_conflicts) == 1
+    assert "UNRESOLVED MEMORY CONFLICTS" in ctx.context
+    assert "5.20" in ctx.context and "4.80" in ctx.context
+    assert "DISAGREES WITH" in ctx.context
+    # The conflict banner precedes the recalled facts.
+    assert ctx.context.index("UNRESOLVED") < len(ctx.context)
+
+
+@pytest.mark.asyncio
+async def test_resolved_conflict_stops_resurfacing(db):
+    await _seed_conflict(db)
+    flags = await list_conflicts(db, NS, status="open")
+    assert flags.total == 1
+
+    await resolve_conflict(db, NS, flags.conflicts[0].id, ConflictResolveRequest(
+        resolution="accept_a", note="vendor A is the contracted golden source",
+    ))
+
+    ctx = await assemble_context(db, NS, ContextRequest(
+        agent_id=AGENT, query="NVDA earnings",
+    ))
+    assert ctx.open_conflicts_total == 0
+    assert ctx.open_conflicts == []
+    assert "UNRESOLVED MEMORY CONFLICTS" not in ctx.context
+
+
+@pytest.mark.asyncio
+async def test_surfacing_can_be_opted_out_per_call(db):
+    await _seed_conflict(db)
+
+    ctx = await assemble_context(db, NS, ContextRequest(
+        agent_id=AGENT, query="NVDA earnings", surface_conflicts=False,
+    ))
+    assert ctx.open_conflicts == []
+    assert ctx.open_conflicts_total == 0
+    assert "UNRESOLVED MEMORY CONFLICTS" not in ctx.context
+
+
+@pytest.mark.asyncio
+async def test_conflicts_of_other_agents_do_not_leak(db):
+    await _seed_conflict(db)
+
+    ctx = await assemble_context(db, NS, ContextRequest(
+        agent_id="a-different-agent", query="NVDA earnings",
+    ))
+    assert ctx.open_conflicts == []
+    assert ctx.open_conflicts_total == 0
+
+
+@pytest.mark.asyncio
+async def test_conflict_overflow_is_counted_not_dropped_silently(db):
+    """More open conflicts than max_conflicts: the block says how many more."""
+    for i in range(3):
+        t = datetime(2026, 3, 10 + i, 12, 0, 0, tzinfo=timezone.utc)
+        for content, source in [
+            (f"AAPL revenue is {100 + i}bn", "feed-A"),
+            (f"AAPL revenue is {90 + i}bn", "feed-B"),
+        ]:
+            await add_memory(db, NS, MemoryAdd(
+                agent_id=AGENT,
+                content=content,
+                event_time=t,
+                source=source,
+                metadata={"ticker": "AAPL", "metric": f"rev-{i}"},
+            ))
+
+    ctx = await assemble_context(db, NS, ContextRequest(
+        agent_id=AGENT, query="AAPL revenue", max_conflicts=2,
+    ))
+    assert ctx.open_conflicts_total == 3
+    assert len(ctx.open_conflicts) == 2
+    assert "+1 more open conflicts not shown" in ctx.context
+    # Oldest first: the longest-unresolved conflict is the most overdue.
+    assert ctx.open_conflicts[0].detected_at <= ctx.open_conflicts[1].detected_at

--- a/agentmem/tests/test_degraded_retrieval.py
+++ b/agentmem/tests/test_degraded_retrieval.py
@@ -1,0 +1,110 @@
+"""
+Degraded-retrieval mode.
+
+An unavailable embedding provider must not take recall down with it: the
+query proceeds lexical-only (BM25 + recency + importance) and the degradation
+is explicit — on the result (``retrieval_degraded``), on the /v1/context
+block, and in the recall audit event — so a decision made under degraded
+recall is reconstructable as such.
+"""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+
+from src.lians.models import EventLog
+from src.lians.schemas import MemoryAdd, RecallRequest, ContextRequest
+from src.lians.memory_service import add_memory, recall_memories, assemble_context
+
+NS = "degraded-ns"
+AGENT = "degraded-agent"
+
+
+class _BrokenProvider:
+    """Simulates an embedding provider outage."""
+
+    async def embed_one(self, text: str) -> list[float]:
+        raise ConnectionError("embedding endpoint unreachable")
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        raise ConnectionError("embedding endpoint unreachable")
+
+
+@pytest.fixture
+def break_embeddings(monkeypatch):
+    """Returns a callable that breaks the provider — call it AFTER seeding."""
+    def _break():
+        import src.lians.memory_service as ms
+        monkeypatch.setattr(ms, "get_embedding_provider", lambda: _BrokenProvider())
+    return _break
+
+
+async def _seed(db):
+    now = datetime.now(timezone.utc)
+    return await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="client mandate restricts leverage to 2x on the growth book",
+        event_time=now,
+    ))
+
+
+@pytest.mark.asyncio
+async def test_recall_survives_embedding_outage(db, break_embeddings):
+    mem = await _seed(db)
+    break_embeddings()
+
+    result = await recall_memories(db, NS, RecallRequest(
+        agent_id=AGENT, query="leverage mandate growth book", k=5,
+    ))
+
+    assert result.retrieval_degraded is True
+    # BM25 still surfaces the fact — the outage degrades quality, not availability.
+    assert [m.id for m in result.memories] == [mem.id]
+
+
+@pytest.mark.asyncio
+async def test_degradation_is_written_to_the_audit_chain(db, break_embeddings):
+    await _seed(db)
+    break_embeddings()
+
+    await recall_memories(db, NS, RecallRequest(
+        agent_id=AGENT, query="leverage mandate", k=5,
+    ))
+
+    rows = (await db.execute(
+        select(EventLog).where(EventLog.namespace == NS, EventLog.op == "recall")
+    )).scalars().all()
+    assert rows, "recall must always be audited"
+    assert rows[-1].payload.get("retrieval_degraded") is True
+
+
+@pytest.mark.asyncio
+async def test_healthy_recall_is_not_flagged_and_not_audited_as_degraded(db):
+    await _seed(db)
+
+    result = await recall_memories(db, NS, RecallRequest(
+        agent_id=AGENT, query="leverage mandate", k=5,
+    ))
+
+    assert result.retrieval_degraded is False
+    rows = (await db.execute(
+        select(EventLog).where(EventLog.namespace == NS, EventLog.op == "recall")
+    )).scalars().all()
+    # The flag is only present in the payload when degradation actually happened,
+    # keeping healthy audit payloads byte-stable for existing consumers.
+    assert "retrieval_degraded" not in rows[-1].payload
+
+
+@pytest.mark.asyncio
+async def test_context_block_carries_the_degradation_flag(db, break_embeddings):
+    await _seed(db)
+    break_embeddings()
+
+    ctx = await assemble_context(db, NS, ContextRequest(
+        agent_id=AGENT, query="leverage mandate growth book",
+    ))
+
+    assert ctx.retrieval_degraded is True
+    assert "leverage" in ctx.context

--- a/agentmem/tests/test_markdown_export.py
+++ b/agentmem/tests/test_markdown_export.py
@@ -1,0 +1,126 @@
+"""
+Signed human-readable Markdown export.
+
+The memory statement renders the exhaustive point-in-time knowledge state as
+Markdown with YAML frontmatter; its SHA-256 is anchored in the tamper-evident
+audit chain (content_hash of an export_markdown event), so the document is
+verifiable offline (hash) and online (chain).
+"""
+from __future__ import annotations
+
+import hashlib
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+
+from src.lians.models import EventLog
+from src.lians.schemas import MemoryAdd
+from src.lians.memory_service import add_memory, erase_subject
+from src.lians.export_markdown import (
+    export_memory_markdown,
+    strip_integrity_footer,
+    verify_export_document,
+)
+from src.lians.audit_chain import verify_chain
+
+NS = "export-ns"
+AGENT = "export-agent"
+
+
+async def _seed(db):
+    now = datetime.now(timezone.utc)
+    await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="client mandate: no tobacco exposure in any account",
+        event_time=now - timedelta(days=40),
+        source="onboarding-call",
+        metadata={"materiality": "critical"},
+    ))
+    await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="client mentioned preferring email over phone",
+        event_time=now - timedelta(days=10),
+        source="crm-note",
+        subject_id="client-42",
+    ))
+
+
+@pytest.mark.asyncio
+async def test_export_renders_frontmatter_and_facts(db):
+    await _seed(db)
+
+    result = await export_memory_markdown(db, NS, AGENT)
+
+    assert result.memory_count == 2
+    assert result.markdown.startswith("---\nformat: lians-memory-export/v1")
+    assert f"namespace: {NS}" in result.markdown
+    assert "no tobacco exposure" in result.markdown
+    assert "materiality: critical" in result.markdown
+    assert "[onboarding-call]" not in result.markdown  # sources render as headings
+    assert "— onboarding-call" in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_document_hash_is_self_verifiable(db):
+    await _seed(db)
+
+    result = await export_memory_markdown(db, NS, AGENT)
+
+    recomputed, stated = verify_export_document(result.markdown)
+    assert stated == result.document_sha256
+    assert recomputed == stated
+
+    body = strip_integrity_footer(result.markdown)
+    assert hashlib.sha256(body.encode("utf-8")).hexdigest() == result.document_sha256
+
+
+@pytest.mark.asyncio
+async def test_tampered_document_fails_verification(db):
+    await _seed(db)
+    result = await export_memory_markdown(db, NS, AGENT)
+
+    tampered = result.markdown.replace("no tobacco exposure", "tobacco allowed")
+    recomputed, stated = verify_export_document(tampered)
+    assert recomputed != stated
+
+
+@pytest.mark.asyncio
+async def test_export_is_anchored_in_the_audit_chain(db):
+    await _seed(db)
+    result = await export_memory_markdown(db, NS, AGENT)
+
+    rows = (await db.execute(
+        select(EventLog).where(EventLog.namespace == NS, EventLog.op == "export_markdown")
+    )).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].content_hash == result.document_sha256
+    assert rows[0].row_hash == result.audit_row_hash
+    assert rows[0].id == result.audit_event_id
+
+    report = await verify_chain(db, NS)
+    assert report["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_erased_facts_render_as_erasure_markers(db):
+    await _seed(db)
+    await erase_subject(db, NS, "client-42", request_ref="dsar-001")
+
+    result = await export_memory_markdown(db, NS, AGENT)
+
+    assert result.memory_count == 2  # existence preserved
+    assert "ERASED — content crypto-shredded" in result.markdown
+    assert "preferring email" not in result.markdown  # content unrecoverable
+
+
+@pytest.mark.asyncio
+async def test_point_in_time_export_excludes_later_facts(db):
+    await _seed(db)
+    checkpoint = datetime.now(timezone.utc) - timedelta(days=20)
+
+    result = await export_memory_markdown(db, NS, AGENT, as_of=checkpoint)
+
+    assert result.memory_count == 1  # only the 40-day-old mandate existed then
+    assert "no tobacco exposure" in result.markdown
+    assert "preferring email" not in result.markdown

--- a/agentmem/tests/test_materiality_decay.py
+++ b/agentmem/tests/test_materiality_decay.py
@@ -1,0 +1,153 @@
+"""
+Materiality-weighted retrieval decay.
+
+A fact's retrieval half-life scales with ``metadata.materiality`` — a client
+instruction or compliance flag stays retrievable long after a passing
+preference has faded. Ranking-only: storage never decays, the tag is
+deterministic caller metadata, and untagged facts keep the default half-life
+(fully backwards compatible).
+"""
+from __future__ import annotations
+
+import math
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from src.lians.ranking import (
+    RECENCY_HALF_LIFE_DAYS,
+    MATERIALITY_HALF_LIFE_DAYS,
+    _materiality_half_life,
+    _recency_decay,
+)
+from src.lians.schemas import MemoryAdd, RecallRequest
+from src.lians.memory_service import add_memory, recall_memories
+
+NS = "materiality-ns"
+AGENT = "materiality-agent"
+
+
+# ---------------------------------------------------------------------------
+# Unit: half-life resolution
+# ---------------------------------------------------------------------------
+
+def test_untagged_metadata_keeps_default_half_life():
+    assert _materiality_half_life(None) == RECENCY_HALF_LIFE_DAYS
+    assert _materiality_half_life({}) == RECENCY_HALF_LIFE_DAYS
+    assert _materiality_half_life({"ticker": "AAPL"}) == RECENCY_HALF_LIFE_DAYS
+
+
+def test_unknown_or_malformed_tag_falls_back_to_default():
+    assert _materiality_half_life({"materiality": "urgent"}) == RECENCY_HALF_LIFE_DAYS
+    assert _materiality_half_life({"materiality": 3}) == RECENCY_HALF_LIFE_DAYS
+    assert _materiality_half_life({"materiality": None}) == RECENCY_HALF_LIFE_DAYS
+
+
+def test_tag_is_case_and_whitespace_insensitive():
+    assert _materiality_half_life({"materiality": "CRITICAL"}) == MATERIALITY_HALF_LIFE_DAYS["critical"]
+    assert _materiality_half_life({"materiality": " high "}) == MATERIALITY_HALF_LIFE_DAYS["high"]
+
+
+def test_materiality_levels_order_half_lives():
+    assert (
+        MATERIALITY_HALF_LIFE_DAYS["low"]
+        < MATERIALITY_HALF_LIFE_DAYS["standard"]
+        < MATERIALITY_HALF_LIFE_DAYS["high"]
+        < MATERIALITY_HALF_LIFE_DAYS["critical"]
+    )
+    assert MATERIALITY_HALF_LIFE_DAYS["standard"] == RECENCY_HALF_LIFE_DAYS
+
+
+def test_decay_halves_at_half_life():
+    for half_life in (7.0, 30.0, 365.0):
+        t = datetime.now(timezone.utc) - timedelta(days=half_life)
+        assert _recency_decay(t, half_life) == pytest.approx(0.5, abs=1e-3)
+
+
+def test_critical_fact_decays_slower_than_low():
+    t = datetime.now(timezone.utc) - timedelta(days=90)
+    low = _recency_decay(t, MATERIALITY_HALF_LIFE_DAYS["low"])
+    critical = _recency_decay(t, MATERIALITY_HALF_LIFE_DAYS["critical"])
+    assert critical > low
+    assert critical == pytest.approx(math.exp(-math.log(2) * 90 / 365), abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Integration: recall ranking through the full service path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_critical_fact_outranks_equally_old_low_fact(db):
+    """Two equally old, equally relevant facts: the critical one ranks first."""
+    old = datetime.now(timezone.utc) - timedelta(days=180)
+
+    low = await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="client prefers morning meetings about portfolio review",
+        event_time=old,
+        metadata={"materiality": "low"},
+    ))
+    critical = await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="client prefers morning meetings about portfolio review",
+        event_time=old,
+        metadata={"materiality": "critical"},
+    ))
+
+    result = await recall_memories(db, NS, RecallRequest(
+        agent_id=AGENT, query="portfolio review meetings", k=2,
+    ))
+
+    assert [m.id for m in result.memories] == [critical.id, low.id]
+    assert result.memories[0].score > result.memories[1].score
+
+
+@pytest.mark.asyncio
+async def test_untagged_facts_rank_identically_to_standard(db):
+    """Backwards compatibility: no tag scores exactly like materiality=standard."""
+    old = datetime.now(timezone.utc) - timedelta(days=60)
+
+    await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="quarterly rebalancing thresholds were reviewed",
+        event_time=old,
+        metadata={},
+    ))
+    await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="quarterly rebalancing thresholds were reviewed",
+        event_time=old,
+        metadata={"materiality": "standard"},
+    ))
+
+    result = await recall_memories(db, NS, RecallRequest(
+        agent_id=AGENT, query="rebalancing thresholds", k=2,
+    ))
+
+    assert len(result.memories) == 2
+    assert result.memories[0].score == pytest.approx(result.memories[1].score, abs=1e-9)
+
+
+@pytest.mark.asyncio
+async def test_point_in_time_recall_applies_materiality(db):
+    """as_of recall (bitemporal log path) honors the same half-life policy."""
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=180)
+
+    low = await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="compliance restriction on energy sector trades",
+        event_time=old,
+        metadata={"materiality": "low"},
+    ))
+    critical = await add_memory(db, NS, MemoryAdd(
+        agent_id=AGENT,
+        content="compliance restriction on energy sector trades",
+        event_time=old,
+        metadata={"materiality": "critical"},
+    ))
+
+    result = await recall_memories(db, NS, RecallRequest(
+        agent_id=AGENT, query="energy sector restriction", k=2, as_of=now,
+    ))
+
+    assert [m.id for m in result.memories] == [critical.id, low.id]


### PR DESCRIPTION
Five features adopted from the July 2026 competitive review of OpenClaw and Ombre, each translated into Lians' regulated-memory posture. One commit per feature, each with its own test file. Full suite: **739 passed, 33 skipped** (skips are optional-dependency/Docker-Postgres tests).

## Features

1. **Materiality-weighted retrieval decay** — `metadata.materiality` (`low`/`standard`/`high`/`critical`) maps to 7/30/120/365-day retrieval half-lives in ranking, applied on both live-facts and point-in-time scoring. Ranking-only: storage never decays; facts persist until superseded or provably erased. Untagged facts behave exactly as before.

2. **Explicit audited degraded-retrieval mode** — an embedding-provider outage no longer takes recall down: the query proceeds lexical-only (BM25 + recency + importance), with `retrieval_degraded` on `RecallResult`/`ContextResult`, a flag in the recall audit event (only present when true — healthy payloads stay byte-stable), a `semantic_degraded` metric label for alerting, and no caching of degraded results. Keyed lookups never embed, so they never degrade.

3. **Active conflict resurfacing** — `/v1/context` pushes the agent's open conflicts to the top of every block as explicit "X DISAGREES WITH Y" lines, oldest first, until adjudicated. Bounded by `max_conflicts` with a "+N more" overflow line; per-call opt-out via `surface_conflicts=false`; other agents' conflicts never leak.

4. **Signed human-readable Markdown export** — `GET /v1/snapshot/markdown` renders the exhaustive point-in-time knowledge state as Markdown with YAML frontmatter; erased facts appear as explicit crypto-shred markers. The document's SHA-256 is anchored in the tamper-evident audit chain as an `export_markdown` event, and an integrity footer states the verification procedure. `raw=true` returns bare `text/markdown`.

5. **Pre-compaction memory flush (SDK)** — `LiansMemoryHarness.flush_before_compaction()` (explicit facts, LLM extractor, or assistant-message fallback) plus `CompactionGuard` for automatic threshold tracking; `create_flush_node()` for LangGraph; an `agentmem_flush`/`flush_memory` tool in the OpenAI-Agents, CrewAI, and AutoGen builders. Every flush write is tagged `_flush: "pre_compaction"` so the audit chain shows when the agent externalized what it knew.

## Incidental fixes

- Test conftest no longer INTERNALERRORs the whole run when a half-started Docker daemon hangs `pg_isready` (uncaught `TimeoutExpired`).
- The new LangGraph flush node runs sync clients in an executor — calling `LocalLiansClient` inside a running event loop raises `RuntimeError`. The pre-existing recall/remember nodes share this latent issue (masked because those tests skip without `langgraph` installed); follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
