### PR TITLE
Use restricted machine exec for schema checks

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -199,18 +199,39 @@ jobs:
             --release-command-timeout 10m \
             --wait-timeout 10m
 
-      - name: Verify schema revision inside the production app
+      - name: Resolve the production machine
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_SSH_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}
         run: |
           set -euo pipefail
-          revision="$(
-            flyctl ssh console \
+          production_machine_id="$(
+            flyctl machines list \
               --app agentmem-lotus \
-              --command "alembic -c alembic.ini current" \
-              --quiet 2>/dev/null |
-              awk 'NF { print $1; exit }'
+              --json |
+              jq -er '
+                [.[] | select(.state == "started")] as $started |
+                if ($started | length) == 1 then $started[0].id
+                else error("expected exactly one started production machine")
+                end
+              '
           )"
+          echo "PRODUCTION_MACHINE_ID=$production_machine_id" >> "$GITHUB_ENV"
+
+      - name: Verify schema revision inside the production app
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_MACHINE_EXEC_TOKEN }}
+        run: |
+          set -euo pipefail
+          output="$(
+            flyctl machine exec \
+              "$PRODUCTION_MACHINE_ID" \
+              "/bin/sh -lc 'cd /app/agentmem; alembic -c alembic.ini current'" \
+              --app agentmem-lotus \
+              --timeout 60 \
+              2>&1
+          )"
+          printf '%s\n' "$output"
+          revision="$(grep -oE '^0028_decision_envelopes' <<<"$output" | head -n 1)"
           test "$revision" = "0028_decision_envelopes"
           echo "Production schema revision: $revision"
 


### PR DESCRIPTION
## What changed

- resolves the single started production machine with the app deploy token
- verifies Alembic revision through a command-restricted Fly machine-exec token
- constrains that token to one exact read-only command inside `/app/agentmem`
- removes the unused broader SSH credential path

## Why

Release v22 deployed and migrated successfully, but `flyctl ssh console` still exited nonzero on a GitHub-hosted runner even with an app-scoped SSH token. Fly machine-exec avoids WireGuard/SSH setup and supports an exact-command capability token.

## Impact

The production workflow can prove the live schema revision without granting its verification step deploy or general SSH access.

## Validation

- exact restricted token and command returned `0028_decision_envelopes (head)` against the live machine
- production full public smoke passed after v22 cutover
- unused SSH and failed-test tokens were revoked