### PR TITLE
Allow recent Fly snapshot at production gate

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -129,11 +129,16 @@ jobs:
           volume_id="$(jq -er '.[0].id' <<<"$volumes")"
 
           before_ids="$RUNNER_TEMP/production-snapshot-ids-before.txt"
-          flyctl volumes snapshots list "$volume_id" \
-            --app agentmem-lotus-db \
-            --json |
-            jq -r '.[].id' |
+          before_snapshots="$(
+            flyctl volumes snapshots list "$volume_id" \
+              --app agentmem-lotus-db \
+              --json
+          )"
+          jq -r '.[].id' <<<"$before_snapshots" |
             sort >"$before_ids"
+          latest_before="$(
+            jq -ec 'sort_by(.created_at) | last' <<<"$before_snapshots"
+          )"
 
           # Fly currently prints a scheduling message even when --json is
           # requested. Confirm the backup through the snapshot list instead
@@ -144,6 +149,7 @@ jobs:
 
           snapshot_id=""
           snapshot_status=""
+          snapshot_source="new"
           for _ in $(seq 1 30); do
             snapshots="$(
               flyctl volumes snapshots list "$volume_id" \
@@ -168,11 +174,26 @@ jobs:
             sleep 2
           done
 
+          if [ -z "$snapshot_id" ]; then
+            # Fly may rate-limit or coalesce snapshot requests when an
+            # automatic snapshot was created recently. A recent encrypted
+            # snapshot still satisfies the rollback gate.
+            snapshot_id="$(jq -er '.id' <<<"$latest_before")"
+            snapshot_status="$(jq -er '.status' <<<"$latest_before")"
+            snapshot_created_at="$(jq -er '.created_at' <<<"$latest_before")"
+            snapshot_created_epoch="$(date -u -d "$snapshot_created_at" +%s)"
+            snapshot_age_seconds="$(( $(date -u +%s) - snapshot_created_epoch ))"
+            test "$snapshot_age_seconds" -ge 0
+            test "$snapshot_age_seconds" -le 7200
+            snapshot_source="existing recent"
+          fi
+
           test -n "$snapshot_id"
           test "$snapshot_status" = "created"
-          echo "Production database snapshot created: $snapshot_id"
+          echo "Production database snapshot selected: $snapshot_id ($snapshot_source)"
           echo "### Database safety" >> "$GITHUB_STEP_SUMMARY"
           echo "- Snapshot: \`$snapshot_id\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Source: $snapshot_source" >> "$GITHUB_STEP_SUMMARY"
           echo "- Volume: encrypted" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Deploy with release migration and canary health checks

--- a/docs/production-release.md
+++ b/docs/production-release.md
@@ -28,8 +28,9 @@ image is promoted.
 - Fly credentials are app-scoped and expire after 90 days.
 - The workflow rechecks the private staging database before touching
   production.
-- The workflow records the prior good image and creates a fresh encrypted
-  database-volume snapshot before deploying.
+- The workflow records the prior good image and requests a fresh encrypted
+  database-volume snapshot before deploying. If Fly coalesces that request,
+  it accepts only an existing `created` snapshot no older than two hours.
 - Fly gates promotion on `/readyz`.
 - The workflow verifies revision `0028_decision_envelopes` and the public API
   surface after deployment.
@@ -60,7 +61,8 @@ Do not proceed if any item is unknown.
 3. Choose the `master` branch, enter `DEPLOY`, and start the workflow.
 4. Confirm that **Recheck staging database** passes.
 5. Let the protected production job complete its five-minute wait.
-6. Confirm the workflow records a prior image and a new database snapshot.
+6. Confirm the workflow records a prior image and selects a `created`
+   database snapshot no older than two hours.
 7. Confirm the Fly release migration reaches `0028_decision_envelopes`.
 8. Confirm the deployment and public smoke checks pass.
 9. Inspect `/health`, `/readyz`, error rate, and request latency for at least
@@ -71,7 +73,7 @@ Do not proceed if any item is unknown.
 Abort or stop promotion if:
 
 - the staging database check fails;
-- no new production snapshot reaches `created`;
+- no production snapshot is both `created` and less than two hours old;
 - the release command fails or reports any revision other than
   `0028_decision_envelopes`;
 - `/readyz` does not become healthy within the workflow timeout;


### PR DESCRIPTION
## Summary
- prefer a newly-created production volume snapshot
- safely fall back only to a created encrypted snapshot no older than two hours when Fly coalesces the request
- document the exact backup gate

## Context
Production deploy attempts stopped before migration because Fly accepted the snapshot request but did not emit a second snapshot while a recent automatic snapshot already existed. Production remained unchanged.