### PR TITLE
Add direct README star path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Lians-ai/Lians">Learn more</a>
+  <a href="https://www.lians.ai/">Website</a>
   -
   <a href="https://github.com/Lians-ai/Lians/tree/master/docs">Docs</a>
   -
   <a href="docs/install.md">Install</a>
   -
   <a href="https://github.com/Lians-ai/Lians#self-hosted-quickstart">Quickstart</a>
+  -
+  <a href="https://github.com/Lians-ai/Lians/stargazers"><strong>Star Lians</strong></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What changed

- Replaced the circular README "Learn more" link with the live Lians website.
- Added a direct, visible "Star Lians" action beside Docs, Install, and Quickstart.

## Why

The first README navigation link returned visitors to the page they were already viewing, while the repository had no direct star conversion path near its primary calls to action.

## Impact

Visitors can now reach the product website or star the repository without searching through GitHub controls.

## Validation

- `git diff --check`
- README-only HTML link change
