### PR TITLE
Track verified distribution outcomes

### DIFF
--- a/docs/gtm/distribution-log-2026-07-17.md
+++ b/docs/gtm/distribution-log-2026-07-17.md
@@ -1,0 +1,55 @@
+# Distribution log, July 17, 2026
+
+This ledger records zero-cost distribution work for Lians. Show HN is excluded.
+Statuses reflect verified public state, not planned activity.
+
+## Canonical assets
+
+| Asset | Status | Evidence |
+|---|---|---|
+| Package discovery metadata and local MCP bundle | Merged | [Lians PR 24](https://github.com/Lians-ai/Lians/pull/24) |
+| Local-first MCP and benchmark publication | Merged | [Lians PR 23](https://github.com/Lians-ai/Lians/pull/23) |
+| Website Article 12 and canonical marketing content | Merged to redesign branch | [Website PR 1](https://github.com/Ds6826/lian-website/pull/1) |
+| Website production promotion | Draft review required | [Website PR 2](https://github.com/Ds6826/lian-website/pull/2) |
+
+## Directories and curated lists
+
+| Channel | Status | Evidence or next action |
+|---|---|---|
+| Official MCP Registry | Published | Registry name `io.github.ebeirne/lians` |
+| mcp.so | Queued for review | [Lians listing](https://mcp.so/servers/lians-b81d5f) |
+| Smithery | Server record created, deployment blocked by registry API | [Server page](https://smithery.ai/servers/info-2zyf/lians-agent-memory), [CLI issue 797](https://github.com/smithery-ai/cli/issues/797) |
+| PulseMCP | Awaiting manual ingestion request | Gmail draft prepared for `hello@pulsemcp.com` |
+| Glama | Manual account and CAPTCHA required | Free Add Server flow opened; no payment authorized |
+| awesome-mcp-servers | Open PR, Glama check required | [PR 10320](https://github.com/punkpeye/awesome-mcp-servers/pull/10320) |
+| Awesome-Agent-Memory | Open PR | [PR 61](https://github.com/TeleAI-UAGI/Awesome-Agent-Memory/pull/61) |
+| awesome-ai-memory | Open PR | [PR 62](https://github.com/topoteretes/awesome-ai-memory/pull/62) |
+| Awesome-AI-Memory | Open bilingual PR | [PR 124](https://github.com/IAAR-Shanghai/Awesome-AI-Memory/pull/124) |
+
+## Framework documentation
+
+| Framework | Status | Evidence or blocker |
+|---|---|---|
+| LangChain and LangGraph | Ready for review, reviewer tagged once | [PR 4949](https://github.com/langchain-ai/docs/pull/4949) |
+| CrewAI | Draft, maintainer-only AI label required | [PR 6584](https://github.com/crewAIInc/crewAI/pull/6584) |
+| AutoGen | No new submission | Project is in maintenance mode; active successor should be evaluated instead |
+| OpenAI Agents SDK | No external listing submitted | Current official docs favor first-party session and memory examples rather than a vendor directory |
+
+## Vendor right of reply
+
+The detailed templates, public URLs, and response statuses are maintained in
+[public-right-of-reply-2026-07-17.md](public-right-of-reply-2026-07-17.md).
+
+## Editorial outreach
+
+| Target | Status | Angle |
+|---|---|---|
+| VeritasChain | Gmail draft prepared | Execution audit trails plus bitemporal agent knowledge provenance |
+| Agent-memory roundup publishers | Research in progress | Reproducible regulated-memory evaluation and lookahead-bias demo |
+
+## Operating constraints
+
+- No paid placements, sponsorships, subscriptions, or promoted listings.
+- No secrets or API keys sent through public forms or issues.
+- No Show HN submission.
+- No em dashes in newly published Lians copy.

--- a/docs/gtm/public-right-of-reply-2026-07-17.md
+++ b/docs/gtm/public-right-of-reply-2026-07-17.md
@@ -135,6 +135,6 @@ that date.
 |---|---|---|---|---|
 | Mem0 | [Discussion 6373](https://github.com/mem0ai/mem0/discussions/6373) | 2026-07-17 | Pending | Pending |
 | Graphiti | [Issue 1664](https://github.com/getzep/graphiti/issues/1664) | 2026-07-17 | Pending | Pending |
-| Letta | [Issue 3401](https://github.com/letta-ai/letta/issues/3401) | 2026-07-17 | Pending | Pending |
+| Letta | [Issue 3402](https://github.com/letta-ai/letta/issues/3402) | 2026-07-17 | Pending | Resubmitted through the required feature form after issue 3401 was automatically closed for missing disclosure fields |
 | Hindsight | [Discussion 2790](https://github.com/vectorize-io/hindsight/discussions/2790) | 2026-07-17 | Pending | Pending |
-| Supermemory | [Issue 1303](https://github.com/supermemoryai/supermemory/issues/1303) | 2026-07-17 | Pending | Pending |
+| Supermemory | [Issue 1303](https://github.com/supermemoryai/supermemory/issues/1303) | 2026-07-17 | Routed to internal ticket ENG-1070 | Publicly acknowledged the handoff and offered to rerun a vendor-supplied configuration |


### PR DESCRIPTION
## What changed

- Add a verified distribution ledger for canonical assets, directories, curated lists, framework documentation, vendor outreach, and editorial pitches
- Update the Letta right-of-reply link to the compliant open issue
- Record Supermemory's ENG-1070 handoff and our public follow-up

## Why

Distribution work should be auditable from the canonical repository rather than reconstructed from private notes.

## Validation

- git diff --check passes
- New ledger contains no em dashes
- Every public status links to its current evidence