### PR TITLE
Prepare npm publishing for trusted OIDC

### DIFF
--- a/.github/workflows/publish-lian-npm.yml
+++ b/.github/workflows/publish-lian-npm.yml
@@ -1,22 +1,28 @@
 name: Publish lians to npm
 
 on:
+  workflow_dispatch:
   push:
     tags:
-      - "v*"            # unified release tag — one `vX.Y.Z` ships every language
-      - "lians-ts-v*"   # TypeScript-only tag (kept for back-compat)
+      - "v*"            # unified release tag; one `vX.Y.Z` ships every language
+      - "lians-ts-v*"   # TypeScript-only tag kept for backward compatibility
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
 
       - name: Install dependencies
         working-directory: agentmem/sdk/typescript
@@ -26,8 +32,15 @@ jobs:
         working-directory: agentmem/sdk/typescript
         run: npm run build
 
+      - name: Test
+        working-directory: agentmem/sdk/typescript
+        run: npm test
+
       - name: Publish to npm
         working-directory: agentmem/sdk/typescript
         run: npm publish --access public
+        # npm CLI 11.5.1+ prefers the short-lived GitHub OIDC credential. Keep
+        # the existing token as a migration fallback until trusted publishing
+        # is verified, then remove the secret from the repository.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,51 +1,75 @@
 # Publishing the SDKs
 
-Lians ships five SDKs. This is the release process and the registry path for each.
-Releases are cut by pushing a semver tag; `release.yml` builds the language
-artifacts and attaches them to the GitHub Release.
+Lians ships Python, TypeScript, Go, Java, and C SDKs. A unified `vX.Y.Z` tag runs the language-specific publication workflows and creates GitHub Release artifacts.
+
+## Release checklist
+
+1. Set the same version in:
+   - `agentmem/sdk/python/pyproject.toml`
+   - `agentmem/sdk/typescript/package.json`
+   - `agentmem/sdk/typescript/package-lock.json`
+   - `agentmem/sdk/java/pom.xml`
+2. Update package README installation examples.
+3. Merge the release PR only after the full CI matrix passes.
+4. Confirm PyPI trusted publishing, npm trusted publishing, and Maven Central credentials are configured.
+5. Create and push one annotated tag:
 
 ```bash
-git tag v0.2.1
-git push origin v0.2.1
+git tag -a v0.4.2 -m "release: v0.4.2"
+git push origin v0.4.2
 ```
 
-| SDK | Registry | How it's published | Secret(s) needed |
-|-----|----------|--------------------|------------------|
-| **Python** | [PyPI](https://pypi.org/project/lians-sdk) | `publish-lian.yml` builds sdist+wheel and uploads via `twine` | `PYPI_API_TOKEN` |
-| **TypeScript** | [npm](https://www.npmjs.com/package/@lians-ai/lians) | `publish-lian-npm.yml` runs `npm publish` | `NPM_TOKEN` |
-| **Go** | proxy.golang.org / pkg.go.dev | `release.yml` → `go-tag` auto-mirrors the tag to the module path (see below) | none |
-| **Java** | Maven Central (gated) / GitHub Release jar | `release.yml` → `maven-central` (`mvn deploy -P release`) when opted in; else jar on the Release | `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `MAVEN_GPG_KEY`, `MAVEN_GPG_PASSPHRASE` + var `PUBLISH_MAVEN_CENTRAL=true` |
-| **C** | source tarball on the GitHub Release | packaged by `release.yml` (vendored into the consumer build) | none |
+6. Monitor all three workflows until completion:
+   - `publish-lian.yml`
+   - `publish-lian-npm.yml`
+   - `release.yml`
+7. Verify the published version from each public registry. A successful workflow is not proof that a registry search index has propagated.
 
-## Go module tags (automatic)
+## Registry matrix
 
-The Go module lives in a subdirectory, so `go get` resolves a version from a tag
-**prefixed with the module path**. The `go-tag` job in `release.yml` creates this
-automatically when you push a `vX.Y.Z` tag — no manual step:
+| SDK | Registry | Publication path | Authentication |
+|---|---|---|---|
+| Python | [PyPI](https://pypi.org/project/lians-sdk/) | `publish-lian.yml` builds the sdist and wheel, then publishes them | PyPI trusted publisher through GitHub OIDC |
+| TypeScript | [npm](https://www.npmjs.com/package/@lians-ai/lians) | `publish-lian-npm.yml` builds, tests, and runs `npm publish` | npm trusted publisher through GitHub OIDC, with `NPM_TOKEN` retained temporarily as a migration fallback |
+| Go | proxy.golang.org and pkg.go.dev | `release.yml` creates a module-path tag | GitHub token supplied to the workflow |
+| Java | Maven Central and GitHub Release JAR | `release.yml` signs and deploys with the `release` Maven profile | Sonatype credentials and GPG signing secrets |
+| C | GitHub Release source archive | `release.yml` creates `lians-c-<version>.tar.gz` | GitHub token supplied to the workflow |
 
-```
-v0.3.0  ──(release.yml go-tag)──▶  agentmem/sdk/go/v0.3.0
-```
+## npm trusted publishing
 
-Consumers then use:
+Configure the existing `@lians-ai/lians` package on npmjs.com with this trusted publisher:
+
+| Field | Value |
+|---|---|
+| Provider | GitHub Actions |
+| Organization or user | `Lians-ai` |
+| Repository | `Lians` |
+| Workflow filename | `publish-lian-npm.yml` |
+| Allowed action | `npm publish` |
+
+The workflow uses a GitHub-hosted runner, Node 24, npm 11.5.1 or later, and `id-token: write`. After one OIDC publication succeeds, remove the `NPM_TOKEN` repository secret and the fallback environment variable from the workflow.
+
+The workflow also supports manual dispatch. This is useful when registry authorization fails after a tag has already published successfully to the other registries. A manual rerun publishes the version currently present on the selected branch, so verify that the npm version is still unpublished first.
+
+## Go module tags
+
+The Go module lives in a subdirectory. `release.yml` mirrors `vX.Y.Z` to `agentmem/sdk/go/vX.Y.Z` automatically so consumers can run:
 
 ```bash
-go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.3.0
+go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.4.1
 ```
 
-## Java → Maven Central
+## Maven Central
 
-Out of the box, `release.yml` attaches the built jar to the GitHub Release (no
-secrets). To publish to **Maven Central**: add the `OSSRH_*` / `MAVEN_GPG_*`
-secrets, set the repository **variable** `PUBLISH_MAVEN_CENTRAL=true`, and the
-`maven-central` job runs `mvn -B deploy -P release` — the `release` profile in
-`pom.xml` builds sources + javadoc, GPG-signs, and publishes via the Sonatype
-Central Portal. (GitHub Packages is an alternative: point `distributionManagement`
-at `https://maven.pkg.github.com/Lians-ai/Lians` and use `GITHUB_TOKEN`.)
+The Maven job requires these repository secrets:
 
-## C
+- `OSSRH_USERNAME`
+- `OSSRH_PASSWORD`
+- `MAVEN_GPG_KEY`
+- `MAVEN_GPG_PASSPHRASE`
 
-The C SDK is distributed as source (header + `.c` files) — the idiomatic model for
-a small libcurl client. `release.yml` packages `agentmem/sdk/c` into
-`lians-c-<version>.tar.gz` on the Release; consumers vendor it and build with
-their own CMake/Make. (A future option: an apt/conan/vcpkg recipe.)
+It also requires the repository variable `PUBLISH_MAVEN_CENTRAL=true`. The Maven `release` profile builds source and Javadoc archives, signs every artifact, and deploys through the Sonatype Central Portal. Search indexing can lag behind a successful deployment.
+
+## C source archive
+
+The C SDK is distributed as source. `release.yml` packages `agentmem/sdk/c` into `lians-c-<version>.tar.gz` for consumers to vendor into their own build.


### PR DESCRIPTION
## Summary
- enable GitHub OIDC permissions for npm trusted publishing
- move the npm release runner to Node 24 and setup-node v6
- build and test the TypeScript SDK before publishing
- add a manual workflow dispatch path for repairing a registry-only failure without moving a release tag
- keep the existing token temporarily as a documented migration fallback
- replace stale publishing documentation with the current PyPI, npm, Go, Maven Central, and C release paths
- document the exact npm trusted-publisher fields for @lians-ai/lians
- remove encoding corruption and Unicode em dashes from the touched release documentation

## Security rationale
Trusted publishing uses short-lived GitHub OIDC credentials and automatically produces npm provenance. After one OIDC publish succeeds, the long-lived NPM_TOKEN should be removed.

## Verification
- git diff --check passed
- local actionlint was unavailable because Go is not installed in this Windows environment
- repository CI will verify the product matrix; this PR does not publish a package