### PR TITLE
Add reproducible Glama MCP container

### DIFF
--- a/.github/scripts/smoke_mcp_container.py
+++ b/.github/scripts/smoke_mcp_container.py
@@ -1,0 +1,49 @@
+"""Perform a real MCP handshake against the Glama container image."""
+
+import asyncio
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+EXPECTED_TOOLS = {
+    "remember",
+    "recall",
+    "recall_at",
+    "reconstruct",
+    "list_conflicts",
+    "memory_lineage",
+    "fact_history",
+    "backtest_check",
+}
+
+
+async def main() -> None:
+    parameters = StdioServerParameters(
+        command="docker",
+        args=[
+            "run",
+            "--rm",
+            "-i",
+            "--read-only",
+            "--tmpfs",
+            "/data:rw,noexec,nosuid,size=32m,mode=1777",
+            "lians-mcp-glama:test",
+        ],
+    )
+
+    async with stdio_client(parameters) as streams:
+        async with ClientSession(*streams) as session:
+            await session.initialize()
+            response = await session.list_tools()
+
+    names = {tool.name for tool in response.tools}
+    missing = EXPECTED_TOOLS - names
+    if missing:
+        raise RuntimeError(f"container did not expose expected tools: {sorted(missing)}")
+
+    print(f"MCP container handshake passed with {len(names)} tools")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,3 +176,24 @@ jobs:
       - name: Test
         run: go test ./...
         working-directory: agentmem/sdk/go
+
+  mcp-container:
+    name: Glama MCP container
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build Glama image
+        run: docker build --file Dockerfile.glama --tag lians-mcp-glama:test .
+
+      - name: Install MCP test client
+        run: pip install "mcp>=1,<2"
+
+      - name: Initialize server and list tools
+        run: python .github/scripts/smoke_mcp_container.py

--- a/Dockerfile.glama
+++ b/Dockerfile.glama
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ARG LIANS_VERSION=0.4.1
+
+RUN groupadd --system lians \
+    && useradd --system --gid lians --create-home lians \
+    && mkdir -p /data \
+    && chown lians:lians /data \
+    && pip install --no-cache-dir "lians-sdk[mcp]==${LIANS_VERSION}"
+
+USER lians
+
+ENV LIANS_AGENT_ID=mcp-agent \
+    LIANS_LOCAL_DB=/data/mcp.db \
+    LIANS_NAMESPACE=mcp \
+    PYTHONUNBUFFERED=1
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["lians-mcp"]

--- a/docs/glama-deployment.md
+++ b/docs/glama-deployment.md
@@ -1,0 +1,35 @@
+# Glama deployment
+
+Lians includes a dedicated container recipe for Glama's MCP build and
+introspection pipeline.
+
+## Build specification
+
+- Dockerfile: `Dockerfile.glama`
+- Command: use the image entrypoint without additional arguments
+- Transport: stdio
+- Persistent volume: `/data`
+- API key: not required for local SQLite mode
+
+The image runs `lians-sdk[mcp]==0.4.1` as a non-root user. Its default database
+path is `/data/mcp.db`.
+
+## Local build
+
+```bash
+docker build --file Dockerfile.glama --tag lians-mcp-glama .
+docker run --rm -i --volume lians-data:/data lians-mcp-glama
+```
+
+An MCP client must communicate with the container over standard input and
+standard output. The process is expected to remain open while the client session
+is active.
+
+## Automated verification
+
+Repository CI builds the same image, starts it through the official Python MCP
+client, performs the initialization handshake, calls `tools/list`, and verifies
+that all eight expected Lians tools are present.
+
+The image does not declare a hosted endpoint. Glama can wrap the stdio process
+with its own gateway when deploying the server.

--- a/integrations/mcpb/manifest.json
+++ b/integrations/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "lians-agent-memory",
   "display_name": "Lians Agent Memory",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bitemporal agent memory with deterministic supersession, point-in-time recall, and local persistent storage.",
   "author": {
     "name": "Lians",

--- a/integrations/mcpb/pyproject.toml
+++ b/integrations/mcpb/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "lians-agent-memory-mcpb"
-version = "0.4.0"
+version = "0.4.1"
 description = "Local MCPB launcher for Lians agent memory"
 requires-python = ">=3.10"
-dependencies = ["lians-sdk[mcp,local]==0.4.0"]
+dependencies = ["lians-sdk[mcp,local]==0.4.1"]
 
 [tool.uv]
 package = false

--- a/integrations/mcpb/uv.lock
+++ b/integrations/mcpb/uv.lock
@@ -510,25 +510,25 @@ wheels = [
 
 [[package]]
 name = "lians-agent-memory-mcpb"
-version = "0.4.0"
+version = "0.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "lians-sdk", extra = ["local", "mcp"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "lians-sdk", extras = ["mcp", "local"], specifier = "==0.4.0" }]
+requires-dist = [{ name = "lians-sdk", extras = ["mcp", "local"], specifier = "==0.4.1" }]
 
 [[package]]
 name = "lians-sdk"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/43/53864361f147692448a064e2cff90937530e2e6e8fdf4a42e6e387871a3f/lians_sdk-0.4.0.tar.gz", hash = "sha256:4d5abfb053a238c79f8124ab28dfc244a5299ea8d073e810ae2e6a60e0d9d8d1", size = 170723, upload-time = "2026-07-06T06:10:57.987Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/61/b8189d74a1257cb8bcfb10123090dc0098528cb484fc0cce75acf4857004/lians_sdk-0.4.1.tar.gz", hash = "sha256:25515ba733fe4c125e73f674a385d32d02d1b6556b94b0f85e8c9f8e0bb116c6", size = 198132, upload-time = "2026-07-17T20:18:15.319Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/96/d752670921cc2dc946cdf52b9db18d6ee1be39666e235920b48fa178a8ae/lians_sdk-0.4.0-py3-none-any.whl", hash = "sha256:8dd3dc30e0365ed6c06af1d35be897b3fe853b43fb919a09c5f81212ba94978f", size = 210090, upload-time = "2026-07-06T06:10:56.442Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/f526bdb50c7efa121c181141291e58139fc4c35b91000b52622d50f97cd3/lians_sdk-0.4.1-py3-none-any.whl", hash = "sha256:a33a6a2701a759b354ebff655b3ee60898d018a7b06cedfdb5da0acd6acff169", size = 238844, upload-time = "2026-07-17T20:18:13.902Z" },
 ]
 
 [package.optional-dependencies]
@@ -546,8 +546,19 @@ local = [
     { name = "sqlalchemy" },
 ]
 mcp = [
+    { name = "aiosqlite" },
+    { name = "asyncpg" },
+    { name = "cryptography" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "mcp" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pgvector" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sqlalchemy" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n\n- add a dedicated non-root Dockerfile.glama for the local stdio MCP server\n- persist local SQLite data under /data without requiring an API key\n- add a CI smoke test that performs a real MCP initialize and 	ools/list exchange through the container\n- document the Glama build specification\n- update the MCPB package and lockfile to 0.4.1\n\n## Local verification\n\n- workflow YAML parses successfully\n- smoke-test script compiles\n- MCPB manifest parses and its uv lock is current\n- git diff --check passes\n- no em dashes were added\n\nDocker Desktop is not running in the local environment, so the container build and protocol handshake are delegated to the new GitHub Actions job before merge.