### PR TITLE
Make MCP local-first and improve package discovery

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use Lians in research or production evaluation, please cite this software."
+title: "Lians: bitemporal long-term memory for AI agents"
+type: software
+authors:
+  - family-names: Beirne
+    given-names: Ethan
+repository-code: "https://github.com/Lians-ai/Lians"
+url: "https://www.lians.ai"
+license: Apache-2.0
+version: 0.4.0
+date-released: 2026-07-06
+keywords:
+  - agent memory
+  - bitemporal data
+  - point-in-time recall
+  - audit trail
+  - AI compliance

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/Lians-ai/Lians">Learn more</a>
   -
-  <a href="https://github.com/Lians-ai/Lians/tree/main/docs">Docs</a>
+  <a href="https://github.com/Lians-ai/Lians/tree/master/docs">Docs</a>
   -
   <a href="docs/install.md">Install</a>
   -
@@ -123,7 +123,7 @@ Procurement and technical review materials:
 
 ## MCP - Native tool in any AI client
 
-Lians is listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.ebeirne%2Flians/versions/latest). Any MCP-compatible host - Claude Desktop, Cursor, VS Code, Windsurf, and others - can connect to your Lians server as a native tool with a one-time config. No SDK code, no custom adapter, no wrapper.
+Lians is listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.ebeirne%2Flians/versions/latest). Any MCP-compatible host - Claude Desktop, Cursor, VS Code, Windsurf, and others - can use local persistent memory immediately or connect to a hosted Lians server. No SDK code, custom adapter, Docker service, URL, or API key is required for local mode.
 
 Your agents get eight tools automatically:
 
@@ -147,18 +147,13 @@ Add to your `claude_desktop_config.json` (or equivalent MCP config):
   "mcpServers": {
     "lians": {
       "command": "uvx",
-      "args": ["--from", "lians-sdk[mcp]", "lians-mcp"],
-      "env": {
-        "LIANS_URL": "https://your-lians-server.internal",
-        "LIANS_API_KEY": "lians_...",
-        "LIANS_AGENT_ID": "trading-desk-1"
-      }
+      "args": ["--from", "lians-sdk[mcp]", "lians-mcp"]
     }
   }
 }
 ```
 
-Restart your client and Lians memory tools appear immediately — no install step for your users beyond setting the three env vars.
+Restart your client and Lians memory tools appear immediately. Local mode persists to `~/.lians/mcp.db`. To use a hosted deployment instead, set `LIANS_URL`, `LIANS_API_KEY`, and optionally `LIANS_AGENT_ID`.
 
 ### Any other MCP host
 
@@ -166,7 +161,7 @@ Restart your client and Lians memory tools appear immediately — no install ste
 uvx --from 'lians-sdk[mcp]' lians-mcp
 ```
 
-Set `LIANS_URL`, `LIANS_API_KEY`, and optionally `LIANS_AGENT_ID` in the environment.
+No environment variables are needed for local mode. Set `LIANS_URL`, `LIANS_API_KEY`, and optionally `LIANS_AGENT_ID` to use a remote server.
 
 ---
 

--- a/agentmem/sdk/python/README.md
+++ b/agentmem/sdk/python/README.md
@@ -18,6 +18,7 @@ pip install lians-sdk[langgraph]    # + LangGraph node factories
 pip install lians-sdk[crewai]       # + CrewAI BaseTool wrappers
 pip install lians-sdk[openai-agents] # + OpenAI Agents SDK tools
 pip install lians-sdk[autogen]      # + AutoGen v0.4 tools
+pip install lians-sdk[mcp]          # + zero-config local MCP server
 pip install lians-sdk[all]          # Everything
 ```
 

--- a/agentmem/sdk/python/lians/local_client.py
+++ b/agentmem/sdk/python/lians/local_client.py
@@ -688,6 +688,17 @@ class LocalLiansClient:
             result = await list_conflicts(db, self._namespace, status=status, limit=limit)
         return result.model_dump(mode="json")
 
+    def memory_lineage(self, memory_id: str) -> dict:
+        """Return every version in a memory's supersession lineage."""
+        return self._run(self._async_memory_lineage(memory_id))
+
+    async def _async_memory_lineage(self, memory_id: str) -> dict:
+        from uuid import UUID
+        from src.lians.memory_service import get_memory_lineage
+        async with self._session_factory() as db:
+            result = await get_memory_lineage(db, self._namespace, UUID(memory_id))
+        return result.model_dump(mode="json")
+
     def resolve_conflict(
         self,
         conflict_id: str,

--- a/agentmem/sdk/python/lians/mcp_server.py
+++ b/agentmem/sdk/python/lians/mcp_server.py
@@ -11,9 +11,11 @@ Run (stdio transport — standard for local LLM integration):
     lians-mcp
 
 Environment variables:
-    LIANS_URL        Lians API base URL (default: http://localhost:8000)
-    LIANS_API_KEY    API key with read+write scopes
+    LIANS_URL        Optional Lians API base URL; omit for local mode
+    LIANS_API_KEY    API key for remote mode
     LIANS_AGENT_ID   Agent identifier / memory namespace (default: mcp-agent)
+    LIANS_LOCAL_DB   Local SQLite path (default: ~/.lians/mcp.db)
+    LIANS_NAMESPACE  Local tenant namespace (default: mcp)
 
 Configure in Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json):
     {
@@ -33,14 +35,104 @@ from __future__ import annotations
 
 import asyncio
 import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
-LIANS_URL = os.environ.get("LIANS_URL", "http://localhost:8000")
+LIANS_URL = os.environ.get("LIANS_URL", "").rstrip("/")
 LIANS_API_KEY = os.environ.get("LIANS_API_KEY", "")
 LIANS_AGENT_ID = os.environ.get("LIANS_AGENT_ID", "mcp-agent")
+LIANS_LOCAL_DB = os.environ.get("LIANS_LOCAL_DB", str(Path.home() / ".lians" / "mcp.db"))
+LIANS_NAMESPACE = os.environ.get("LIANS_NAMESPACE", "mcp")
+
+_LOCAL_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="lians-mcp-local")
+_LOCAL_CLIENT: Any = None
+
+
+def _iso(value: str) -> datetime:
+    """Parse the ISO-8601 form used by MCP clients, including a trailing Z."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _get_local_client() -> Any:
+    global _LOCAL_CLIENT
+    if _LOCAL_CLIENT is None:
+        from .local_client import LocalLiansClient
+        _LOCAL_CLIENT = LocalLiansClient(
+            db_path=LIANS_LOCAL_DB,
+            namespace=LIANS_NAMESPACE,
+        )
+    return _LOCAL_CLIENT
+
+
+def _local_api(method: str, path: str, body: dict | None = None) -> dict:
+    """Map the public HTTP-shaped MCP calls onto LocalLiansClient."""
+    client = _get_local_client()
+    body = body or {}
+    parsed = urlsplit(path)
+    query = parse_qs(parsed.query)
+
+    if method == "POST" and parsed.path == "/v1/memories":
+        return client.add(
+            agent_id=body["agent_id"],
+            content=body["content"],
+            event_time=_iso(body["event_time"]),
+            source=body.get("source"),
+            metadata=body.get("metadata", {}),
+        )
+    if method == "POST" and parsed.path == "/v1/recall":
+        as_of = _iso(body["as_of"]) if body.get("as_of") else None
+        return client.recall(
+            agent_id=body["agent_id"],
+            query=body["query"],
+            k=body.get("k", 5),
+            as_of=as_of,
+            filters=body.get("filters", {}),
+        )
+    if method == "POST" and parsed.path == "/v1/audit/reconstruct":
+        return client.reconstruct(
+            agent_id=body["agent_id"],
+            as_of=_iso(body["as_of"]),
+            query=body.get("query"),
+        )
+    if method == "GET" and parsed.path == "/v1/conflicts":
+        return client.list_conflicts(
+            status=query.get("status", ["open"])[0],
+            limit=int(query.get("limit", [20])[0]),
+        )
+    if (
+        method == "GET"
+        and parsed.path.startswith("/v1/memories/")
+        and parsed.path.endswith("/lineage")
+    ):
+        memory_id = parsed.path.removeprefix("/v1/memories/").removesuffix("/lineage")
+        return client.memory_lineage(memory_id)
+    if method == "GET" and parsed.path == "/v1/facts/history":
+        ticker = query.get("ticker", [""])[0]
+        return {
+            "ticker": ticker,
+            "items": client.fact_history(
+                agent_id=query.get("agent_id", [LIANS_AGENT_ID])[0],
+                ticker=ticker,
+                metric=query.get("metric", [""])[0],
+                limit=int(query.get("limit", [50])[0]),
+            ),
+        }
+    if method == "POST" and parsed.path == "/v1/backtest/check":
+        return client.backtest_check(
+            agent_id=body["agent_id"],
+            simulation_as_of=_iso(body["simulation_as_of"]),
+        )
+    raise ValueError(f"Unsupported local MCP route: {method} {parsed.path}")
 
 
 async def _api(method: str, path: str, body: dict | None = None) -> dict:
+    if not LIANS_URL:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(_LOCAL_EXECUTOR, _local_api, method, path, body)
+
     import httpx
     headers = {"X-API-Key": LIANS_API_KEY, "Content-Type": "application/json"}
     async with httpx.AsyncClient(timeout=30.0) as client:

--- a/agentmem/sdk/python/pyproject.toml
+++ b/agentmem/sdk/python/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "hatchling.build"
 [project]
 name = "lians-sdk"
 version = "0.4.0"
-description = "Financial-grade AI memory — bitemporal facts, SEC 17a-4 audit chain, GDPR crypto-shred"
+description = "Bitemporal long-term memory for AI agents with point-in-time recall, tamper-evident audit trails, and GDPR crypto-erasure"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 readme = "README.md"
-keywords = ["ai", "memory", "finance", "agents", "langchain", "langgraph", "crewai", "compliance", "bitemporal"]
+keywords = ["ai", "agent-memory", "long-term-memory", "llm", "mcp", "langchain", "langgraph", "crewai", "compliance", "audit-trail", "bitemporal", "gdpr"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -43,7 +43,7 @@ local         = [
     # import time, which requires the asyncpg dialect to be importable
     "asyncpg>=0.29",
 ]
-mcp           = ["mcp>=1.0.0", "httpx>=0.27.0"]
+mcp           = ["mcp>=1.0.0", "httpx>=0.27.0", "lians-sdk[local]"]
 all           = [
     "lians-sdk[langchain,langgraph,crewai,openai-agents,autogen,local,mcp]",
 ]
@@ -52,9 +52,11 @@ all           = [
 lians-mcp = "lians.mcp_server:main"
 
 [project.urls]
-Homepage      = "https://github.com/Lians-ai/Lians"
+Homepage      = "https://www.lians.ai"
 Repository    = "https://github.com/Lians-ai/Lians"
-Documentation = "https://github.com/Lians-ai/Lians#readme"
+Documentation = "https://github.com/Lians-ai/Lians/tree/master/docs"
+Changelog     = "https://github.com/Lians-ai/Lians/releases"
+Issues        = "https://github.com/Lians-ai/Lians/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["lians"]

--- a/agentmem/sdk/typescript/package.json
+++ b/agentmem/sdk/typescript/package.json
@@ -1,24 +1,30 @@
 {
   "name": "@lians-ai/lians",
   "version": "0.4.0",
-  "description": "TypeScript/JavaScript SDK for Lians — financial-grade AI memory with bitemporal model, SEC 17a-4 audit chain, and GDPR crypto-shred",
+  "description": "Bitemporal long-term memory for AI agents with point-in-time recall, tamper-evident audit trails, and GDPR crypto-erasure",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "author": "Ethan Beirne",
-  "homepage": "https://github.com/Lians-ai/Lians#readme",
+  "homepage": "https://www.lians.ai",
   "repository": {
     "type": "git",
     "url": "https://github.com/Lians-ai/Lians.git"
   },
+  "bugs": {
+    "url": "https://github.com/Lians-ai/Lians/issues"
+  },
   "keywords": [
     "ai",
-    "memory",
-    "agents",
+    "agent-memory",
+    "long-term-memory",
+    "ai-agents",
     "finance",
     "compliance",
     "bitemporal",
-    "audit",
+    "audit-trail",
+    "gdpr",
+    "point-in-time",
     "mcp",
     "langchain"
   ],

--- a/agentmem/tests/test_mcp_local.py
+++ b/agentmem/tests/test_mcp_local.py
@@ -1,0 +1,83 @@
+"""Unit coverage for zero-config MCP routing into LocalLiansClient."""
+from datetime import datetime
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sdk" / "python"))
+
+from lians import mcp_server
+
+
+class _FakeLocalClient:
+    def __init__(self):
+        self.calls = []
+
+    def add(self, **kwargs):
+        self.calls.append(("add", kwargs))
+        return {"id": "memory-1"}
+
+    def recall(self, **kwargs):
+        self.calls.append(("recall", kwargs))
+        return {"memories": []}
+
+    def memory_lineage(self, memory_id):
+        self.calls.append(("memory_lineage", {"memory_id": memory_id}))
+        return {"nodes": [], "edges": []}
+
+    def fact_history(self, **kwargs):
+        self.calls.append(("fact_history", kwargs))
+        return []
+
+
+def test_local_remember_parses_iso_timestamp(monkeypatch):
+    fake = _FakeLocalClient()
+    monkeypatch.setattr(mcp_server, "_LOCAL_CLIENT", fake)
+
+    result = mcp_server._local_api("POST", "/v1/memories", {
+        "agent_id": "research",
+        "content": "NVDA raised guidance",
+        "event_time": "2026-07-17T14:30:00Z",
+        "metadata": {"ticker": "NVDA"},
+    })
+
+    assert result == {"id": "memory-1"}
+    name, values = fake.calls[0]
+    assert name == "add"
+    assert values["event_time"] == datetime.fromisoformat("2026-07-17T14:30:00+00:00")
+
+
+def test_local_recall_at_preserves_point_in_time(monkeypatch):
+    fake = _FakeLocalClient()
+    monkeypatch.setattr(mcp_server, "_LOCAL_CLIENT", fake)
+
+    mcp_server._local_api("POST", "/v1/recall", {
+        "agent_id": "research",
+        "query": "guidance",
+        "as_of": "2026-01-01T00:00:00Z",
+        "k": 7,
+    })
+
+    name, values = fake.calls[0]
+    assert name == "recall"
+    assert values["as_of"].isoformat() == "2026-01-01T00:00:00+00:00"
+    assert values["k"] == 7
+
+
+def test_local_query_routes_parse_query_strings(monkeypatch):
+    fake = _FakeLocalClient()
+    monkeypatch.setattr(mcp_server, "_LOCAL_CLIENT", fake)
+
+    mcp_server._local_api("GET", "/v1/memories/abc-123/lineage")
+    history = mcp_server._local_api(
+        "GET",
+        "/v1/facts/history?ticker=NVDA&metric=guidance&agent_id=desk&limit=12",
+    )
+
+    assert fake.calls[0] == ("memory_lineage", {"memory_id": "abc-123"})
+    assert fake.calls[1] == ("fact_history", {
+        "agent_id": "desk",
+        "ticker": "NVDA",
+        "metric": "guidance",
+        "limit": 12,
+    })
+    assert history == {"ticker": "NVDA", "items": []}

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,4 +1,4 @@
-﻿# Lians Benchmark: Financial Memory Quality vs mem0, Zep, and Letta
+# Lians Benchmark: Financial Memory Quality vs mem0, Zep, and Letta
 
 This document compares Lians against mem0 and Zep across four dimensions that
 matter most for financial AI agents: stale-fact contamination, supersession
@@ -29,7 +29,7 @@ quarter's guidance replaces this quarter's guidance, the agent must:
 
 mem0 was not designed with these constraints. Zep's **Graphiti** (released Jan 2025,
 20k+ GitHub stars as of June 2026) now implements a genuine bitemporal model and
-point-in-time queries for its knowledge graph — a meaningful capability advance.
+point-in-time queries for its knowledge graph - a meaningful capability advance.
 What Graphiti does not provide is the compliance stack: no SHA-256 hash chain, no
 GDPR crypto-shred with audit survival, no information barriers at the DB layer, and
 no dedicated backtest-contamination detection API. Lians was designed for all of it.
@@ -50,7 +50,7 @@ stale revisions so they never reach the LLM context.
 | Pure cosine (mem0-style) | 4 / 4 | #4 |
 
 mem0 uses pure cosine retrieval with no structured supersession.
-The four stale revisions share near-identical embeddings with the query — so all
+The four stale revisions share near-identical embeddings with the query - so all
 four outrank or tie the current fact. The agent receives contaminated context.
 
 Lians applies a **0.1× validity multiplier** to superseded memories at the DB
@@ -62,16 +62,16 @@ of their cosine similarity.
 
 ## Benchmark 2: Supersession Classification Accuracy
 
-**Setup:** 22 labeled memory pairs — 12 synthetic cases covering edge cases and
+**Setup:** 22 labeled memory pairs - 12 synthetic cases covering edge cases and
 12 real-world cases sourced from public records (FOMC rate decisions, NVDA FY2026
 guidance revisions, TSLA quarterly delivery releases, Moody's ratings actions).
 Each pair is classified by Lians's Stage 1+2 deterministic engine (no LLM call).
 
 **Classes:**
-- **SUPERSEDES** — same entity+attribute, newer event, different value
-- **CONFIRMS** — same entity+attribute, same value (duplicate source)
-- **ADDS** — different attribute or reversed temporal direction
-- **CONTRADICTS_SAME_TIME** — conflicting values at the same event timestamp
+- **SUPERSEDES** - same entity+attribute, newer event, different value
+- **CONFIRMS** - same entity+attribute, same value (duplicate source)
+- **ADDS** - different attribute or reversed temporal direction
+- **CONTRADICTS_SAME_TIME** - conflicting values at the same event timestamp
 
 | Class | Precision | Recall | F1 | Support |
 |-------|-----------|--------|----|---------|
@@ -82,10 +82,10 @@ Each pair is classified by Lians's Stage 1+2 deterministic engine (no LLM call).
 | **Overall accuracy** | | | **100% (22/22)** | |
 
 **Real-world data sources (public record):**
-- FOMC rate decisions: Sep 18 2024 (−25bp), Nov 7 2024 (−25bp), Dec 18 2024 (−25bp), Jan 29 2025 (hold) — Federal Reserve press releases
-- NVDA guidance chain: $28B (Nov 2024) → $32B (Feb 2025) → $36B (May 2025) → $40B (Nov 2025) — NVIDIA earnings calls
-- TSLA deliveries: Q2 2024 actuals vs Q3 2024 actuals; analyst consensus vs Q3 2024 actual — Tesla investor relations
-- JPMorgan Chase Moody's outlook upgrade — Moody's Dec 2023 ratings action
+- FOMC rate decisions: Sep 18 2024 (−25bp), Nov 7 2024 (−25bp), Dec 18 2024 (−25bp), Jan 29 2025 (hold) - Federal Reserve press releases
+- NVDA guidance chain: $28B (Nov 2024) → $32B (Feb 2025) → $36B (May 2025) → $40B (Nov 2025) - NVIDIA earnings calls
+- TSLA deliveries: Q2 2024 actuals vs Q3 2024 actuals; analyst consensus vs Q3 2024 actual - Tesla investor relations
+- JPMorgan Chase Moody's outlook upgrade - Moody's Dec 2023 ratings action
 
 **Invariants proven by test suite:**
 - A memory with an older `event_time` **never** supersedes a newer one (temporal ordering)
@@ -94,13 +94,13 @@ Each pair is classified by Lians's Stage 1+2 deterministic engine (no LLM call).
 - Five consecutive revisions all chain correctly: $28B→$32B→$36B→$38B→$40B
 
 **mem0** has no structured supersession engine. It relies on the downstream LLM
-to reason about stale data in its context — this is prompt engineering, not memory
+to reason about stale data in its context - this is prompt engineering, not memory
 hygiene. A stale `$28B` guidance figure passed to an LLM alongside a current `$40B`
 figure creates hallucination risk.
 
 **Zep/Graphiti** extracts entity handles and edges with an LLM pass and tracks
 temporal validity intervals per edge. Its supersession is still LLM-driven entity
-merging — it has no explicit typed relation (`SUPERSEDES` / `CONFIRMS` / `ADDS` /
+merging - it has no explicit typed relation (`SUPERSEDES` / `CONFIRMS` / `ADDS` /
 `CONTRADICTS_SAME_TIME`), no temporal-ordering invariant enforcement (older facts can
 overwrite newer ones depending on ingestion order), no `CONTRADICTS_SAME_TIME`
 distinction, and no cross-attribute guard rails. The supersession classification
@@ -127,14 +127,14 @@ relational storage model. See the section below for the architectural distinctio
 
 Point-in-time recall means answering: *"What did the agent know about X on date D?"*
 
-mem0 has no `event_time` concept and no bitemporal model — it always returns the
+mem0 has no `event_time` concept and no bitemporal model - it always returns the
 most-recently-ingested memory for a query, not the one that was valid at a given
 date. It cannot reconstruct past agent state.
 
 **Zep/Graphiti** (as of Jan 2025 paper and June 2026 releases) now implements a
 genuine bitemporal model: graph edges carry `t_valid` / `t_invalid` intervals
 (event-time axis) and a separate ingestion timestamp. It does support point-in-time
-queries at the graph level — "What did we know about entity X as of date D?"
+queries at the graph level - "What did we know about entity X as of date D?"
 
 The distinction from Lians on this benchmark is architectural: Graphiti's
 point-in-time model operates over a **knowledge graph** (nodes and edges), not a
@@ -145,11 +145,11 @@ chains is not published or benchmarked by Zep. The result above marks Graphiti a
 untested (N/T) rather than incorrect (✗).
 
 Lians stores two orthogonal timestamps per memory:
-- `event_time` — when the real-world event happened (the business clock)
-- `ingestion_time` — when the memory was ingested (the system clock)
+- `event_time` - when the real-world event happened (the business clock)
+- `ingestion_time` - when the memory was ingested (the system clock)
 
 The `as_of` filter applies to `event_time` via `valid_from ≤ as_of < valid_to`.
-Ingestion order is irrelevant — out-of-order ingestion is correctly handled
+Ingestion order is irrelevant - out-of-order ingestion is correctly handled
 (`test_temporal_stress.py::test_out_of_order_ingestion_correct_recall`).
 
 This is a regulatory requirement, not a nice-to-have. SEC Rule 17a-4 requires
@@ -180,11 +180,11 @@ Benchmark 1): pure cosine's P@3 collapses to 0.25 (1 current fact surrounded by
 before ranking.
 
 Lians's hybrid scorer combines:
-- **Okapi BM25** (k₁=1.5, b=0.75) — term frequency without stopword inflation
+- **Okapi BM25** (k₁=1.5, b=0.75) - term frequency without stopword inflation
 - **Cosine similarity** against Voyage Finance-2 embeddings (1024-dim, finance-tuned)
-- **Recency decay** — exponential half-life of 90 days on `event_time`
-- **Importance weight** — caller-provided salience blended at 0.6:0.4 ratio
-- **Validity gate** — 0.1× multiplier on superseded memories (present-time) or
+- **Recency decay** - exponential half-life of 90 days on `event_time`
+- **Importance weight** - caller-provided salience blended at 0.6:0.4 ratio
+- **Validity gate** - 0.1× multiplier on superseded memories (present-time) or
   strict `valid_from ≤ as_of < valid_to` filter (point-in-time)
 
 ---
@@ -199,7 +199,7 @@ This dimension has no direct analogue in mem0 or Zep.
 | SHA-256 hash chain (SEC 17a-4) | ✓ | ✗ | ✗ |
 | Tamper detection on any modified row | ✓ | ✗ | ✗ |
 | GDPR crypto-shred (Art. 17) | ✓ | ✗ | Partial |
-| Crypto-shred preserves audit hashes | ✓ | — | — |
+| Crypto-shred preserves audit hashes | ✓ | - | - |
 | Point-in-time audit reconstruction | ✓ | ✗ | ✗ |
 | Information barriers (Chinese walls) | ✓ | ✗ | ✗ |
 | Retention policy with legal hold | ✓ | ✗ | ✗ |
@@ -222,8 +222,8 @@ This dimension has no direct analogue in mem0 or Zep.
 - `GET /v1/admin/audit/verify` still returns `{"status": "ok"}` after erasure
 
 **Admin operation audit trail (Phase 7):**
-Every admin action — key provision, revoke, rotation, barrier assignment,
-retention policy change, billing configuration — writes a `chain_log` entry
+Every admin action - key provision, revoke, rotation, barrier assignment,
+retention policy change, billing configuration - writes a `chain_log` entry
 with `agent_id="__admin__"`. Regulators can see who provisioned what and when.
 
 ---
@@ -236,7 +236,7 @@ git clone <repo>
 cd Ai_Mem_Soft
 pip install -e .
 
-# Run all benchmark tests (zero API calls — uses local hash-projection embeddings)
+# Run all benchmark tests (zero API calls - uses local hash-projection embeddings)
 python -m pytest \
   Lians/tests/test_supersession_benchmark.py \
   Lians/tests/test_recall_quality.py \
@@ -261,11 +261,11 @@ EMBEDDING_PROVIDER=local MASTER_ENCRYPTION_KEY="" KMS_PROVIDER=env \
 **What this benchmark does not measure:**
 - Latency under load (mem0 and Zep were not installed in the test environment)
 - Embedding quality on held-out financial corpora (results use hash-projection
-  vectors, not Voyage Finance-2 — production MRR will differ)
+  vectors, not Voyage Finance-2 - production MRR will differ)
 - LLM adjudication quality (Stage 3 supersession, disabled in all benchmarks)
 - Multi-agent namespace isolation latency (tested functionally, not for throughput)
 
-**Embedding note:** All recall numbers above use the `local` provider — a
+**Embedding note:** All recall numbers above use the `local` provider - a
 deterministic hash-projection into 1024 dimensions. This provider is designed for
 test repeatability, not recall quality. Production deployments with `EMBEDDING_PROVIDER=voyage`
 (voyage-finance-2 model, finance-domain fine-tuned) will achieve higher MRR and
@@ -283,7 +283,7 @@ sequential I/O hops on the critical path:
 | Stage | Before roadmap | After roadmap (keyed) | After roadmap (semantic) |
 |-------|---------------|----------------------|--------------------------|
 | Redis cache | 1 round-trip | 1 round-trip (skipped on hit) | 1 round-trip |
-| Keyed router | — | **0 DB hops (live_facts index)** | falls through |
+| Keyed router | - | **0 DB hops (live_facts index)** | falls through |
 | Embedding | always | **skipped** | 1 async call |
 | ANN search | full ``memories`` table | **live_facts partition only** | live_facts partition |
 | DEK unwrap | 1 per subject per recall | **0 (in-process DEK cache)** | 0 |
@@ -295,7 +295,7 @@ to sub-millisecond (B-tree index on live_facts).  This path covers the
 majority of financial agent workloads where the agent knows *what* it wants.
 
 Semantic recalls drop from cold-model + full-table-scan to warm-model +
-live_facts-partition scan — roughly 3–8× fewer rows inspected.
+live_facts-partition scan - roughly 3-8× fewer rows inspected.
 
 ---
 
@@ -310,12 +310,12 @@ about staleness.
 
 After the roadmap:
 - **Latency**: Lians's keyed router (Change 2) handles the majority of
-  financial recalls in sub-millisecond — comparable to mem0's simple cosine
+  financial recalls in sub-millisecond - comparable to mem0's simple cosine
   lookup on a warm index, but with stale-fact exclusion built in.
 - **Correctness**: mem0's stale-contamination problem (Benchmark 1: 4/4 stale
   facts in top-5) is architectural, not a tuning issue.  The roadmap makes
   Lians faster *and* keeps the 0/4 score intact.
-- **Compliance**: unchanged — mem0 has no audit trail, no crypto-shred, no
+- **Compliance**: unchanged - mem0 has no audit trail, no crypto-shred, no
   point-in-time recall.
 
 ### vs. Zep / Graphiti
@@ -323,7 +323,7 @@ After the roadmap:
 **What changed (June 2026 spot-check):** Zep's Graphiti library (Jan 2025 paper,
 20k+ GitHub stars) now implements a genuine bitemporal model. Graph edges carry
 `t_valid` / `t_invalid` (event-time) and a separate ingestion timestamp. Graphiti
-explicitly supports point-in-time queries. This is a real capability — not marketing.
+explicitly supports point-in-time queries. This is a real capability - not marketing.
 
 **What this closes:** the "only bitemporal agent memory" headline no longer belongs
 exclusively to Lians. Any positioning that leans on bitemporal as the primary
@@ -363,7 +363,7 @@ It does not provide a shared multi-agent memory layer, bitemporal modeling,
 or regulatory compliance primitives.
 
 - **Architecture**: Letta is per-agent (single LLM instance with paged memory);
-  Lians is a service-layer shared across agents — the right model for
+  Lians is a service-layer shared across agents - the right model for
   financial firms running multiple specialized agents that must share facts
   under information barriers.
 - **Compliance**: Letta has no equivalent of Lians's SEC 17a-4 audit
@@ -405,12 +405,12 @@ or regulatory compliance primitives.
 | Kubernetes + HPA + PDB manifests | **✓** | ✗ | ✗ | ✗ |
 
 For financial institutions operating under SEC, FINRA, MiFID II, or CFTC
-oversight, the compliance column is not optional — it is the table stake that
+oversight, the compliance column is not optional - it is the table stake that
 separates a production-grade memory layer from a developer tool.
 
 As of June 2026, Graphiti/Zep has closed the bitemporal and point-in-time gaps that
 existed at launch. The differentiator is no longer "the only temporal agent memory"
-— it is the compliance stack: hash chain, crypto-shred, information barriers, and
+- it is the compliance stack: hash chain, crypto-shred, information barriers, and
 backtest contamination detection. None of those exist in any competitor.
 
 The performance roadmap makes Lians competitive on latency *without*
@@ -420,20 +420,47 @@ implemented so they no longer penalize the hot path.
 
 ---
 
-## Memory evaluation harness (LoCoMo / LongMemEval protocol)
+## Public memory benchmark results
 
-The standard long-term-memory benchmarks — [LoCoMo](https://github.com/snap-research/locomo)
-and [LongMemEval](https://github.com/xiaowu0162/LongMemEval) — feed a model a
-multi-session conversation, then ask questions whose answers depend on
-remembering and *updating* facts across sessions, and score the generated answer
-with an LLM judge.
+The standard long-term-memory benchmarks, [LoCoMo](https://github.com/snap-research/locomo)
+and [LongMemEval](https://github.com/xiaowu0162/LongMemEval), feed a model a
+multi-session history and ask questions whose answers depend on remembering and
+updating facts across sessions.
 
-Lians ships a harness (`agentmem/benchmarks/memory_eval.py`) that measures the
-part a memory layer is actually responsible for: **evidence retrieval** — does
-recall surface the memory containing the answer? This `answer_recall@k` metric is
-deterministic and judge-free, so it isolates the memory system from the downstream
-LLM and directly exercises the property Lians is built for: a **superseded fact
-must not be retrieved, and its current replacement must be**.
+### LoCoMo
+
+We publish deterministic evidence-retrieval results on the complete LoCoMo
+dataset. These scores isolate retrieval from answer generation and are not
+directly comparable to LLM-judged answer-accuracy scores.
+
+| Metric | Result |
+|---|---:|
+| Answerable questions | 1,536 |
+| Evidence hit at 10 | **72.5%** |
+| All evidence at 10 | **59.7%** |
+| Temporal evidence hit at 10 | **79.4%** |
+
+The run uses `LocalLiansClient`, BAAI/bge-large-en-v1.5 embeddings, default
+ranking weights, and no benchmark-specific tuning. Category 5 is excluded from
+the headline because it tests answer refusal rather than evidence retrieval.
+The complete methodology, category breakdown, limitations, and reproduction
+commands are in the [LoCoMo benchmark report](../agentmem/docs/benchmarks/locomo-v0.4.0.md).
+
+### LongMemEval and LongMemEval-V2 status
+
+The repository includes a LongMemEval-S retrieval pipeline, but no official
+answer-accuracy score is published yet. The official protocol requires a fixed
+answer model and an LLM judge after retrieval. LongMemEval-V2 also requires its
+released reader and embedding endpoints. We will publish those numbers only
+after the complete official pipelines have run, including results that are not
+category-leading.
+
+### Evaluation harness
+
+Lians also ships `agentmem/benchmarks/memory_eval.py`, a compact harness that
+measures whether recall surfaces the memory containing the answer. Its
+`answer_recall@k` metric is deterministic and judge-free, which isolates the
+memory system from the downstream model.
 
 Run it on the bundled sample (no external data, no API keys):
 
@@ -443,27 +470,17 @@ python -m benchmarks.memory_eval            # bundled sample
 python -m benchmarks.memory_eval --dataset path/to/locomo.json --k 10
 ```
 
-To run the real benchmarks, convert their samples to the harness schema
-(`benchmarks/data/sample_memory_eval.json`) — sessions with dated turns, then
+To run another dataset, convert its samples to the harness schema
+(`benchmarks/data/sample_memory_eval.json`): sessions with dated turns, then
 questions with gold answers (and an optional `stale` value for supersession
 cases).
-
-### Our positioning
-
-mem0 markets raw recall scores (91.6 LoCoMo, 94.8 LongMemEval). Lians' thesis
-isn't "highest recall at any cost" — it's **correct, current, auditable recall**:
-the harness's supersession cases show Lians returning the *current* value and
-excluding the stale one, which a pure accumulate-everything store cannot do. The
-honest summary for a regulated buyer is *comparable retrieval plus the compliance
-stack (audit chain, crypto-shred, DB-layer barriers) that the benchmark leaders
-don't have* — see [compare-mem0.md](compare-mem0.md) and [compare-zep.md](compare-zep.md).
 
 ---
 
 ## Regulated memory eval (the benchmark only compliance-grade memory passes)
 
 General benchmarks measure conversational recall. They do **not** measure what a
-regulated buyer must guarantee — and an accumulate-everything store fails those by
+regulated buyer must guarantee - and an accumulate-everything store fails those by
 design. `agentmem/benchmarks/regulated_eval.py` checks five hard invariants:
 
 | Invariant | What it proves | A plain store… |
@@ -479,7 +496,7 @@ cd agentmem
 python -m benchmarks.regulated_eval     # 5/5 invariants hold on Lians
 ```
 
-Run the *same* harness against a mem0 / Zep adapter and items 1, 3, and 4 fail —
+Run the *same* harness against a mem0 / Zep adapter and items 1, 3, and 4 fail -
 that contrast, not a recall percentage, is the regulated buyer's decision. (A sixth
-invariant — barrier-leakage isolation — is verified separately against PostgreSQL
+invariant - barrier-leakage isolation - is verified separately against PostgreSQL
 RLS with a non-superuser role; see `test_pgvector.py`.)

--- a/docs/gtm/public-right-of-reply-2026-07-17.md
+++ b/docs/gtm/public-right-of-reply-2026-07-17.md
@@ -1,0 +1,140 @@
+# Public vendor right of reply, July 17, 2026
+
+These posts ask each evaluated vendor to check its own column in the Lians
+regulated-memory evaluation. The response window closes July 31, 2026.
+Corrections remain welcome after that date.
+
+Common links:
+
+- Results and methodology: <https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md>
+- Runnable adapters: <https://github.com/Lians-ai/Lians/tree/master/agentmem/benchmarks/adapters>
+
+## Mem0
+
+Title: `Fact check request for Mem0's regulated-memory evaluation results`
+
+We executed Mem0 OSS in our open regulated-memory evaluation and would like
+the Mem0 team to review its column before we promote the results more widely.
+
+The evaluation tests five properties: stale-revision suppression,
+point-in-time recall, provable erasure, lookahead protection, and historical
+audit-state reconstruction. Lians runs through the same harness.
+
+Mem0's results, methodology, and per-cell evidence are public:
+
+- https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md
+- https://github.com/Lians-ai/Lians/blob/master/agentmem/benchmarks/adapters/mem0_adapter.py
+
+We used Mem0 OSS 2.0.11 with the documented OpenAI configuration. We pinned
+`gpt-4o-mini` after reporting a default-model compatibility issue in #6085,
+so the evaluation would not score Mem0 on a failed setup.
+
+If we missed an API or configuration that changes a cell, please share it.
+We will rerun it, publish the result wherever it lands, and credit the
+correction. Adapter pull requests are also welcome.
+
+Please respond by July 31, 2026 if possible. Corrections remain welcome after
+that date.
+
+## Graphiti
+
+Title: `Fact check request for Graphiti's regulated-memory evaluation results`
+
+We executed Graphiti OSS in our open regulated-memory evaluation and would
+like the Graphiti team to review its column before wider promotion.
+
+The live run credited Graphiti's contradiction invalidation and backdated
+`invalid_at` behavior. The main question is whether default search should
+exclude invalidated edges when results are used as agent context, and whether
+we have fairly distinguished validity windows from two-axis point-in-time
+recall.
+
+- https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md
+- https://github.com/Lians-ai/Lians/blob/master/agentmem/benchmarks/adapters/graphiti_oss_adapter.py
+
+The run used Graphiti OSS 0.29.2 with OpenAI clients and embedded Kuzu. The
+Kuzu accommodations are documented in #1258.
+
+If a supported API or configuration changes any cell, please share it. We
+will rerun it, publish the result wherever it lands, and credit the
+correction. Adapter pull requests are welcome.
+
+Please respond by July 31, 2026 if possible. Corrections remain welcome after
+that date.
+
+## Letta
+
+Title: `Fact check request for Letta's regulated-memory evaluation column`
+
+We included Letta in an open evaluation of five regulated-memory properties:
+stale-revision suppression, point-in-time recall, provable erasure, lookahead
+protection, and historical audit-state reconstruction. Lians runs through the
+same harness.
+
+Letta's current column is capability-assessed from its public API rather than
+executed live. We would like the Letta team to check that assessment:
+
+- https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md
+- https://github.com/Lians-ai/Lians/blob/master/agentmem/benchmarks/adapters/letta_adapter.py
+
+The evaluation is intentionally about turnkey compliance primitives, not a
+general ranking of agent architectures. If we missed an API or mischaracterized
+agent-managed memory, please share the correction. We will update the column,
+credit the correction, and run a vendor-supplied configuration where possible.
+
+Please respond by July 31, 2026 if possible. Corrections remain welcome after
+that date.
+
+## Hindsight
+
+Title: `Fact check request for Hindsight's regulated-memory evaluation column`
+
+We included Hindsight in an open evaluation of five regulated-memory
+properties and would like the Hindsight team to review its capability-assessed
+column:
+
+- https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md
+- https://github.com/Lians-ai/Lians/blob/master/agentmem/benchmarks/adapters/hindsight_adapter.py
+
+The specific question we most want checked is erasure. Our review found no
+public deletion API, so the current adapter scores that primitive as absent.
+If that API exists or has since been added, please point us to it. We will
+correct the adapter, rerun the evaluation, publish the result wherever it
+lands, and credit the correction.
+
+Any other per-cell corrections or vendor-supplied configurations are welcome.
+Please respond by July 31, 2026 if possible. Corrections remain welcome after
+that date.
+
+## Supermemory
+
+Title: `Fact check request for Supermemory's regulated-memory evaluation column`
+
+We included Supermemory in an open evaluation of five regulated-memory
+properties: stale-revision suppression, point-in-time recall, provable
+erasure, lookahead protection, and historical audit-state reconstruction.
+Lians runs through the same harness.
+
+Supermemory's current column is capability-assessed from its public API. Its
+profile consolidation receives partial credit for supersession, while the
+remaining cells reflect the public API surface we found:
+
+- https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md
+- https://github.com/Lians-ai/Lians/blob/master/agentmem/benchmarks/adapters/supermemory_adapter.py
+
+If we missed an API or configuration that changes a cell, please share it.
+We will update the adapter, run a vendor-supplied configuration where
+possible, publish the result wherever it lands, and credit the correction.
+
+Please respond by July 31, 2026 if possible. Corrections remain welcome after
+that date.
+
+## Publication log
+
+| Vendor | Public channel | Sent | Response | Action |
+|---|---|---|---|---|
+| Mem0 | [Discussion 6373](https://github.com/mem0ai/mem0/discussions/6373) | 2026-07-17 | Pending | Pending |
+| Graphiti | [Issue 1664](https://github.com/getzep/graphiti/issues/1664) | 2026-07-17 | Pending | Pending |
+| Letta | [Issue 3401](https://github.com/letta-ai/letta/issues/3401) | 2026-07-17 | Pending | Pending |
+| Hindsight | [Discussion 2790](https://github.com/vectorize-io/hindsight/discussions/2790) | 2026-07-17 | Pending | Pending |
+| Supermemory | [Issue 1303](https://github.com/supermemoryai/supermemory/issues/1303) | 2026-07-17 | Pending | Pending |

--- a/server.json
+++ b/server.json
@@ -2,11 +2,11 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.ebeirne/lians",
   "title": "Lians \u2014 Financial-Grade Agent Memory",
-  "description": "Bitemporal memory for AI agents. SEC 17a-4 audit chain, GDPR crypto-shred, information barriers.",
+  "description": "Bitemporal long-term memory for AI agents with point-in-time recall, tamper-evident audit trails, and GDPR crypto-erasure.",
   "version": "0.4.0",
   "websiteUrl": "https://www.lians.ai",
   "repository": {
-    "url": "https://github.com/ebeirne/Lians2",
+    "url": "https://github.com/Lians-ai/Lians",
     "source": "github"
   },
   "packages": [
@@ -32,14 +32,14 @@
       "environmentVariables": [
         {
           "name": "LIANS_URL",
-          "description": "Base URL of your Lians server (self-hosted or cloud)",
-          "isRequired": true,
+          "description": "Optional base URL of a hosted or self-hosted Lians server; omit for local SQLite mode",
+          "isRequired": false,
           "isSecret": false
         },
         {
           "name": "LIANS_API_KEY",
           "description": "API key with read and write scopes",
-          "isRequired": true,
+          "isRequired": false,
           "isSecret": true
         },
         {
@@ -47,6 +47,18 @@
           "description": "Agent identifier used as the memory namespace",
           "isRequired": false,
           "default": "mcp-agent"
+        },
+        {
+          "name": "LIANS_LOCAL_DB",
+          "description": "Local SQLite path used when LIANS_URL is omitted",
+          "isRequired": false,
+          "default": "~/.lians/mcp.db"
+        },
+        {
+          "name": "LIANS_NAMESPACE",
+          "description": "Local tenant namespace",
+          "isRequired": false,
+          "default": "mcp"
         }
       ]
     }


### PR DESCRIPTION
﻿## Summary

- add zero-configuration local MCP discovery
- point public metadata at the canonical organization repository
- add citation metadata
- publish the complete LoCoMo evidence-retrieval result and methodology

## Benchmark disclosure

The LoCoMo result is 72.5% evidence hit at 10 across 1,536 answerable questions, with 79.4% on temporal questions. It is explicitly labeled as judge-free retrieval and not directly comparable to LLM-judged answer accuracy. No LongMemEval or LongMemEval-V2 score is claimed before the complete official reader and judge pipelines run.

## Validation

All 12 repository CI jobs pass on the earlier commit. The benchmark report includes the exact dataset, model, settings, limitations, and reproduction command.
