### PR TITLE
Fix SQLite UUID coercion flake

### DIFF
--- a/agentmem/src/lians/models.py
+++ b/agentmem/src/lians/models.py
@@ -3,13 +3,16 @@ from datetime import datetime, timezone
 from sqlalchemy import (
     Column, String, Text, DateTime, Float, Boolean,
     ForeignKey, Index, LargeBinary, JSON, Integer,
-    UniqueConstraint, text, types as sa_types,
+    UniqueConstraint, Uuid as UUID, text, types as sa_types,
 )
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.engine import Dialect
 from pgvector.sqlalchemy import Vector
 from .db import Base
 from .config import get_settings
+
+# Use SQLAlchemy's cross-dialect type: native UUID on PostgreSQL and CHAR(32)
+# on SQLite. PostgreSQL's dialect-only UUID type gives SQLite numeric affinity,
+# which can coerce rare numeric-looking UUID hex strings into integers/floats.
 
 
 class _FlexVector(sa_types.TypeDecorator):

--- a/agentmem/tests/test_sqlite_uuid_storage.py
+++ b/agentmem/tests/test_sqlite_uuid_storage.py
@@ -1,0 +1,40 @@
+"""Regression coverage for UUID storage in the SQLite unit-test backend."""
+
+import hashlib
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+
+from src.lians.models import ApiKey
+
+
+@pytest.mark.asyncio
+async def test_numeric_uuid_hex_is_preserved_as_text(db):
+    """SQLite must not coerce a UUID that happens to look numeric into a number."""
+    key_id = uuid.UUID(int=1)
+    hashed_key = hashlib.sha256(b"numeric-looking-uuid").hexdigest()
+    db.add(
+        ApiKey(
+            id=key_id,
+            hashed_key=hashed_key,
+            namespace="uuid-storage-test",
+            scopes=["read"],
+        )
+    )
+    await db.commit()
+
+    raw_id, storage_type = (
+        await db.execute(
+            text("SELECT id, typeof(id) FROM api_keys WHERE hashed_key = :hashed_key"),
+            {"hashed_key": hashed_key},
+        )
+    ).one()
+    assert raw_id == key_id.hex
+    assert storage_type == "text"
+
+    db.expunge_all()
+    restored = (
+        await db.execute(select(ApiKey).where(ApiKey.hashed_key == hashed_key))
+    ).scalar_one()
+    assert restored.id == key_id


### PR DESCRIPTION
## What changed

- use SQLAlchemy's cross-dialect UUID type so PostgreSQL keeps native UUID columns while SQLite uses `CHAR(32)`
- add a deterministic regression using `UUID(int=1)` to prove numeric-looking UUID hex values remain text and round-trip correctly

## Root cause

The PostgreSQL-only UUID type compiled to a column named `UUID` under SQLite. SQLite assigns that type numeric affinity, so a rare UUID containing only numeric-looking hex characters could be coerced to an integer or float. SQLAlchemy's UUID result processor then failed while reconstructing the ORM row. This caused the Python 3.11 `test_missing_simulation_as_of` CI failure after 760 passing tests.

## Impact

Production PostgreSQL behavior remains native UUID. The change stabilizes the in-memory SQLite test backend and prevents the same rare coercion anywhere SQLite is used.

## Validation

- deterministic reproduction confirmed the old type stored `UUID(int=1)` as SQLite `integer` and failed ORM reconstruction
- `agentmem/tests/test_sqlite_uuid_storage.py`: 1 passed
- UUID regression plus full backtest file: 16 passed
- CI-selected Ruff checks passed
- `git diff --check` passed

Production deployment remains held until this PR's Python 3.11/3.12 checks are green.
