### PR TITLE
Fix human-facing MCP Registry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
   <a href="https://www.npmjs.com/package/@lians-ai/lians">
     <img src="https://img.shields.io/npm/v/%40lians-ai%2Flians?label=npm" alt="npm version">
   </a>
-  <a href="https://registry.modelcontextprotocol.io/v0/servers/io.github.ebeirne%2Flians/versions/latest">
+  <a href="https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians">
     <img src="https://img.shields.io/badge/MCP-Official%20Registry-blueviolet" alt="MCP Official Registry">
   </a>
   <a href="LICENSE">
@@ -152,7 +152,7 @@ Procurement and technical review materials:
 
 ## MCP - Native tool in any AI client
 
-Lians is listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.ebeirne%2Flians/versions/latest). Any MCP-compatible host - Claude Desktop, Cursor, VS Code, Windsurf, and others - can use local persistent memory immediately or connect to a hosted Lians server. No SDK code, custom adapter, Docker service, URL, or API key is required for local mode.
+Lians is listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians). Any MCP-compatible host - Claude Desktop, Cursor, VS Code, Windsurf, and others - can use local persistent memory immediately or connect to a hosted Lians server. No SDK code, custom adapter, Docker service, URL, or API key is required for local mode.
 
 Your agents get eight tools automatically:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,7 +49,7 @@ Pushing a `vX.Y.Z` tag triggers:
   mcp-publisher login github     # interactive device flow; token expires
   mcp-publisher publish
   # verify:
-  curl -s "https://registry.modelcontextprotocol.io/v0/servers/io.github.ebeirne%2Flians/versions/latest"
+  curl -fsS "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ebeirne%2Flians&version=latest"
   ```
 
 - Verify: `pip install lians-sdk==X.Y.Z`, `npm view @lians-ai/lians`, `go get github.com/Lians-ai/Lians/agentmem/sdk/go@vX.Y.Z`, and the Maven Central listing.

--- a/docs/migrate-from-zep.md
+++ b/docs/migrate-from-zep.md
@@ -103,7 +103,7 @@ For production deployment (Fly.io, Kubernetes, bare Docker): [docs/deploy.md](de
 
 ## MCP server
 
-Lians is listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.ebeirne%2Flians/versions/latest). Add it to Claude Desktop, Cursor, or Windsurf:
+Lians is listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians). Add it to Claude Desktop, Cursor, or Windsurf:
 
 ```json
 {

--- a/skills/README.md
+++ b/skills/README.md
@@ -24,7 +24,7 @@ npx skills add https://github.com/Lians-ai/Lians --skill lians-integrate
 - **Codex** — drop-in `AGENTS.md` and MCP config in
   [`../integrations/codex`](../integrations/codex).
 - **Any MCP host** — Lians is on the
-  [official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.ebeirne%2Flians/versions/latest).
+  [official MCP Registry](https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians).
 
 ## Why these exist
 


### PR DESCRIPTION
## What changed

- Replaced four GitHub documentation links that sent readers to a raw MCP Registry JSON endpoint with the Registry's human-facing, pre-filtered Lians search page.
- Updated the release verification command to the stable `/v0.1/servers` API with `search` and `version=latest`.

## Why

The old URL is a machine API path, so clicking the README badge or documentation link produced raw JSON rather than a usable Registry page.

## User and developer impact

Readers now land on the Official MCP Registry UI already filtered to `io.github.ebeirne/lians`. Maintainers retain a strict machine-readable verification command for release checks.

## Root cause

One endpoint was being used for two different jobs: human navigation and machine verification. The Registry exposes separate UI and stable API surfaces for those purposes.

## Validation

- Human Registry URL: HTTP 200, title `Official MCP Registry`
- Stable machine API: HTTP 200, one exact `io.github.ebeirne/lians` record, version `0.4.1`, status `active`, latest `true`
- Repo-wide stale `/v0/servers/.../versions/latest` scan: zero matches
- `git diff --check`: passing
