### PR TITLE
Fix production post-deploy verification gates

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -263,30 +263,89 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}
         run: |
           set -euo pipefail
+          image_label="deployment-github-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          deployed_image="registry.fly.io/agentmem-lotus:${image_label}"
           flyctl deploy \
             --app agentmem-lotus \
             --config fly.toml \
+            --image-label "$image_label" \
             --remote-only \
             --strategy canary \
             --wait-timeout 10m
+          echo "DEPLOYED_IMAGE=$deployed_image" >> "$GITHUB_ENV"
 
       - name: Resolve the production machine
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}
         run: |
           set -euo pipefail
-          production_machine_id="$(
-            flyctl machines list \
-              --app agentmem-lotus \
-              --json |
-              jq -er '
-                [.[] | select(.state == "started")] as $started |
-                if ($started | length) == 1 then $started[0].id
-                else error("expected exactly one started production machine")
-                end
-              '
-          )"
+          production_machine_id=""
+          machines='[]'
+
+          # flyctl deploy can return while the control plane briefly reports the
+          # updated machine as "replacing". Poll until the newest complete
+          # release and the only started machine both identify this exact build.
+          for attempt in $(seq 1 60); do
+            if ! releases="$(flyctl releases --app agentmem-lotus --json)"; then
+              sleep 2
+              continue
+            fi
+            if ! jq -e --arg image "$DEPLOYED_IMAGE" '
+              length > 0
+              and .[0].Status == "complete"
+              and .[0].ImageRef == $image
+            ' <<<"$releases" >/dev/null; then
+              sleep 2
+              continue
+            fi
+
+            if ! machines="$(
+              flyctl machines list \
+                --app agentmem-lotus \
+                --json
+            )"; then
+              sleep 2
+              continue
+            fi
+
+            set +e
+            production_machine_id="$(
+              python scripts/select_fly_production_machine.py \
+                --expected-image "$DEPLOYED_IMAGE" \
+                --expected-sha "$GITHUB_SHA" \
+                <<<"$machines"
+            )"
+            selection_status=$?
+            set -e
+            if [ "$selection_status" -eq 0 ]; then
+              break
+            fi
+            if [ "$selection_status" -ne 1 ]; then
+              exit "$selection_status"
+            fi
+            if [ $((attempt % 10)) -eq 0 ]; then
+              echo "Waiting for Fly to converge on the exact release (attempt $attempt/60)."
+            fi
+            sleep 2
+          done
+
+          if [ -z "$production_machine_id" ]; then
+            echo "Fly did not converge on the exact healthy production release." >&2
+            echo "Expected image: $DEPLOYED_IMAGE" >&2
+            jq -c '[.[] | {
+              id,
+              state,
+              image: .config.image,
+              commit: .image_ref.labels.GH_SHA,
+              host_status,
+              cordoned,
+              checks: [.checks[]? | {name, status}]
+            }]' <<<"$machines" >&2
+            exit 1
+          fi
+
           echo "PRODUCTION_MACHINE_ID=$production_machine_id" >> "$GITHUB_ENV"
+          echo "Resolved production machine $production_machine_id for $DEPLOYED_IMAGE."
 
       - name: Verify schema revision inside the production app
         env:
@@ -296,7 +355,7 @@ jobs:
           output="$(
             flyctl machine exec \
               "$PRODUCTION_MACHINE_ID" \
-              "/bin/sh -lc 'cd /app/agentmem; alembic -c alembic.ini current'" \
+              "/bin/sh -c 'cd /app/agentmem && /opt/venv/bin/alembic -c alembic.ini current'" \
               --app agentmem-lotus \
               --timeout 60 \
               2>&1

--- a/agentmem/tests/test_check_production_deployment_script.py
+++ b/agentmem/tests/test_check_production_deployment_script.py
@@ -35,21 +35,65 @@ def test_validate_base_url_requires_secret_free_https() -> None:
             MODULE.validate_base_url(value)
 
 
-def test_validate_health_requires_database() -> None:
-    MODULE.validate_health(
-        response(200, {"status": "ok", "checks": {"db": "ok", "redis": "disabled"}}),
-        "Health",
+def test_validate_health_requires_sanitized_success() -> None:
+    MODULE.validate_health(response(200, {"status": "ok"}), "Health")
+    for payload in (
+        {"status": "degraded"},
+        {"status": "ok", "checks": {"db": "ok", "redis": "disabled"}},
+    ):
+        with pytest.raises(RuntimeError, match="sanitized healthy response"):
+            MODULE.validate_health(response(200, payload), "Health")
+
+
+def test_validate_hidden_requires_not_found() -> None:
+    MODULE.validate_hidden(response(404, {"detail": "Not Found"}), "OpenAPI")
+    with pytest.raises(RuntimeError, match="publicly exposed"):
+        MODULE.validate_hidden(response(200, {"openapi": "3.1.0"}), "OpenAPI")
+
+
+def test_run_validates_hardened_production_contract(monkeypatch) -> None:
+    responses = {
+        "/livez": response(200, {"status": "alive"}),
+        "/health": response(200, {"status": "ok"}),
+        "/readyz": response(200, {"status": "ok"}),
+        "/docs": response(404, {"detail": "Not Found"}),
+        "/openapi.json": response(404, {"detail": "Not Found"}),
+        "/v1/decision-envelopes": response(401, {"detail": "Unauthorized"}),
+    }
+    requested: list[str] = []
+
+    def fake_request(_base_url: str, path: str, **_kwargs):
+        requested.append(path)
+        return responses[path]
+
+    monkeypatch.setattr(MODULE, "request", fake_request)
+    result = MODULE.run("https://api.example.com")
+
+    assert requested == list(responses)
+    assert result["authentication_boundary"] == "ok"
+    assert result["documentation_boundary"] == "ok"
+
+
+def test_run_rejects_exposed_openapi(monkeypatch) -> None:
+    responses = {
+        "/livez": response(200, {"status": "alive"}),
+        "/health": response(200, {"status": "ok"}),
+        "/readyz": response(200, {"status": "ok"}),
+        "/docs": response(404, {"detail": "Not Found"}),
+        "/openapi.json": response(200, {"openapi": "3.1.0"}),
+    }
+    monkeypatch.setattr(
+        MODULE,
+        "request",
+        lambda _base_url, path, **_kwargs: responses[path],
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="OpenAPI was publicly exposed"):
+        MODULE.run("https://api.example.com")
+
+
+def test_validate_health_rejects_non_200() -> None:
+    with pytest.raises(RuntimeError, match="HTTP 503"):
         MODULE.validate_health(
-            response(200, {"status": "degraded", "checks": {"db": "ok"}}),
+            response(503, {"status": "degraded"}),
             "Health",
         )
-
-
-def test_validate_openapi_requires_release_paths() -> None:
-    MODULE.validate_openapi(
-        response(200, {"paths": {path: {} for path in MODULE.REQUIRED_OPENAPI_PATHS}})
-    )
-    with pytest.raises(RuntimeError, match="/v1/decision-envelopes"):
-        MODULE.validate_openapi(response(200, {"paths": {}}))

--- a/agentmem/tests/test_select_fly_production_machine_script.py
+++ b/agentmem/tests/test_select_fly_production_machine_script.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "select_fly_production_machine.py"
+SPEC = importlib.util.spec_from_file_location(
+    "select_fly_production_machine", SCRIPT_PATH
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+EXPECTED_IMAGE = "registry.fly.io/agentmem-lotus:deployment-github-123-1"
+EXPECTED_SHA = "a" * 40
+
+
+def machine(*, state: str = "started") -> dict[str, object]:
+    return {
+        "id": "78451d0fe5d158",
+        "state": state,
+        "image_ref": {
+            "registry": "registry.fly.io",
+            "repository": "agentmem-lotus",
+            "tag": "deployment-github-123-1",
+            "labels": {"GH_SHA": EXPECTED_SHA},
+        },
+        "config": {"image": EXPECTED_IMAGE},
+        "checks": [{"name": "servicecheck", "status": "passing"}],
+        "host_status": "ok",
+        "cordoned": False,
+    }
+
+
+def select(machines: object) -> str | None:
+    return MODULE.select_machine(
+        machines,
+        expected_image=EXPECTED_IMAGE,
+        expected_sha=EXPECTED_SHA,
+    )
+
+
+def test_selects_only_exact_healthy_release_machine() -> None:
+    assert select([machine()]) == "78451d0fe5d158"
+
+
+@pytest.mark.parametrize("state", ["created", "starting", "replacing", "stopping"])
+def test_waits_during_legitimate_fly_transition_states(state: str) -> None:
+    assert select([machine(state=state)]) is None
+
+
+def test_waits_for_exact_image_commit_and_health() -> None:
+    wrong_config = machine()
+    wrong_config["config"] = {"image": EXPECTED_IMAGE + "-stale"}
+
+    wrong_commit = machine()
+    wrong_commit_image_ref = copy.deepcopy(wrong_commit["image_ref"])
+    assert isinstance(wrong_commit_image_ref, dict)
+    wrong_commit_image_ref["labels"] = {"GH_SHA": "b" * 40}
+    wrong_commit["image_ref"] = wrong_commit_image_ref
+
+    failing_check = machine()
+    failing_check["checks"] = [{"name": "servicecheck", "status": "critical"}]
+
+    for candidate in (wrong_config, wrong_commit, failing_check):
+        assert select([candidate]) is None
+
+
+def test_does_not_choose_during_ambiguous_multi_machine_state() -> None:
+    second = machine()
+    second["id"] = "28692e6b642758"
+    assert select([machine(), second]) is None
+
+
+def test_rejects_malformed_expected_identity() -> None:
+    with pytest.raises(ValueError, match="image reference"):
+        MODULE.select_machine(
+            [machine()],
+            expected_image="docker.io/untrusted/image:latest",
+            expected_sha=EXPECTED_SHA,
+        )
+    with pytest.raises(ValueError, match="commit SHA"):
+        MODULE.select_machine(
+            [machine()],
+            expected_image=EXPECTED_IMAGE,
+            expected_sha="main",
+        )

--- a/scripts/check_production_deployment.py
+++ b/scripts/check_production_deployment.py
@@ -11,14 +11,6 @@ from urllib.error import HTTPError
 from urllib.parse import urljoin, urlparse
 from urllib.request import Request, urlopen
 
-REQUIRED_OPENAPI_PATHS = {
-    "/v1/decision-envelopes",
-    "/v1/evidence/blast-radius",
-    "/v1/memories",
-    "/v1/recall",
-}
-
-
 @dataclass(frozen=True)
 class Response:
     status: int
@@ -76,23 +68,13 @@ def validate_health(response: Response, label: str) -> None:
     if response.status != 200:
         raise RuntimeError(f"{label} returned HTTP {response.status}")
     payload = json_body(response, label)
-    if payload.get("status") != "ok":
-        raise RuntimeError(f"{label} reported status {payload.get('status')!r}")
-    checks = payload.get("checks")
-    if not isinstance(checks, dict) or checks.get("db") != "ok":
-        raise RuntimeError(f"{label} did not report a healthy database")
+    if payload != {"status": "ok"}:
+        raise RuntimeError(f"{label} did not return the sanitized healthy response")
 
 
-def validate_openapi(response: Response) -> None:
-    if response.status != 200:
-        raise RuntimeError(f"OpenAPI returned HTTP {response.status}")
-    payload = json_body(response, "OpenAPI")
-    paths = payload.get("paths")
-    if not isinstance(paths, dict):
-        raise TypeError("OpenAPI document has no paths object")
-    missing = sorted(REQUIRED_OPENAPI_PATHS.difference(paths))
-    if missing:
-        raise RuntimeError(f"OpenAPI is missing required paths: {', '.join(missing)}")
+def validate_hidden(response: Response, label: str) -> None:
+    if response.status != 404:
+        raise RuntimeError(f"{label} was publicly exposed with HTTP {response.status}")
 
 
 def run(base_url: str, *, health_only: bool = False) -> dict[str, Any]:
@@ -111,14 +93,15 @@ def run(base_url: str, *, health_only: bool = False) -> dict[str, Any]:
         "readiness": "ok",
     }
     if not health_only:
-        validate_openapi(request(normalized, "/openapi.json"))
+        validate_hidden(request(normalized, "/docs"), "Docs")
+        validate_hidden(request(normalized, "/openapi.json"), "OpenAPI")
         protected = request(normalized, "/v1/decision-envelopes")
         if protected.status != 401:
             raise RuntimeError(
                 "Protected endpoint did not reject missing credentials with HTTP 401"
             )
         result["authentication_boundary"] = "ok"
-        result["openapi_contract"] = "ok"
+        result["documentation_boundary"] = "ok"
     return result
 
 

--- a/scripts/select_fly_production_machine.py
+++ b/scripts/select_fly_production_machine.py
@@ -1,0 +1,104 @@
+"""Select the one healthy Fly machine running an exact production build."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from typing import Any
+
+EXPECTED_IMAGE_PREFIX = "registry.fly.io/agentmem-lotus:deployment-"
+MACHINE_ID_PATTERN = re.compile(r"^[0-9a-f]{14}$")
+
+
+def _published_image(machine: dict[str, Any]) -> str | None:
+    image_ref = machine.get("image_ref")
+    if not isinstance(image_ref, dict):
+        return None
+    registry = image_ref.get("registry")
+    repository = image_ref.get("repository")
+    tag = image_ref.get("tag")
+    if not all(isinstance(value, str) and value for value in (registry, repository, tag)):
+        return None
+    return f"{registry}/{repository}:{tag}"
+
+
+def select_machine(
+    machines: object,
+    *,
+    expected_image: str,
+    expected_sha: str,
+) -> str | None:
+    """Return the exact ready machine, or ``None`` while Fly is converging."""
+    if not expected_image.startswith(EXPECTED_IMAGE_PREFIX):
+        raise ValueError("unexpected production image reference")
+    if not re.fullmatch(r"[0-9a-f]{40}", expected_sha):
+        raise ValueError("expected SHA must be a full lowercase Git commit SHA")
+    if not isinstance(machines, list) or not all(
+        isinstance(machine, dict) for machine in machines
+    ):
+        raise TypeError("Fly machines payload must be a JSON array of objects")
+
+    started = [machine for machine in machines if machine.get("state") == "started"]
+    if len(started) != 1:
+        return None
+
+    machine = started[0]
+    config = machine.get("config")
+    image_ref = machine.get("image_ref")
+    checks = machine.get("checks")
+    if not isinstance(config, dict) or not isinstance(image_ref, dict):
+        return None
+    labels = image_ref.get("labels")
+    if not isinstance(labels, dict):
+        return None
+    if config.get("image") != expected_image:
+        return None
+    if _published_image(machine) != expected_image:
+        return None
+    if labels.get("GH_SHA") != expected_sha:
+        return None
+    if machine.get("host_status") != "ok" or machine.get("cordoned") is not False:
+        return None
+    if not isinstance(checks, list) or not checks:
+        return None
+    if not all(
+        isinstance(check, dict) and check.get("status") == "passing"
+        for check in checks
+    ):
+        return None
+
+    machine_id = machine.get("id")
+    if not isinstance(machine_id, str) or not MACHINE_ID_PATTERN.fullmatch(machine_id):
+        raise ValueError("Fly returned an invalid production machine ID")
+    return machine_id
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-image", required=True)
+    parser.add_argument("--expected-sha", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        machines = json.load(sys.stdin)
+        machine_id = select_machine(
+            machines,
+            expected_image=args.expected_image,
+            expected_sha=args.expected_sha,
+        )
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        print(f"Invalid Fly machine data: {exc}", file=sys.stderr)
+        return 2
+    if machine_id is None:
+        return 1
+    print(machine_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Production run 30725542348 completed Fly release v24, but the workflow queried Machines during Fly's short post-deploy replacement transition and required one machine to be started immediately. The skipped schema and public smoke gates also used assumptions that no longer match the production image or hardened API surface.

## What changed

- Give every Actions deployment a unique deployment-github-RUN-ATTEMPT image tag.
- Poll for the latest complete release and select only the sole started, healthy, uncordoned machine whose config image, published image, and GH_SHA all match this run.
- Use the absolute in-image Alembic executable for the private schema check.
- Enforce the hardened public contract: sanitized health/readiness, hidden docs and OpenAPI, and a 401 authentication boundary.
- Add regression coverage for Fly transition, stale image/SHA, ambiguous machines, failing checks, and the hardened smoke contract.

## Verification

- 14 targeted tests passed.
- Ruff undefined-name/syntax gate passed.
- Python compileall passed.
- Release and public OpenAPI source contracts passed.
- actionlint v1.7.12 passed.
- Current live machine resolved by exact v24 image and ebfee36 SHA.
- Live public smoke contract passed.
- Read-only live schema command returned 0028_decision_envelopes (head).

No deployment is triggered by this PR.