### PR TITLE
Verify Maven Central 0.4.1 availability

### DIFF
--- a/agentmem/sdk/java/README.md
+++ b/agentmem/sdk/java/README.md
@@ -28,7 +28,7 @@ Gradle:
 implementation "ai.lians:lians-sdk:0.4.1"
 ```
 
-Maven Central publication is pending. Until it is enabled, release JARs are attached to [GitHub Releases](https://github.com/Lians-ai/Lians/releases).
+Version 0.4.1 is available from [Maven Central](https://central.sonatype.com/artifact/ai.lians/lians-sdk/0.4.1). Release JARs are also attached to [GitHub Releases](https://github.com/Lians-ai/Lians/releases).
 
 ## Quickstart
 

--- a/docs/gtm/distribution-log-2026-07-17.md
+++ b/docs/gtm/distribution-log-2026-07-17.md
@@ -53,7 +53,7 @@ Statuses reflect verified public state, not planned activity.
 | Registry | Status | Evidence or blocker |
 |---|---|---|
 | PyPI | Version 0.4.1 verified live | [lians-sdk](https://pypi.org/project/lians-sdk/) exposes the new homepage, summary, README, benchmarks, and documentation links |
-| Maven Central | Deployment accepted, search indexing pending | [Release workflow](https://github.com/Lians-ai/Lians/actions/runs/29610671357) completed the Maven Central deploy job successfully |
+| Maven Central | Version 0.4.1 verified live | [Canonical POM](https://repo1.maven.org/maven2/ai/lians/lians-sdk/0.4.1/lians-sdk-0.4.1.pom) and [Sonatype artifact page](https://central.sonatype.com/artifact/ai.lians/lians-sdk/0.4.1) both returned HTTP 200 |
 | npm | Version 0.4.1 publication blocked by token authorization | [Failed publish workflow](https://github.com/Lians-ai/Lians/actions/runs/29610671394) received an npm registry 404 while 0.4.0 remains public; replace the scoped package token before rerunning |
 
 ## Vendor right of reply


### PR DESCRIPTION
## Summary
- replace the temporary Java README publication notice with the verified Maven Central artifact link
- update the distribution ledger from deployment accepted to publicly live
- cite both the canonical Maven repository POM and the Sonatype artifact page

## Verification
- both public URLs returned HTTP 200
- git diff --check passed
- no Unicode em dashes were added