### PR TITLE
Ship semantic embeddings in local package extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ No environment variables are needed for local mode. Set `LIANS_URL`, `LIANS_API_
 ## Quickstart
 
 ```bash
-pip install lians-sdk[local]   # zero-setup local mode (SQLite, no Docker)
+pip install lians-sdk[local]   # SQLite plus real local semantic embeddings, no Docker
 ```
 
 ```python

--- a/agentmem/sdk/python/README.md
+++ b/agentmem/sdk/python/README.md
@@ -12,7 +12,7 @@
 
 ```bash
 pip install lians-sdk
-pip install lians-sdk[local]         # Zero-setup SQLite mode
+pip install lians-sdk[local]         # SQLite plus real local semantic embeddings
 pip install lians-sdk[mcp]           # Local MCP server
 pip install lians-sdk[langchain]     # LangChain
 pip install lians-sdk[langgraph]     # LangGraph

--- a/agentmem/sdk/python/pyproject.toml
+++ b/agentmem/sdk/python/pyproject.toml
@@ -42,6 +42,10 @@ local         = [
     # engine's db module builds its (unused-in-local-mode) default engine at
     # import time, which requires the asyncpg dialect to be importable
     "asyncpg>=0.29",
+    # LocalLiansClient defaults to this provider when it is installed. Keep it
+    # in the local extra so the documented install never falls back to the
+    # deterministic test-grade embedding stub.
+    "sentence-transformers>=3.0",
 ]
 mcp           = [
     "mcp>=1.0.0,<2",
@@ -55,6 +59,7 @@ mcp           = [
     "numpy>=1.26",
     "fastapi>=0.110",
     "asyncpg>=0.29",
+    "sentence-transformers>=3.0",
 ]
 all           = [
     "lians-sdk[langchain,langgraph,crewai,openai-agents,autogen,local,mcp]",

--- a/agentmem/tests/test_packaging.py
+++ b/agentmem/tests/test_packaging.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import tomllib
+
+
+def test_local_entry_point_extras_include_real_semantic_embeddings() -> None:
+    pyproject = Path(__file__).parents[1] / "sdk" / "python" / "pyproject.toml"
+    package = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    extras = package["project"]["optional-dependencies"]
+
+    for extra in ("local", "mcp"):
+        assert any(
+            dependency.startswith("sentence-transformers")
+            for dependency in extras[extra]
+        ), f"lians-sdk[{extra}] must not fall back to test-grade embeddings"


### PR DESCRIPTION
## What changed

- adds `sentence-transformers>=3.0` to the `local` and `mcp` package extras
- clarifies that the local install includes real semantic embeddings
- adds a packaging regression test for both local entry points

## Why

`LocalLiansClient` prefers sentence-transformers and warns users that `lians-sdk[local]` enables real semantic recall. The published extra did not include that dependency, so a clean documented install could fall back to the deterministic test-grade embedding provider. The same gap affected the standalone MCP extra.

## Impact

Future Python releases will give local and MCP users the semantic embedding behavior promised by the install command. Existing explicit embedding-provider overrides continue to work.

## Validation

- focused packaging test passed
- source distribution and wheel built successfully
- wheel metadata contains `sentence-transformers>=3.0` for `local`, `mcp`, and `all`
- `git diff --check`
