### PR TITLE
Refresh SDK package pages for 0.4.1

### DIFF
--- a/agentmem/sdk/java/README.md
+++ b/agentmem/sdk/java/README.md
@@ -6,13 +6,9 @@
 
 # Lians Java SDK
 
-Financial-grade agent memory for the JVM — bitemporal recall, SEC 17a-4 audit
-chain, GDPR/HIPAA crypto-shred, information barriers, and a relationship graph for
-conflict-of-interest / related-party / care-network queries.
+**Bitemporal long-term memory for JVM agents.** Keep current facts clean, reconstruct what an agent knew at a past time, retain tamper-evident audit records, and query relationship graphs for conflict-of-interest and related-party workflows.
 
-Built for where Java already runs: bank and insurer risk systems, healthcare
-platforms, and legal tech. Java 11+, one dependency (Jackson); HTTP is the JDK's
-`java.net.http`.
+Java 11+, one runtime dependency on Jackson, and HTTP through the JDK.
 
 ## Install
 
@@ -22,94 +18,64 @@ Maven:
 <dependency>
   <groupId>ai.lians</groupId>
   <artifactId>lians-sdk</artifactId>
-  <version>0.2.0</version>
+  <version>0.4.1</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-implementation "ai.lians:lians-sdk:0.2.0"
+implementation "ai.lians:lians-sdk:0.4.1"
 ```
 
-## Quick start
+Maven Central publication is pending. Until it is enabled, release JARs are attached to [GitHub Releases](https://github.com/Lians-ai/Lians/releases).
+
+## Quickstart
 
 ```java
 import ai.lians.LiansClient;
 import ai.lians.LiansClientOptions;
-import ai.lians.model.MemoryOut;
 import ai.lians.model.RecallResult;
 import java.time.Instant;
 import java.util.Map;
 
 LiansClient client = new LiansClient(LiansClientOptions.builder()
-        .baseUrl("https://api.lians.dev")              // or your self-hosted server
+        .baseUrl("https://mem.yourfirm.internal")
         .apiKey(System.getenv("LIANS_API_KEY"))
-        .adminSecret(System.getenv("LIANS_ADMIN_SECRET"))   // only for /v1/admin/* audit calls
         .build());
 
-// Store a fact with its BUSINESS event-time (not now)
 client.addMemory("equity-desk", "NVDA FY2026 revenue guidance raised to $40B",
         Instant.parse("2025-11-19T16:00:00Z"),
         Map.of("ticker", "NVDA", "metric", "revenue_guidance"));
 
-// Recall current (non-stale) facts
-RecallResult r = client.recall("equity-desk", "NVDA revenue guidance", 5);
-for (MemoryOut m : r.memories) {
-    System.out.println(m.eventTime + "  " + m.content);
-}
-
-// Point-in-time — what did we know on a past date?
+RecallResult current = client.recall("equity-desk", "NVDA revenue guidance", 5);
 RecallResult past = client.recallAt("equity-desk", "NVDA revenue guidance",
         Instant.parse("2025-09-01T00:00:00Z"), 5);
 ```
 
-## Compliance & graph surfaces
+## Audit and graph surfaces
 
 ```java
-// Exhaustive knowledge state at a date (regulator demo)
 client.snapshot("equity-desk", Instant.parse("2026-03-01T00:00:00Z"), 1000);
-
-// Lookahead-bias proof before trusting a backtest
 client.backtestCheck("equity-desk", Instant.parse("2026-01-01T00:00:00Z"));
+client.eraseSubject("subject-42", "REQUEST-2026-001");
+client.verifyChain("your-namespace");
 
-// GDPR/HIPAA crypto-shred + verify the tamper-evident chain
-client.eraseSubject("MRN-00042", "GDPR-REQ-2026-001");
-client.verifyChain("your-namespace");   // requires adminSecret
-
-// Relationship graph — conflict-of-interest / related-party reachability
 client.relate("matter-7", "Attorney", "represented", "ClientX",
         Instant.parse("2026-01-01T00:00:00Z"), false, false);
-client.relate("matter-7", "ClientX", "adverse_to", "PartyY",
-        Instant.parse("2026-01-01T00:00:00Z"), false, false);
-var coi = client.path("matter-7", "Attorney", "PartyY", 4, null);
-// -> {"connected": true, "hops": 2, "path": [...]}
-
-// Graph-proximity reranking
-client.recallNear("equity-desk", "earnings", "FundA", "ticker", 5);
+var path = client.path("matter-7", "Attorney", "PartyY", 4, null);
 ```
 
-## Notes
+## Why Java and Lians
 
-- Timestamps are `java.time.Instant` (serialized as ISO-8601 UTC).
-- Errors (non-2xx) throw `LiansException` exposing `status()` and `body()`.
-- Responses with rich schemas (snapshot, graph, conflicts, audit) return Jackson
-  `JsonNode`; `addMemory`/`recall` return typed `MemoryOut` / `RecallResult`.
-- `LiansClient` is thread-safe — create one and share it.
+Java is the backbone of many financial, insurance, healthcare, and legal systems. This SDK brings Lians point-in-time recall, deterministic supersession, audit history, crypto-erasure workflow, and relationship graph to the JVM.
 
-## Why Java + Lians
+See the [published benchmark results](https://github.com/Lians-ai/Lians/blob/master/docs/benchmark.md), [regulated-memory evaluation](https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md), and [public correction ledger](https://github.com/Lians-ai/Lians/blob/master/docs/gtm/public-right-of-reply-2026-07-17.md). The evaluation includes runnable adapters so results can be reproduced and challenged.
 
-mem0 ships Python/TypeScript only; Zep adds Go. Neither offers a Java SDK — yet
-Java is the backbone of regulated back-offices. This SDK brings the full
-compliance memory layer (and the relationship graph that neither competitor pairs
-with an open compliance spine) to the JVM. See the
-[mem0](../../../docs/compare-mem0.md) and [Zep/Graphiti](../../../docs/compare-zep.md)
-comparisons.
-
-## Build & test
+## Build and test
 
 ```bash
 cd agentmem/sdk/java
-mvn test      # JUnit tests run against an in-process mock server — no live Lians needed
+mvn test
 mvn package
 ```

--- a/agentmem/sdk/java/pom.xml
+++ b/agentmem/sdk/java/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>ai.lians</groupId>
   <artifactId>lians-sdk</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <packaging>jar</packaging>
 
   <name>Lians SDK</name>

--- a/agentmem/sdk/python/README.md
+++ b/agentmem/sdk/python/README.md
@@ -1,34 +1,34 @@
-﻿<p align="center">
+<p align="center">
   <a href="https://github.com/Lians-ai/Lians">
     <img src="https://raw.githubusercontent.com/Lians-ai/Lians/HEAD/docs/images/logo.png" width="340" alt="Lians logo">
   </a>
 </p>
 
-# Lians (蓮)
+# Lians
 
-**Financial-grade AI memory** — bitemporal facts, SEC 17a-4 audit chain, GDPR crypto-shred.
+**Bitemporal long-term memory for AI agents.** Keep current facts clean, reconstruct what an agent knew at a past time, and retain tamper-evident audit records.
 
 ## Install
 
 ```bash
-pip install lians-sdk          # HTTP client only
-pip install lians-sdk[local]        # + zero-setup SQLite mode (no server needed)
-pip install lians-sdk[langchain]    # + LangChain chat history & tools
-pip install lians-sdk[langgraph]    # + LangGraph node factories
-pip install lians-sdk[crewai]       # + CrewAI BaseTool wrappers
-pip install lians-sdk[openai-agents] # + OpenAI Agents SDK tools
-pip install lians-sdk[autogen]      # + AutoGen v0.4 tools
-pip install lians-sdk[mcp]          # + zero-config local MCP server
-pip install lians-sdk[all]          # Everything
+pip install lians-sdk
+pip install lians-sdk[local]         # Zero-setup SQLite mode
+pip install lians-sdk[mcp]           # Local MCP server
+pip install lians-sdk[langchain]     # LangChain
+pip install lians-sdk[langgraph]     # LangGraph
+pip install lians-sdk[crewai]        # CrewAI
+pip install lians-sdk[openai-agents] # OpenAI Agents SDK
+pip install lians-sdk[autogen]       # AutoGen v0.4
+pip install lians-sdk[all]           # Everything
 ```
 
 ## Quickstart
 
 ```python
-from lians import LocalLiansClient
 from datetime import datetime, timezone
+from lians import LocalLiansClient
 
-mem = LocalLiansClient()  # no server, no Docker, no API key
+mem = LocalLiansClient()  # No server, Docker, or API key
 
 mem.add(
     agent_id="analyst-1",
@@ -38,68 +38,46 @@ mem.add(
     importance=0.9,
 )
 
-# Superseded facts are excluded at the DB layer — LLM never sees stale data
-result = mem.recall(agent_id="analyst-1", query="NVDA revenue guidance")
+# Superseded facts are excluded before they reach the model
+current = mem.recall(agent_id="analyst-1", query="NVDA revenue guidance")
 
-# Point-in-time: what did we know on March 1?
-result = mem.recall_at(
+# Reconstruct what was known on a past date
+past = mem.recall_at(
     agent_id="analyst-1",
     query="NVDA revenue guidance",
     as_of=datetime(2025, 3, 1, tzinfo=timezone.utc),
 )
-
-# Extract memories directly from a conversation (like mem0.add(messages=[...]))
-mem.add_from_messages(
-    agent_id="analyst-1",
-    messages=[
-        {"role": "user",      "content": "What guidance did NVDA give?"},
-        {"role": "assistant", "content": "NVDA raised FY2026 revenue guidance to $40B."},
-    ],
-)
 ```
 
-## What makes Lians different
+## Why Lians
 
-| Feature | Lians | mem0 | Graphiti/Zep |
-|---------|------|------|-------------|
-| Bitemporal model (event + ingestion time) | ✓ | ✗ | ✓ |
-| Supersession (stale facts excluded at DB layer) | ✓ | ✗ | Partial |
-| SEC 17a-4 tamper-evident audit chain | ✓ | ✗ | ✗ |
-| GDPR crypto-shred with audit survival | ✓ | ✗ | ✗ |
-| Information barriers (PostgreSQL RLS) | ✓ | ✗ | ✗ |
-| Backtest contamination detection | ✓ | ✗ | ✗ |
+- Bitemporal facts with event time and ingestion time
+- Deterministic supersession before memories reach the model
+- Point-in-time recall and lookahead-bias checks
+- Tamper-evident audit history and a crypto-erasure workflow
+- Local SQLite mode with no server or API key
+- Hosted and self-hosted deployment paths
+
+See the [published benchmark results](https://github.com/Lians-ai/Lians/blob/master/docs/benchmark.md), [regulated-memory evaluation](https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md), and [public correction ledger](https://github.com/Lians-ai/Lians/blob/master/docs/gtm/public-right-of-reply-2026-07-17.md). The evaluation includes runnable adapters so results can be reproduced and challenged.
 
 ## Framework integrations
 
 ```python
-# LangChain
 from lians.langchain_integration import LiansChatHistory, build_tools
-
-# LangGraph
 from lians.langgraph_integration import create_recall_node, create_remember_node
-
-# CrewAI
 from lians.crewai_integration import build_crewai_tools
-
-# OpenAI Agents SDK
 from lians.openai_agents_integration import build_openai_agent_tools
-
-# AutoGen v0.4
 from lians.autogen_integration import build_autogen_tools
 ```
 
-## Switching to hosted API
+## Hosted or self-hosted API
 
 ```python
-# Dev (local SQLite, no server)
-from lians import LocalLiansClient
-mem = LocalLiansClient()
-
-# Production (self-hosted or managed)
 from lians import LiansClient
+
 mem = LiansClient(base_url="https://mem.yourfirm.internal", api_key="...")
 ```
 
-Full documentation: [github.com/ebeirne/Lians](https://github.com/ebeirne/Lians)
+Full documentation: [github.com/Lians-ai/Lians](https://github.com/Lians-ai/Lians)
 
 <!-- mcp-name: io.github.ebeirne/lians -->

--- a/agentmem/sdk/python/pyproject.toml
+++ b/agentmem/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lians-sdk"
-version = "0.4.0"
+version = "0.4.1"
 description = "Bitemporal long-term memory for AI agents with point-in-time recall, tamper-evident audit trails, and GDPR crypto-erasure"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/agentmem/sdk/typescript/README.md
+++ b/agentmem/sdk/typescript/README.md
@@ -6,20 +6,15 @@
 
 # @lians-ai/lians
 
-**Financial-grade AI memory for TypeScript/Node** — bitemporal facts, SEC 17a-4
-audit chain, GDPR crypto-shred, information barriers. The TypeScript client for
-[Lians](https://github.com/Lians-ai/Lians).
+**Bitemporal long-term memory for TypeScript and Node.** Keep current facts clean, reconstruct what an agent knew at a past time, and retain tamper-evident audit records.
 
 ## Install
 
 ```bash
 npm install @lians-ai/lians
-# or: pnpm add @lians-ai/lians   /   yarn add @lians-ai/lians
 ```
 
-Requires a running Lians server (`docker compose up --build`, or a managed
-endpoint). For zero-setup local prototyping without a server, the Python SDK's
-`LocalLiansClient` (SQLite) is the fastest path.
+This client connects to a self-hosted or managed Lians server. For zero-setup local prototyping, use the Python SDK's SQLite-backed `LocalLiansClient`.
 
 ## Quickstart
 
@@ -31,7 +26,6 @@ const client = new LiansClient({
   apiKey: process.env.LIANS_API_KEY!,
 });
 
-// Write a fact with its event time
 await client.addMemory({
   agent_id: "equity-desk",
   content: "NVDA FY2026 revenue guidance raised to $40B",
@@ -39,39 +33,34 @@ await client.addMemory({
   metadata: { ticker: "NVDA", metric: "revenue_guidance" },
 });
 
-// Recall — superseded facts are excluded at the DB layer, never reach the LLM
 const { memories } = await client.recall({
   agent_id: "equity-desk",
   query: "NVDA revenue guidance",
 });
 
-// GDPR Art. 17 crypto-shred — content becomes unreadable, audit trail survives
-await client.eraseSubject({ subject_id: "subj-123", reason: "GDPR-REQ-1" });
+const snapshot = await client.snapshot({
+  agent_id: "equity-desk",
+  as_of: "2025-03-01T00:00:00Z",
+});
 
-// Point-in-time audit snapshot — what did we know on a past date?
-const snap = await client.snapshot({ agent_id: "equity-desk", as_of: "2025-03-01T00:00:00Z" });
-
-// Backtest lookahead-bias guard — flag facts unknowable at the simulation date
-const report = await client.backtestCheck({ agent_id: "equity-desk", as_of: "2025-01-01T00:00:00Z" });
+const report = await client.backtestCheck({
+  agent_id: "equity-desk",
+  as_of: "2025-01-01T00:00:00Z",
+});
 ```
 
-## What makes Lians different
+## Why Lians
 
-| Feature | Lians | mem0 | Graphiti/Zep |
-|---------|:----:|:----:|:-----------:|
-| Bitemporal model (event + ingestion time) | ✓ | ✗ | ✓ |
-| Supersession (stale facts excluded at DB layer) | ✓ | ✗ | Partial |
-| SEC 17a-4 tamper-evident audit chain | ✓ | ✗ | ✗ |
-| GDPR crypto-shred with audit survival | ✓ | ✗ | ✗ |
-| Information barriers (PostgreSQL RLS) | ✓ | ✗ | ✗ |
-| Backtest contamination detection | ✓ | ✗ | ✗ |
+- Bitemporal facts with event time and ingestion time
+- Deterministic supersession before memories reach the model
+- Point-in-time recall and lookahead-bias checks
+- Tamper-evident audit history and a crypto-erasure workflow
+- Information barriers through PostgreSQL row-level security
 
-See the [regulated-eval head-to-head](https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md).
+See the [published benchmark results](https://github.com/Lians-ai/Lians/blob/master/docs/benchmark.md), [regulated-memory evaluation](https://github.com/Lians-ai/Lians/blob/master/docs/regulated-eval-results.md), and [public correction ledger](https://github.com/Lians-ai/Lians/blob/master/docs/gtm/public-right-of-reply-2026-07-17.md). The evaluation includes runnable adapters so results can be reproduced and challenged.
 
 ## TypeScript-first
 
-Fully typed: every request and response is a named interface (`MemoryAdd`,
-`RecallRequest`, `RecallResult`, `EraseRequest`, `KnowledgeSnapshot`, …), exported
-from the package root. Errors throw a typed `LiansError` with the HTTP status.
+Every request and response is a named interface exported from the package root. Errors throw a typed `LiansError` with the HTTP status.
 
 Full documentation: [github.com/Lians-ai/Lians](https://github.com/Lians-ai/Lians)

--- a/agentmem/sdk/typescript/package-lock.json
+++ b/agentmem/sdk/typescript/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "agentmem-sdk",
-  "version": "0.2.0",
+  "name": "@lians-ai/lians",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agentmem-sdk",
-      "version": "0.2.0",
+      "name": "@lians-ai/lians",
+      "version": "0.4.1",
+      "license": "Apache-2.0",
       "devDependencies": {
         "@jest/globals": "^29",
         "@types/node": "^20",

--- a/agentmem/sdk/typescript/package.json
+++ b/agentmem/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lians-ai/lians",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bitemporal long-term memory for AI agents with point-in-time recall, tamper-evident audit trails, and GDPR crypto-erasure",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- refresh PyPI, npm, and Java package README copy around verifiable bitemporal-memory capabilities
- remove stale competitor scorecards and unsupported absolute compliance language
- link directly to published benchmarks, the regulated-memory evaluation, and the public correction ledger
- update Python, TypeScript, and Java package versions to 0.4.1
- repair stale TypeScript lockfile package identity and version
- mark Maven Central availability as pending until publishing is enabled
- remove Unicode em dashes from all touched public package copy

## Local verification
- Python: python -m build, wheel and sdist succeeded
- TypeScript: 15 Jest tests passed and npm run build succeeded
- Java: local Maven unavailable; rely on the repository Java 11/17/21 CI matrix

## Release safety
This PR does not create a tag or publish packages. A unified v0.4.1 tag should only be created after every required check passes and Maven publishing configuration is reviewed.