### PR TITLE
Record verified v0.4.1 distribution outcomes

### DIFF
--- a/docs/gtm/distribution-log-2026-07-17.md
+++ b/docs/gtm/distribution-log-2026-07-17.md
@@ -8,6 +8,8 @@ Statuses reflect verified public state, not planned activity.
 | Asset | Status | Evidence |
 |---|---|---|
 | Package discovery metadata and local MCP bundle | Merged | [Lians PR 24](https://github.com/Lians-ai/Lians/pull/24) |
+| Package-page refresh | Merged | [Lians PR 31](https://github.com/Lians-ai/Lians/pull/31) passed all 12 CI jobs and removed stale scorecards and unsupported absolute claims |
+| Unified SDK release | Published | [Lians v0.4.1](https://github.com/Lians-ai/Lians/releases/tag/v0.4.1) includes Java and C artifacts plus the Go module tag |
 | Local-first MCP and benchmark publication | Merged | [Lians PR 23](https://github.com/Lians-ai/Lians/pull/23) |
 | Website Article 12 and canonical marketing content | Merged to redesign branch | [Website PR 1](https://github.com/Ds6826/lian-website/pull/1) |
 | Website production promotion | Draft review required | [Website PR 2](https://github.com/Ds6826/lian-website/pull/2) |
@@ -38,6 +40,14 @@ Statuses reflect verified public state, not planned activity.
 | CrewAI | Draft, maintainer-only AI label required | [PR 6584](https://github.com/crewAIInc/crewAI/pull/6584) |
 | AutoGen and Microsoft Agent Framework | Successor sample proposed | AutoGen is in maintenance mode; [Agent Framework issue 7168](https://github.com/microsoft/agent-framework/issues/7168) proposes a local bitemporal-memory MCP sample |
 | OpenAI Agents SDK | No external listing submitted | Current official docs favor first-party session and memory examples rather than a vendor directory |
+
+## Package registries
+
+| Registry | Status | Evidence or blocker |
+|---|---|---|
+| PyPI | Version 0.4.1 verified live | [lians-sdk](https://pypi.org/project/lians-sdk/) exposes the new homepage, summary, README, benchmarks, and documentation links |
+| Maven Central | Deployment accepted, search indexing pending | [Release workflow](https://github.com/Lians-ai/Lians/actions/runs/29610671357) completed the Maven Central deploy job successfully |
+| npm | Version 0.4.1 publication blocked by token authorization | [Failed publish workflow](https://github.com/Lians-ai/Lians/actions/runs/29610671394) received an npm registry 404 while 0.4.0 remains public; replace the scoped package token before rerunning |
 
 ## Vendor right of reply
 

--- a/docs/gtm/distribution-log-2026-07-17.md
+++ b/docs/gtm/distribution-log-2026-07-17.md
@@ -23,10 +23,15 @@ Statuses reflect verified public state, not planned activity.
 | MCPServers.org | Submitted on free tier | Review promised within 12 hours; notification routed to `support@lians.ai` |
 | MCP.Directory | Submitted for review | Submission confirmed; publication review promised within 24 hours |
 | MCP Server Hub | Submitted, listing not yet verified | Free form accepted and reset without a public confirmation ID |
+| AgentNDX | Submitted for curated review | Public form confirmed receipt and stated a 48-hour review target |
+| DeepYard | Submitted for review | Formspree confirmation page verified successful submission in the MCP Servers category |
+| AI Tools Directory | Submission failed on public form | Completed form returned `Failed to process submission`; no listing claimed |
 | ServerHub | Submission blocked by directory error | Public form returned `Cross-origin requests are not allowed` while fetching the GitHub repository |
 | Smithery | Server record created, deployment blocked by registry API | [Server page](https://smithery.ai/servers/info-2zyf/lians-agent-memory), [CLI issue 797](https://github.com/smithery-ai/cli/issues/797) |
 | PulseMCP | Awaiting manual ingestion request | Gmail draft prepared for `hello@pulsemcp.com` |
 | Glama | Manual account and CAPTCHA required | Free Add Server flow opened; no payment authorized |
+| mcpub | Not eligible for current transport | Directory requires a hosted HTTP MCP endpoint and a `/.well-known/mcp.json` resource; Lians currently publishes a local stdio server |
+| Unyly | Declined | Submission requires accepting creator marketplace terms and is oriented around hosted billing and revenue share, which is outside the zero-cost local-server campaign |
 | awesome-mcp-servers | Open PR, Glama check required | [PR 10320](https://github.com/punkpeye/awesome-mcp-servers/pull/10320) |
 | Awesome-Agent-Memory | Open PR | [PR 61](https://github.com/TeleAI-UAGI/Awesome-Agent-Memory/pull/61) |
 | awesome-ai-memory | Open PR | [PR 62](https://github.com/topoteretes/awesome-ai-memory/pull/62) |


### PR DESCRIPTION
## Summary
- record the merged package-page refresh and unified v0.4.1 release
- add an authoritative package-registry status section
- distinguish verified PyPI publication, accepted Maven deployment, and the npm authorization blocker
- preserve the zero-cost campaign evidence trail without claiming unverified registry indexing

No product code changes.