### PR TITLE
Harden runtime, webhooks, and deployment controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+* @Lians-ai @Ds6826 @ebeirne
+
+/.github/ @Lians-ai @Ds6826 @ebeirne
+/Dockerfile @Lians-ai @Ds6826 @ebeirne
+/fly.toml @Lians-ai @Ds6826 @ebeirne
+/agentmem/alembic/ @Lians-ai @Ds6826 @ebeirne
+/agentmem/src/lians/auth.py @Lians-ai @Ds6826 @ebeirne
+/agentmem/src/lians/config.py @Lians-ai @Ds6826 @ebeirne
+/agentmem/src/lians/crypto.py @Lians-ai @Ds6826 @ebeirne
+/agentmem/src/lians/middleware.py @Lians-ai @Ds6826 @ebeirne
+/agentmem/src/lians/webhook_service.py @Lians-ai @Ds6826 @ebeirne

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      python:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: /agentmem/sdk/python
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      python-sdk:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: /integrations/mcpb
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      mcpb:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: /packages/agentmem-backtest-check
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      backtest-check:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /agentmem/sdk/typescript
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      typescript-sdk:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /integrations/grafana-lians-app
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      grafana-app:
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directory: /agentmem/sdk/go
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      go-sdk:
+        patterns: ["*"]
+
+  - package-ecosystem: maven
+    directory: /agentmem/sdk/java
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      java-sdk:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+    branches: ["master", "main"]
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - name: Analyze
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches: ["master", "main"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Reject vulnerable dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+        with:
+          fail-on-severity: moderate
+          license-check: true
+          deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, SSPL-1.0

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -100,6 +100,15 @@ jobs:
 
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
 
+      - name: Install migration dependencies
+        run: >-
+          python -m pip install
+          "alembic>=1.13,<2"
+          "sqlalchemy[asyncio]>=2.0.30,<3"
+          "asyncpg>=0.29,<1"
+          "pydantic-settings>=2.14,<3"
+          "pgvector>=0.3,<1"
+
       - name: Record rollback image
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}
@@ -186,7 +195,38 @@ jobs:
           echo "- Age: $snapshot_age_seconds seconds" >> "$GITHUB_STEP_SUMMARY"
           echo "- Volume: encrypted" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Deploy with release migration and canary health checks
+      - name: Run migration through the private database tunnel
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_DB_TOKEN }}
+          MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          flyctl proxy 15433:5432 \
+            --app agentmem-lotus-db \
+            --bind-addr 127.0.0.1 \
+            --quiet \
+            >"$RUNNER_TEMP/fly-production-proxy.log" 2>&1 &
+          proxy_pid=$!
+          trap 'kill "$proxy_pid" 2>/dev/null || true' EXIT
+
+          python - <<'PY'
+          import socket
+          import time
+
+          deadline = time.monotonic() + 60
+          while time.monotonic() < deadline:
+              try:
+                  with socket.create_connection(("127.0.0.1", 15433), timeout=1):
+                      break
+              except OSError:
+                  time.sleep(1)
+          else:
+              raise SystemExit("Fly production proxy did not become ready within 60 seconds")
+          PY
+
+          python scripts/migrate_via_fly_proxy.py --host 127.0.0.1 --port 15433
+
+      - name: Deploy with canary health checks
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}
         run: |
@@ -196,7 +236,6 @@ jobs:
             --config fly.toml \
             --remote-only \
             --strategy canary \
-            --release-command-timeout 10m \
             --wait-timeout 10m
 
       - name: Resolve the production machine

--- a/.github/workflows/publish-backtest-check.yml
+++ b/.github/workflows/publish-backtest-check.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 
@@ -37,7 +37,7 @@ jobs:
         working-directory: packages/agentmem-backtest-check
 
       - name: Upload dist as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dist
           path: packages/agentmem-backtest-check/dist/
@@ -56,12 +56,12 @@ jobs:
 
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           packages-dir: dist/

--- a/.github/workflows/publish-lian-npm.yml
+++ b/.github/workflows/publish-lian-npm.yml
@@ -15,10 +15,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish-lian.yml
+++ b/.github/workflows/publish-lian.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
 
@@ -25,7 +25,7 @@ jobs:
         run: python -m build
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dist
           path: agentmem/sdk/python/dist/
@@ -38,12 +38,12 @@ jobs:
       id-token: write   # required for OIDC trusted publishing
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           skip-existing: true   # re-running a release tag is a no-op, not a failure

--- a/.github/workflows/publish-mcp-container.yml
+++ b/.github/workflows/publish-mcp-container.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 
@@ -47,17 +47,17 @@ jobs:
         run: python .github/scripts/smoke_mcp_container.py
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Publish image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           file: Dockerfile.glama

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
     name: Build Java jar
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
           java-version: "17"
@@ -27,7 +27,7 @@ jobs:
         run: mvn -B --no-transfer-progress package
         working-directory: agentmem/sdk/java
       - name: Attach jar to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: agentmem/sdk/java/target/*.jar
 
@@ -35,13 +35,13 @@ jobs:
     name: Package C source
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Create tarball
         run: |
           version="${GITHUB_REF_NAME#v}"
           tar -czf "lians-c-${version}.tar.gz" -C agentmem/sdk c
       - name: Attach tarball to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: lians-c-*.tar.gz
 
@@ -49,10 +49,10 @@ jobs:
     name: Tag Go module for go get
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.22"
       - name: Build & vet
@@ -81,8 +81,8 @@ jobs:
     # java-jar job attaches the jar to the Release.
     if: ${{ vars.PUBLISH_MAVEN_CENTRAL == 'true' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
           java-version: "17"

--- a/.github/workflows/riad-1.yml
+++ b/.github/workflows/riad-1.yml
@@ -24,9 +24,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: pip
@@ -46,7 +46,7 @@ jobs:
         run: python agentmem/benchmarks/riad_comparison.py --write --repetitions 10
 
       - name: Upload receipts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: riad-1-${{ github.sha }}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,6 +284,26 @@ jobs:
         run: go test ./...
         working-directory: agentmem/sdk/go
 
+  runtime-container:
+    name: Production runtime container
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Build production image without the optional local model
+        run: >-
+          docker build
+          --build-arg EXTRAS=
+          --build-arg PREDOWNLOAD_MODEL=
+          --tag lians-runtime:test
+          .
+
+      - name: Verify non-root runtime and application import
+        run: |
+          test "$(docker image inspect lians-runtime:test --format '{{.Config.User}}')" = "10001:10001"
+          docker run --rm lians-runtime:test python -c "import lians.main"
+
   mcp-container:
     name: Glama MCP container
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     name: Release, API, and dependency contracts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: pip
@@ -41,8 +41,8 @@ jobs:
       AGENTMEM_ALLOW_UNENCRYPTED: "true"
       RECALL_CACHE_ENABLED: "false"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: pip
@@ -77,7 +77,7 @@ jobs:
             --out results/claim-evidence-latest.json \
             --require foundation_verified
       - name: Preserve foundation evidence receipts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: memory-foundation-evidence-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
@@ -130,10 +130,10 @@ jobs:
       RECALL_CACHE_ENABLED: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -194,10 +194,10 @@ jobs:
         node-version: ["18", "20", "22"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -222,10 +222,10 @@ jobs:
         java-version: ["11", "17", "21"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
           java-version: ${{ matrix.java-version }}
@@ -241,7 +241,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Install libcurl dev headers
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
@@ -269,10 +269,10 @@ jobs:
         go-version: ["1.21", "1.22", "1.23"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -289,10 +289,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ARG EXTRAS=local
 COPY pyproject.toml ./
 COPY agentmem/src/ ./agentmem/src/
 RUN python -m pip install --no-cache-dir --upgrade pip==25.3 \
-    && python -m pip install --no-cache-dir ".[$EXTRAS]"
+    && if [ -n "$EXTRAS" ]; then package_spec=".[$EXTRAS]"; else package_spec="."; fi \
+    && python -m pip install --no-cache-dir "$package_spec"
 
 # Pre-download the local embedding model for zero-network runtime startup.
 ARG PREDOWNLOAD_MODEL=BAAI/bge-large-en-v1.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,60 @@
-﻿FROM python:3.12-slim
+FROM python:3.12-slim AS builder
 
 WORKDIR /app
 
-# System deps: gcc + libpq-dev for asyncpg C extension; libffi-dev for cryptography
+# Compilers and development headers exist only in the build stage.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
     libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies before copying the full source tree so that
-# Docker reuses this layer on code-only changes (pyproject.toml is the cache key).
-# [local] installs sentence-transformers for self-hosted, air-gapped deployments.
-# Pass --build-arg EXTRAS= to build a leaner image when using EMBEDDING_PROVIDER=voyage.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Install a wheel-style package into an isolated virtual environment. Avoid an
+# editable install whose .pth file would point back into the builder filesystem.
 ARG EXTRAS=local
 COPY pyproject.toml ./
 COPY agentmem/src/ ./agentmem/src/
-RUN pip install --no-cache-dir -e ".[$EXTRAS]"
+RUN python -m pip install --no-cache-dir --upgrade pip==25.3 \
+    && python -m pip install --no-cache-dir ".[$EXTRAS]"
 
-# Pre-download the sentence-transformers model at build time so:
-#   (a) first startup requires zero network access
-#   (b) runtime works with readOnlyRootFilesystem: true (no downloads at startup)
-# The model lands in /app/.model_cache (set via SENTENCE_TRANSFORMERS_HOME below).
-# Pass --build-arg PREDOWNLOAD_MODEL= to skip the download (e.g. CI, non-local provider).
+# Pre-download the local embedding model for zero-network runtime startup.
 ARG PREDOWNLOAD_MODEL=BAAI/bge-large-en-v1.5
 ENV SENTENCE_TRANSFORMERS_HOME=/app/.model_cache
-RUN if [ -n "$PREDOWNLOAD_MODEL" ]; then \
+RUN mkdir -p "$SENTENCE_TRANSFORMERS_HOME" \
+    && if [ -n "$PREDOWNLOAD_MODEL" ]; then \
       python -c "from sentence_transformers import SentenceTransformer; \
                  SentenceTransformer('$PREDOWNLOAD_MODEL')"; \
     fi
 
-# After baking the model in, tell HuggingFace libraries not to check for updates
-# or attempt any network calls. This enforces true air-gap behaviour at runtime.
-ENV TRANSFORMERS_OFFLINE=1
-ENV HF_DATASETS_OFFLINE=1
 
-# Copy the remaining source (migrations, SDK, examples)
-COPY agentmem/ ./agentmem/
+FROM python:3.12-slim AS runtime
 
-# Run from agentmem/ so that:
-#   - alembic finds alembic.ini in the CWD
-#   - uvicorn resolves src.lian.main via the CWD on sys.path
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 lians \
+    && useradd --system --uid 10001 --gid lians \
+       --create-home --home-dir /home/lians lians
+
+ENV PATH="/opt/venv/bin:${PATH}" \
+    SENTENCE_TRANSFORMERS_HOME=/app/.model_cache \
+    TRANSFORMERS_OFFLINE=1 \
+    HF_DATASETS_OFFLINE=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /app/.model_cache /app/.model_cache
+COPY agentmem/ /app/agentmem/
+
+RUN chown -R lians:lians /app /opt/venv /home/lians
+
 WORKDIR /app/agentmem
+USER 10001:10001
 
 EXPOSE 8000
 
-# The package is pip-installed (import name "lians") — do not reference the
-# src tree by path here; src.lian.main was a stale pre-rename path that made
-# the compose api service crash-loop while Render masked it via startCommand.
 CMD ["uvicorn", "lians.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/agentmem/.env.example
+++ b/agentmem/.env.example
@@ -83,6 +83,11 @@ API_SECRET_SEED=dev-seed-change-in-production
 # Generate: python -c "import secrets; print(secrets.token_urlsafe(48))"
 ADMIN_SECRET=dev-admin-secret-change-in-production
 
+# In production these default to false. Enable only on a private,
+# authenticated operations network.
+EXPOSE_API_DOCS=
+EXPOSE_HEALTH_DETAILS=
+
 # ── LLM adjudication — Stage 3 supersession (optional) ───────────────────
 # Catches paraphrase supersessions that rule-based Stage 2 misses.
 # Costs ~$0.00025 per call (Claude Haiku); disabled by default.

--- a/agentmem/src/lians/cache.py
+++ b/agentmem/src/lians/cache.py
@@ -21,10 +21,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from datetime import datetime
 from typing import Any, Optional
 
 _redis_client: Any = None
+logger = logging.getLogger("agentmem.cache")
 
 
 def _get_redis() -> Any:
@@ -122,7 +124,7 @@ async def set_cached_recall(
         )
         await redis.setex(key, ttl, payload)
     except Exception:
-        pass
+        logger.debug("Recall cache write failed; continuing without cache", exc_info=True)
 
 
 async def invalidate_agent(namespace: str, agent_id: str) -> None:
@@ -132,4 +134,4 @@ async def invalidate_agent(namespace: str, agent_id: str) -> None:
     try:
         await _get_redis().incr(_generation_key(namespace, agent_id))
     except Exception:
-        pass
+        logger.debug("Recall cache invalidation failed; continuing without cache", exc_info=True)

--- a/agentmem/src/lians/config.py
+++ b/agentmem/src/lians/config.py
@@ -64,6 +64,9 @@ class Settings(BaseSettings):
     # API
     api_secret_seed: str = "dev-seed-change-in-prod"
     admin_secret: str = "dev-admin-secret-change-in-prod"
+    # None follows the environment: enabled in development, disabled in production.
+    expose_api_docs: bool | None = None
+    expose_health_details: bool | None = None
 
     # LLM adjudication (Stage 3 supersession)
     anthropic_api_key: str = ""          # falls back to ANTHROPIC_API_KEY env var

--- a/agentmem/src/lians/main.py
+++ b/agentmem/src/lians/main.py
@@ -41,6 +41,7 @@ from .middleware import (
     AccessLogMiddleware,
     RequestBodyLimitMiddleware,
     RateLimitMiddleware,
+    SecurityHeadersMiddleware,
 )
 
 logger = logging.getLogger("lians.startup")
@@ -157,6 +158,29 @@ def _start_embedding_warmup(
     )
 
 
+async def _validate_database_role(engine, *, production: bool) -> None:
+    """Refuse production startup when PostgreSQL can bypass tenant RLS."""
+    if not production or engine.dialect.name != "postgresql":
+        return
+    async with engine.connect() as connection:
+        role = (
+            await connection.execute(
+                text(
+                    """
+                    SELECT r.rolsuper, r.rolbypassrls
+                    FROM pg_roles AS r
+                    WHERE r.rolname = current_user
+                    """
+                )
+            )
+        ).mappings().one()
+    if role["rolsuper"] or role["rolbypassrls"]:
+        raise RuntimeError(
+            "Unsafe production database role: the application connection must "
+            "be NOSUPERUSER and NOBYPASSRLS so tenant policies are enforceable"
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from .db import (
@@ -174,6 +198,7 @@ async def lifespan(app: FastAPI):
 
     _warn_insecure_secrets(settings)
     _validate_production_secrets(settings)
+    await _validate_database_role(engine, production=_is_production)
 
     if settings.airgap_mode:
         _validate_airgap(settings)
@@ -279,6 +304,17 @@ async def lifespan(app: FastAPI):
     logger.info("Lians shutdown")
 
 
+_runtime_settings = get_settings()
+_is_production = _runtime_settings.deployment_environment.strip().lower() in {
+    "prod",
+    "production",
+}
+_docs_enabled = (
+    _runtime_settings.expose_api_docs
+    if _runtime_settings.expose_api_docs is not None
+    else not _is_production
+)
+
 app = FastAPI(
     title="Lians",
     description=(
@@ -287,6 +323,9 @@ app = FastAPI(
     ),
     version="0.5.0",
     lifespan=lifespan,
+    docs_url="/docs" if _docs_enabled else None,
+    redoc_url="/redoc" if _docs_enabled else None,
+    openapi_url="/openapi.json" if _docs_enabled else None,
 )
 
 
@@ -343,6 +382,7 @@ app.add_middleware(
     RequestBodyLimitMiddleware,
     max_bytes=get_settings().max_request_body_bytes,
 )
+app.add_middleware(SecurityHeadersMiddleware, production=_is_production)
 
 app.include_router(memory_router)
 app.include_router(audit_router)
@@ -404,12 +444,19 @@ async def health(db: AsyncSession = Depends(_get_db)):
     degradations = recent_degradations()
     all_ok = all(v in ("ok", "disabled") for v in checks.values())
     status = "ok" if all_ok and not degradations else "degraded"
-    return JSONResponse(
-        content={
-            "status": status,
+    details_enabled = (
+        get_settings().expose_health_details
+        if get_settings().expose_health_details is not None
+        else not _is_production
+    )
+    content = {"status": status}
+    if details_enabled:
+        content.update({
             "checks": checks,
             "recent_degradations": degradations,
-        },
+        })
+    return JSONResponse(
+        content=content,
         status_code=200 if all_ok else 503,
     )
 

--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -595,7 +595,9 @@ async def add_memory(
                     req.metadata = enriched_meta
                     span.set_attribute("auto_metadata_keys", ",".join(auto_prov["keys"]))
             except Exception:
-                pass  # fail-open: enrichment must never break ingestion
+                # Fail-open: enrichment must never break ingestion, but the
+                # degraded path must remain observable to operators.
+                logger.debug("Auto-metadata enrichment failed", exc_info=True)
 
         # Compile a typed, versioned memory artifact into reserved metadata.
         # The raw content is never rewritten and the projection includes the

--- a/agentmem/src/lians/middleware.py
+++ b/agentmem/src/lians/middleware.py
@@ -3,7 +3,7 @@ Production middleware: request IDs, structured JSON access logging, rate limitin
 
 RequestIDMiddleware   — assigns X-Request-ID to every request; propagates via ContextVar
 AccessLogMiddleware   — logs one JSON line per request with method/path/status/duration_ms
-RateLimitMiddleware   — sliding-window per-API-key limit backed by Redis; fails open
+RateLimitMiddleware   — Redis-backed limit with a bounded local fallback
 
 All three are registered in main.py before any route middleware so they wrap
 every request uniformly, including 4xx/5xx responses from FastAPI's own validation.
@@ -15,6 +15,7 @@ import json
 import logging
 import time
 import uuid
+from collections import OrderedDict
 from contextvars import ContextVar
 from datetime import datetime, timezone
 
@@ -121,6 +122,31 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
         return response
 
 
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Apply browser and transport hardening to every API response."""
+
+    def __init__(self, app, *, production: bool = False):
+        super().__init__(app)
+        self._production = production
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["Permissions-Policy"] = (
+            "camera=(), microphone=(), geolocation=(), payment=()"
+        )
+        if self._production:
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains"
+            )
+            response.headers["Content-Security-Policy"] = (
+                "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+            )
+        return response
+
+
 class RequestBodyLimitMiddleware:
     """Streaming ASGI request-body cap; also handles chunked requests."""
 
@@ -183,9 +209,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     """
     Sliding-window rate limit keyed by API key hash (300 req/min default).
 
-    Uses Redis INCR + EXPIRE for atomic counting across multiple workers.
-    Fails open — if Redis is unavailable, requests pass through unthrottled
-    rather than taking the service down with it.
+    Uses Redis INCR + EXPIRE for atomic counting across multiple workers. If
+    Redis is unavailable, a bounded per-process fallback keeps throttling
+    active instead of silently disabling the control.
 
     The raw API key is never written to Redis; only the first 16 hex chars
     of its SHA-256 hash are used as the key discriminator.
@@ -195,6 +221,36 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self._limit = requests_per_minute
         self._window = 60  # seconds
+        self._fallback: OrderedDict[str, tuple[int, int]] = OrderedDict()
+        self._fallback_max_buckets = 10_000
+
+    def _fallback_increment(self, discriminator: str) -> int:
+        """Return the local count using a bounded fixed-minute window."""
+        window_id = int(time.monotonic() // self._window)
+        previous_window, previous_count = self._fallback.get(
+            discriminator, (-1, 0)
+        )
+        count = previous_count + 1 if previous_window == window_id else 1
+        self._fallback[discriminator] = (window_id, count)
+        self._fallback.move_to_end(discriminator)
+        while len(self._fallback) > self._fallback_max_buckets:
+            self._fallback.popitem(last=False)
+        return count
+
+    def _limit_response(self) -> Response:
+        return Response(
+            content=json.dumps({
+                "detail": f"Rate limit exceeded ({self._limit} req/min). "
+                          f"Retry after {self._window} seconds."
+            }),
+            status_code=429,
+            headers={
+                "Content-Type": "application/json",
+                "Retry-After": str(self._window),
+                "X-RateLimit-Limit": str(self._limit),
+                "X-RateLimit-Remaining": "0",
+            },
+        )
 
     async def dispatch(self, request: Request, call_next) -> Response:
         # Health checks are exempt — LB probes must never be rate-limited
@@ -229,23 +285,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
             remaining = max(0, self._limit - count)
             if count > self._limit:
-                return Response(
-                    content=json.dumps({
-                        "detail": f"Rate limit exceeded ({self._limit} req/min). "
-                                  f"Retry after {self._window} seconds."
-                    }),
-                    status_code=429,
-                    headers={
-                        "Content-Type": "application/json",
-                        "Retry-After": str(self._window),
-                        "X-RateLimit-Limit": str(self._limit),
-                        "X-RateLimit-Remaining": "0",
-                    },
-                )
+                return self._limit_response()
         except Exception:
             from .degradation import record_degradation
             record_degradation("rate_limit", "redis_unavailable")
-            remaining = None  # Redis down — can't compute, skip headers
+            count = self._fallback_increment(discriminator)
+            remaining = max(0, self._limit - count)
+            if count > self._limit:
+                return self._limit_response()
 
         response = await call_next(request)
 

--- a/agentmem/src/lians/ranking.py
+++ b/agentmem/src/lians/ranking.py
@@ -22,6 +22,7 @@ Point-in-time queries (as_of set) still go to the ``memories`` table because
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import os
 import re
@@ -35,6 +36,7 @@ from .models import Memory, LiveFact
 from .crypto import decrypt_content
 
 _ANN_PREFETCH_MULTIPLIER = 20
+logger = logging.getLogger("agentmem.ranking")
 
 W_SEM = 0.50
 # BM25 is unbounded while cosine lives in [-1, 1]; at 0.20 a single strong
@@ -507,7 +509,10 @@ async def _fetch_live_candidates(
             result = await db.execute(ann_stmt)
             return list(result.scalars().all())
         except Exception:
-            pass
+            logger.debug(
+                "Live-fact ANN query failed; falling back to deterministic scan",
+                exc_info=True,
+            )
 
     result = await db.execute(base_stmt)
     return list(result.scalars().all())
@@ -554,7 +559,10 @@ async def _fetch_historical_candidates(
             result = await db.execute(ann_stmt)
             return list(result.scalars().all())
         except Exception:
-            pass
+            logger.debug(
+                "Historical ANN query failed; falling back to deterministic scan",
+                exc_info=True,
+            )
 
     result = await db.execute(base_stmt)
     return list(result.scalars().all())

--- a/agentmem/src/lians/webhook_service.py
+++ b/agentmem/src/lians/webhook_service.py
@@ -32,7 +32,7 @@ import socket
 import uuid
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -102,30 +102,50 @@ def _validate_webhook_url(url: str) -> tuple[str, int]:
     return host, port
 
 
-async def _validate_webhook_destination(url: str) -> None:
-    """Resolve a webhook immediately before delivery and require public IPs."""
+async def _resolve_webhook_destination(url: str) -> tuple[str, str, str]:
+    """Resolve once, require public IPs, and return an IP-pinned HTTPS target.
+
+    Validation followed by a normal hostname request creates a DNS-rebinding
+    window because the HTTP client resolves the name a second time. Connecting
+    to the validated address while retaining the original Host header and TLS
+    SNI closes that gap.
+    """
     host, port = _validate_webhook_url(url)
     try:
-        ipaddress.ip_address(host)
-        return  # Public literal IP was checked above.
+        literal = ipaddress.ip_address(host)
     except ValueError:
-        pass
-
-    try:
-        addresses = await asyncio.to_thread(
-            socket.getaddrinfo,
-            host,
-            port,
-            type=socket.SOCK_STREAM,
-        )
-    except OSError as exc:
-        raise ValueError("Webhook hostname could not be resolved") from exc
-    if not addresses:
-        raise ValueError("Webhook hostname could not be resolved")
-    for info in addresses:
-        address = ipaddress.ip_address(info[4][0])
-        if not address.is_global:
+        try:
+            addresses = await asyncio.to_thread(
+                socket.getaddrinfo,
+                host,
+                port,
+                type=socket.SOCK_STREAM,
+            )
+        except OSError as exc:
+            raise ValueError("Webhook hostname could not be resolved") from exc
+        if not addresses:
+            raise ValueError("Webhook hostname could not be resolved")
+        resolved = [ipaddress.ip_address(info[4][0]) for info in addresses]
+        if any(not address.is_global for address in resolved):
             raise ValueError("Webhook hostname resolves to a non-public address")
+        address = resolved[0]
+    else:
+        address = literal
+
+    parsed = urlsplit(url)
+    address_text = f"[{address}]" if address.version == 6 else str(address)
+    pinned_netloc = address_text if port == 443 else f"{address_text}:{port}"
+    pinned_url = urlunsplit(
+        ("https", pinned_netloc, parsed.path or "/", parsed.query, "")
+    )
+    host_text = f"[{host}]" if ":" in host else host
+    host_header = host_text if port == 443 else f"{host_text}:{port}"
+    return pinned_url, host_header, host
+
+
+async def _validate_webhook_destination(url: str) -> None:
+    """Compatibility validation helper used by callers and older integrations."""
+    await _resolve_webhook_destination(url)
 
 
 # ── HTTP delivery (isolated so tests can mock it) ─────────────────────────────
@@ -133,7 +153,7 @@ async def _validate_webhook_destination(url: str) -> None:
 async def _http_post(url: str, body: bytes, signature: str) -> tuple[int, str]:
     """POST body to url with signature header.  Returns (status_code, error_or_empty)."""
     try:
-        await _validate_webhook_destination(url)
+        pinned_url, host_header, sni_hostname = await _resolve_webhook_destination(url)
     except ValueError as exc:
         return 0, f"Blocked webhook destination: {exc}"
 
@@ -149,13 +169,15 @@ async def _http_post(url: str, body: bytes, signature: str) -> tuple[int, str]:
             trust_env=False,
         ) as client:
             resp = await client.post(
-                url,
+                pinned_url,
                 content=body,
                 headers={
                     "Content-Type": "application/json",
+                    "Host": host_header,
                     "X-Lians-Signature": signature,
                     "X-AgentMem-Signature": signature,
                 },
+                extensions={"sni_hostname": sni_hostname},
             )
             return resp.status_code, "" if resp.is_success else resp.text[:500]
     except Exception as exc:

--- a/agentmem/tests/test_middleware.py
+++ b/agentmem/tests/test_middleware.py
@@ -265,7 +265,7 @@ class TestRateLimitMiddleware:
         assert resp.headers.get("X-RateLimit-Remaining") == "0"
 
     async def test_redis_down_fails_open(self, client):
-        """If Redis is unreachable, rate limiting must not block requests."""
+        """The first local-fallback request passes when Redis is unreachable."""
         with patch("src.lians.cache._get_redis") as mock_redis:
             mock_redis.return_value.incr = AsyncMock(side_effect=ConnectionError("Redis down"))
             resp = await client.post(
@@ -275,6 +275,38 @@ class TestRateLimitMiddleware:
             )
         # Should get a normal response (401/200/422) â€” NOT 429
         assert resp.status_code != 429
+
+    async def test_redis_down_uses_bounded_local_fallback(self):
+        """Redis failure must not silently disable throttling."""
+        from fastapi import FastAPI
+        from src.lians.middleware import RateLimitMiddleware
+
+        limited_app = FastAPI()
+
+        @limited_app.get("/limited")
+        async def limited():
+            return {"ok": True}
+
+        limited_app.add_middleware(RateLimitMiddleware, requests_per_minute=1)
+        with patch("src.lians.cache._get_redis") as mock_redis:
+            mock_redis.return_value.incr = AsyncMock(
+                side_effect=ConnectionError("Redis down")
+            )
+            async with AsyncClient(
+                transport=ASGITransport(app=limited_app),
+                base_url="http://test",
+            ) as local_client:
+                first = await local_client.get(
+                    "/limited", headers={"X-API-Key": "fallback-key"}
+                )
+                second = await local_client.get(
+                    "/limited", headers={"X-API-Key": "fallback-key"}
+                )
+
+        assert first.status_code == 200
+        assert first.headers["X-RateLimit-Remaining"] == "0"
+        assert second.status_code == 429
+        assert second.headers["Retry-After"] == "60"
 
     async def test_health_exempt_from_rate_limit(self, client):
         """Health checks must never be rate-limited regardless of Redis state."""
@@ -341,6 +373,29 @@ class TestRateLimitMiddleware:
             "RateLimitMiddleware is not wired to the configured limit — "
             "RATE_LIMIT_PER_MINUTE is being ignored"
         )
+
+
+@pytest.mark.asyncio
+async def test_production_security_headers_are_applied():
+    from fastapi import FastAPI
+    from src.lians.middleware import SecurityHeadersMiddleware
+
+    secured_app = FastAPI()
+
+    @secured_app.get("/resource")
+    async def resource():
+        return {"ok": True}
+
+    secured_app.add_middleware(SecurityHeadersMiddleware, production=True)
+    async with AsyncClient(
+        transport=ASGITransport(app=secured_app), base_url="https://test"
+    ) as security_client:
+        response = await security_client.get("/resource")
+
+    assert response.headers["Strict-Transport-Security"].startswith("max-age=")
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert "default-src 'none'" in response.headers["Content-Security-Policy"]
 
 
 @pytest.mark.asyncio

--- a/agentmem/tests/test_migrate_via_fly_proxy.py
+++ b/agentmem/tests/test_migrate_via_fly_proxy.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.migrate_via_fly_proxy import _proxied_url
+
+
+def test_proxied_url_preserves_credentials_database_and_query():
+    result = _proxied_url(
+        "postgresql+asyncpg://migration:encoded%2Fsecret@db.internal:5432/lians?ssl=require",
+        "127.0.0.1",
+        15433,
+    )
+    assert result == (
+        "postgresql+asyncpg://migration:encoded%2Fsecret@127.0.0.1:15433/"
+        "lians?ssl=require"
+    )
+
+
+def test_proxied_url_rejects_non_postgres():
+    try:
+        _proxied_url("sqlite:///tmp.db", "127.0.0.1", 15433)
+    except ValueError as exc:
+        assert "PostgreSQL" in str(exc)
+    else:
+        raise AssertionError("non-PostgreSQL migration URLs must be rejected")

--- a/agentmem/tests/test_webhooks.py
+++ b/agentmem/tests/test_webhooks.py
@@ -22,7 +22,7 @@ from src.lians.models import ApiKey, DurableJob, WebhookEndpoint, WebhookDeliver
 from src.lians.webhook_service import (
     register_webhook, list_webhooks, delete_webhook, update_webhook,
     dispatch_event, handle_webhook_job, _sign, _http_post,
-    _validate_webhook_url,
+    _validate_webhook_url, _resolve_webhook_destination,
     MEMORY_SUPERSEDED, MEMORY_CONFLICT, MEMORY_ERASED,
 )
 
@@ -122,6 +122,21 @@ async def test_http_post_blocks_private_destination_before_network():
     )
     assert status == 0
     assert "Blocked webhook destination" in error
+
+
+@pytest.mark.asyncio
+async def test_webhook_destination_is_pinned_to_validated_ip():
+    resolved = [
+        (2, 1, 6, "", ("93.184.216.34", 443)),
+    ]
+    with patch("src.lians.webhook_service.socket.getaddrinfo", return_value=resolved):
+        target, host_header, sni_hostname = await _resolve_webhook_destination(
+            "https://hooks.example.test/events?id=1"
+        )
+
+    assert target == "https://93.184.216.34/events?id=1"
+    assert host_header == "hooks.example.test"
+    assert sni_hostname == "hooks.example.test"
 
 
 @pytest.mark.asyncio

--- a/fly.toml
+++ b/fly.toml
@@ -9,9 +9,6 @@ primary_region = 'sjc'  # colocated with agentmem-lotus-db — cross-region DB c
   # the ~1.3GB sentence-transformers model, and 2×1.6GB OOM-loops a 2GB VM.
   app = "uvicorn lians.main:app --host 0.0.0.0 --port 8000 --workers 1"
 
-[deploy]
-  release_command = "alembic upgrade head"
-
 [http_service]
   internal_port        = 8000
   force_https          = true

--- a/scripts/migrate_via_fly_proxy.py
+++ b/scripts/migrate_via_fly_proxy.py
@@ -1,0 +1,51 @@
+"""Run Alembic through a local Fly proxy without exposing migration credentials.
+
+The production application uses a least-privilege role. DDL credentials live
+only in the protected GitHub environment and are rewritten to the loopback
+proxy for this one process.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _proxied_url(source: str, host: str, port: int) -> str:
+    parsed = urlsplit(source)
+    if parsed.scheme not in {"postgresql", "postgres", "postgresql+asyncpg"}:
+        raise ValueError("Migration URL must be PostgreSQL")
+    if not parsed.username or not parsed.hostname or not parsed.path.strip("/"):
+        raise ValueError("Migration URL is incomplete")
+    userinfo = parsed.username
+    if parsed.password is not None:
+        userinfo = f"{userinfo}:{parsed.password}"
+    netloc = f"{userinfo}@{host}:{port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, ""))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=15433)
+    args = parser.parse_args()
+
+    source = os.environ.pop("MIGRATION_DATABASE_URL", "")
+    if not source:
+        raise SystemExit("MIGRATION_DATABASE_URL is required")
+    os.environ["DATABASE_URL"] = _proxied_url(source, args.host, args.port)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    agentmem = repo_root / "agentmem"
+    os.chdir(agentmem)
+
+    from alembic import command
+    from alembic.config import Config
+
+    command.upgrade(Config(str(agentmem / "alembic.ini")), "head")
+    print("Production database migration completed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
﻿## What changed

- closes webhook DNS rebinding and private-network request paths by binding delivery to the validated address while preserving Host and TLS identity
- adds production security headers, private API documentation defaults, limited health output, and bounded rate-limit fallback behavior
- rejects privileged PostgreSQL runtime roles and separates migrations into a protected owner credential routed through a Fly proxy
- moves the production container to a multi-stage, non-root runtime image
- pins every GitHub Action to a full commit SHA and adds CodeQL, dependency review, Dependabot, and CODEOWNERS
- adds regression coverage for middleware, webhook delivery, and migration URL handling

## Why

The security review found avoidable production exposure around outbound webhooks, runtime database privilege, fail-open rate limiting, mutable supply-chain references, and container privilege. This change makes those boundaries explicit and testable.

## Impact

Production deploys now migrate with the protected `MIGRATION_DATABASE_URL` environment secret, then run the application with the least-privilege `lians_app` role. Production API docs and detailed health metadata are hidden unless explicitly enabled.

## Validation

- 903 tests passed, 10 skipped across the Python application and SDK/integration slices
- 18 TypeScript SDK tests passed
- Alembic upgrade to head succeeded on real PostgreSQL
- Ruff and compileall passed
- Bandit reported zero findings
- isolated project dependency audit reported zero known vulnerabilities
- release and OpenAPI contracts passed
- workflow action references are all full-SHA pinned

GitHub CI built the production runtime image, verified its non-root user, imported the application from the final layer, and passed the Go, Java, C, TypeScript, and Python paths unavailable through the local workstation toolchains.
