### PR TITLE
docs: record additional free MCP directory submissions

### DIFF
--- a/docs/gtm/distribution-log-2026-07-17.md
+++ b/docs/gtm/distribution-log-2026-07-17.md
@@ -19,6 +19,9 @@ Statuses reflect verified public state, not planned activity.
 | Official MCP Registry | Published | Registry name `io.github.ebeirne/lians` |
 | mcp.so | Queued for review | [Lians listing](https://mcp.so/servers/lians-b81d5f) |
 | MCPServers.org | Submitted on free tier | Review promised within 12 hours; notification routed to `support@lians.ai` |
+| MCP.Directory | Submitted for review | Submission confirmed; publication review promised within 24 hours |
+| MCP Server Hub | Submitted, listing not yet verified | Free form accepted and reset without a public confirmation ID |
+| ServerHub | Submission blocked by directory error | Public form returned `Cross-origin requests are not allowed` while fetching the GitHub repository |
 | Smithery | Server record created, deployment blocked by registry API | [Server page](https://smithery.ai/servers/info-2zyf/lians-agent-memory), [CLI issue 797](https://github.com/smithery-ai/cli/issues/797) |
 | PulseMCP | Awaiting manual ingestion request | Gmail draft prepared for `hello@pulsemcp.com` |
 | Glama | Manual account and CAPTCHA required | Free Add Server flow opened; no payment authorized |


### PR DESCRIPTION
## Summary

- records the confirmed MCP.Directory submission
- records the MCP Server Hub submission conservatively pending a public listing
- documents ServerHub's reproducible public-form error
- confirms that no paid placement was selected

No em dashes are included in the new publication copy.