### PR TITLE
Add public issue routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Report reproducible incorrect behavior in Lians.
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping improve Lians. Please remove secrets and personal data from logs and examples.
+  - type: input
+    id: version
+    attributes:
+      label: Lians version
+      placeholder: v0.4.1, container digest, or commit SHA
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      options:
+        - Python SDK
+        - TypeScript SDK
+        - Go SDK
+        - Java SDK
+        - C SDK
+        - MCP server
+        - HTTP API
+        - Local engine
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+      description: Include the observed result and the result you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest safe example or exact steps that reproduce the issue.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: Operating system, runtime version, database, deployment mode
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I removed credentials, personal data, and confidential records.
+          required: true
+        - label: I searched existing issues for the same behavior.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Lians-ai/Lians/security/policy
+    about: Report security vulnerabilities through the private process in our security policy.
+  - name: Documentation
+    url: https://www.lians.ai/docs
+    about: Read setup, SDK, MCP, and deployment documentation.

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -1,0 +1,41 @@
+name: Integration request
+description: Propose or request an SDK, framework, MCP, or deployment integration.
+title: "integration: "
+labels: [enhancement]
+body:
+  - type: input
+    id: project
+    attributes:
+      label: Framework or platform
+      placeholder: LangGraph, CrewAI, AutoGen, OpenAI Agents SDK, MCP client, or deployment platform
+    validations:
+      required: true
+  - type: input
+    id: use_case
+    attributes:
+      label: Use case
+      placeholder: What should Lians enable in this framework or platform?
+    validations:
+      required: true
+  - type: textarea
+    id: interface
+    attributes:
+      label: Expected interface
+      description: Share the API shape, configuration, or developer workflow you expect.
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Relevant documentation
+      description: Link to the framework's official integration or contribution documentation.
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution interest
+      options:
+        - I can help implement or test this
+        - I can test a proposed integration
+        - I am requesting maintainer implementation
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/methodology_correction.yml
+++ b/.github/ISSUE_TEMPLATE/methodology_correction.yml
@@ -1,0 +1,50 @@
+name: Benchmark or methodology correction
+description: Challenge an evaluation result, adapter, default configuration, or capability claim with reproducible evidence.
+title: "methodology: "
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: We will rerun and correct factual errors. Disagreement is welcome; reproducible evidence makes it actionable.
+  - type: dropdown
+    id: artifact
+    attributes:
+      label: Artifact
+      options:
+        - Regulated-memory evaluation
+        - LOCOMO judged benchmark
+        - LOCOMO retrieval benchmark
+        - LongMemEval
+        - Competitor comparison page
+        - Adapter or default configuration
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: claim
+    attributes:
+      label: Claim or result being challenged
+      placeholder: Link to the exact page, report section, row, or source line.
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Proposed correction
+      description: State what is wrong and what the corrected claim or configuration should be.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction evidence
+      description: Include commands, configuration, output, and public source links where possible.
+    validations:
+      required: true
+  - type: checkboxes
+    id: permission
+    attributes:
+      label: Public handling
+      options:
+        - label: Lians may link this issue from the affected public report as a right of reply.
+          required: false


### PR DESCRIPTION
## What changed

- adds a structured bug report form
- adds an integration request form
- adds a benchmark and methodology correction form
- routes security reports to the private security policy and documentation questions to the website

## Why

The website now sends public engagement to GitHub Issues because repository Discussions is disabled. The repository previously offered only an unstructured blank issue, which made integration requests and factual benchmark corrections unnecessarily difficult.

## Impact

Developers and vendors now have explicit public routes for reproducible bugs, integration proposals, and right-of-reply corrections. Blank issues remain enabled for cases that do not fit a form.

## Validation

- parsed every YAML file with PyYAML
- verified unique issue-form field IDs
- checked the new files for em dashes
- `git diff --check`
