### PR TITLE
Record Docker MCP Catalog submission

### DIFF
--- a/docs/gtm/distribution-log-2026-07-17.md
+++ b/docs/gtm/distribution-log-2026-07-17.md
@@ -21,6 +21,7 @@ Statuses reflect verified public state, not planned activity.
 | Channel | Status | Evidence or next action |
 |---|---|---|
 | Official MCP Registry | Version 0.4.1 published | Registry name `io.github.ebeirne/lians`; the publisher accepted 0.4.1 and rejected a verification retry as a duplicate version |
+| Docker MCP Catalog | Open PR, maintainer CI approval required | [Docker MCP Registry PR 4464](https://github.com/docker/mcp-registry/pull/4464) submits the public multi-architecture image `ghcr.io/lians-ai/lians-mcp:0.4.1`; GitHub reports `action_required` because workflows from the first-time fork require maintainer approval |
 | RoninForge State of MCP census | Indexed with a stale degraded result | The July 2 snapshot checked the retired `ebeirne/Lians` URL; the refreshed official registry manifest points to `Lians-ai/Lians` for the next census |
 | mcp.so | Queued for review | [Lians listing](https://mcp.so/servers/lians-b81d5f) |
 | MCPServers.org | Submitted on free tier | Review promised within 12 hours; notification routed to `support@lians.ai` |


### PR DESCRIPTION
## What changed

Records the Docker MCP Catalog submission in the verified distribution ledger.

## Why

The ledger should distinguish a public submission from a published listing and record the current maintainer approval requirement accurately.

## Validation

- Verified Docker PR 4464 is public and ready for review
- Verified both Docker workflows currently report `action_required`
- Ran `git diff --check`
