### PR TITLE
Release Python SDK 0.4.2

### DIFF
--- a/agentmem/sdk/python/pyproject.toml
+++ b/agentmem/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lians-sdk"
-version = "0.4.1"
+version = "0.4.2"
 description = "Bitemporal long-term memory for AI agents with point-in-time recall, tamper-evident audit trails, and GDPR crypto-erasure"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## What changed

Bumps the Python SDK patch version to 0.4.2 for the corrected local and MCP semantic-embedding extras already merged to `master`.

## Release scope

This is a Python-only patch release using the existing `lians-v*` publication workflow. It does not change TypeScript, Go, Java, or C versions.

## Validation

- focused packaging test passed
- source distribution and wheel built successfully
- wheel metadata reports version 0.4.2
- wheel metadata includes `sentence-transformers>=3.0` for `local` and `mcp`
- `git diff --check`