### PR TITLE
Linearize untrusted text parsing

### DIFF
--- a/agentmem/src/lians/adapters/healthcare/__init__.py
+++ b/agentmem/src/lians/adapters/healthcare/__init__.py
@@ -61,6 +61,86 @@ def _normalize_npi(value: str) -> str:
     return digits if len(digits) == 10 else value.strip()
 
 
+_MEDICATION_UNITS = (
+    "mg",
+    "mcg",
+    "ml",
+    "g",
+    "iu",
+    "units",
+    "unit",
+    "tablets",
+    "tablet",
+    "tabs",
+    "tab",
+    "capsules",
+    "capsule",
+    "caps",
+    "cap",
+)
+
+
+def _is_word_char(char: str) -> bool:
+    return char == "_" or char.isalnum()
+
+
+def _space_end(value: str, start: int) -> int:
+    end = start
+    while end < len(value) and value[end].isspace():
+        end += 1
+    return end
+
+
+def _tail_matches_dot_star_end(value: str, start: int, last_newline: int, prior_newline: int) -> bool:
+    """Preserve the old regex's ``.*$`` behavior without rescanning each tail."""
+    if last_newline == -1 or start > last_newline:
+        return True
+    return last_newline == len(value) - 1 and start > prior_newline
+
+
+def _dosage_suffix_start(value: str) -> int | None:
+    r"""Locate a trailing dosage/form suffix in linear time.
+
+    The previous unanchored ``\s+\d+...`` regex retried a long whitespace run
+    at every character when it did not contain a dosage.  This scanner skips
+    each whitespace and digit run once while retaining the same accepted unit
+    forms and word-boundary behavior.
+    """
+    last_newline = value.rfind("\n")
+    prior_newline = value.rfind("\n", 0, last_newline) if last_newline != -1 else -1
+    index = 0
+    while index < len(value):
+        if not value[index].isspace():
+            index += 1
+            continue
+
+        suffix_start = index
+        number_start = _space_end(value, index)
+        if number_start >= len(value) or not value[number_start].isdecimal():
+            index = number_start
+            continue
+
+        number_end = number_start
+        while number_end < len(value) and value[number_end].isdecimal():
+            number_end += 1
+        unit_start = _space_end(value, number_end)
+
+        for unit in _MEDICATION_UNITS:
+            unit_end = unit_start + len(unit)
+            if unit_end > len(value) or value[unit_start:unit_end].casefold() != unit:
+                continue
+            if unit_end < len(value) and _is_word_char(value[unit_end]):
+                continue
+            if _tail_matches_dot_star_end(value, unit_end, last_newline, prior_newline):
+                return suffix_start
+
+        # The consumed digit run cannot begin another dosage match.  Resume at
+        # its end so any later whitespace-delimited dosage is still considered.
+        index = number_end
+
+    return None
+
+
 def _normalize_medication(value: str) -> str:
     """
     Canonical drug name: lowercase, strip trailing dosage/form.
@@ -68,12 +148,8 @@ def _normalize_medication(value: str) -> str:
     "Metformin HCl 500mg tabs" → "metformin hcl"
     Preserves salt forms (HCl, Na, etc.) for accurate supersession matching.
     """
-    v = re.sub(
-        r"\s+\d+\s*(mg|mcg|ml|g|iu|units?|tab(let)?s?|cap(sule)?s?)\b.*$",
-        "",
-        value,
-        flags=re.IGNORECASE,
-    )
+    dosage_start = _dosage_suffix_start(value)
+    v = value if dosage_start is None else value[:dosage_start]
     return v.strip().lower()
 
 
@@ -119,7 +195,7 @@ class HealthcareAdapter:
         if key in _KEY_ALIASES:
             return _KEY_ALIASES[key]
         # If key is an alias, find its canonical group
-        for canonical, aliases in _KEY_ALIASES.items():
+        for aliases in _KEY_ALIASES.values():
             if key in aliases:
                 return aliases
         return [key]

--- a/agentmem/src/lians/interjection.py
+++ b/agentmem/src/lians/interjection.py
@@ -22,7 +22,6 @@ clauses and stores each as a *derived* memory alongside the raw turn:
 from __future__ import annotations
 
 import re
-from typing import Optional
 
 _MAX_CLAUSES = 3
 _MIN_LEN = 15
@@ -32,19 +31,160 @@ _MAX_LEN = 240
 # extracted clauses so they stay self-attributing.
 _SPEAKER_RE = re.compile(r"^([A-Za-z][\w .'&-]{0,24}):\s+(.*)$", re.DOTALL)
 
-# Segment boundaries: sentence enders and spoken-style em/en dashes.
-_SEGMENT_SPLIT = re.compile(r"(?<=[.!?…])\s+|\s+[—–]\s*|\s*[—–]\s+|\s+--\s+")
+# Segment boundaries: sentence enders and spoken-style em/en dashes.  These
+# used to be expressed as overlapping ``\s+`` regex alternatives.  Searching
+# an untrusted, long whitespace run forced the regex engine to retry the run at
+# every character (quadratic time).  The scanners below consume every input
+# character at most a constant number of times instead.
+_SENTENCE_ENDERS = frozenset(".!?…")
+_SPOKEN_DASHES = frozenset("—–")
+_COMMA_CONNECTORS = ("so", "since", "because", "but", "although", "though", "anyway")
 
-# Conservative intra-segment clause connectors. Splitting is only ever on
-# these; a fact stated across a bare comma ("I eat fish now, I'm not
-# vegetarian anymore") stays intact.
-_CLAUSE_SPLIT = re.compile(
-    r",\s+(?:so|since|because|but|although|though|anyway)\b\s*|\s+because\s+"
-    # a first-person fact riding a conjunction ("...steakhouse and I'm
-    # pescatarian now") splits off; "and they/it/..." stays joined.
-    r"|,?\s+and\s+(?=I\b|I'm\b|my\b)",
-    re.IGNORECASE,
-)
+
+def _space_end(value: str, start: int) -> int:
+    """Return the first index after one contiguous whitespace run."""
+    end = start
+    while end < len(value) and value[end].isspace():
+        end += 1
+    return end
+
+
+def _is_word_char(char: str) -> bool:
+    """Match the word-character behavior needed by the former ``\b`` checks."""
+    return char == "_" or char.isalnum()
+
+
+def _word_at(value: str, start: int, word: str) -> bool:
+    """Case-insensitive ASCII word match with a trailing word boundary."""
+    end = start + len(word)
+    return (
+        end <= len(value)
+        and value[start:end].casefold() == word
+        and (end == len(value) or not _is_word_char(value[end]))
+    )
+
+
+def _split_segments(body: str) -> list[str]:
+    """Split sentence/dash segments in linear time.
+
+    This preserves the former separator rules: sentence-ending whitespace,
+    em/en dashes with whitespace on either side, and ``--`` surrounded by
+    whitespace.
+    """
+    parts: list[str] = []
+    start = 0
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if char.isspace():
+            separator_start = index
+            whitespace_end = _space_end(body, index)
+
+            if separator_start > 0 and body[separator_start - 1] in _SENTENCE_ENDERS:
+                parts.append(body[start:separator_start])
+                start = whitespace_end
+                index = whitespace_end
+                continue
+
+            if whitespace_end < len(body) and body[whitespace_end] in _SPOKEN_DASHES:
+                separator_end = _space_end(body, whitespace_end + 1)
+                parts.append(body[start:separator_start])
+                start = separator_end
+                index = separator_end
+                continue
+
+            if (
+                body.startswith("--", whitespace_end)
+                and whitespace_end + 2 < len(body)
+                and body[whitespace_end + 2].isspace()
+            ):
+                separator_end = _space_end(body, whitespace_end + 2)
+                parts.append(body[start:separator_start])
+                start = separator_end
+                index = separator_end
+                continue
+
+            index = whitespace_end
+            continue
+
+        if char in _SPOKEN_DASHES and index + 1 < len(body) and body[index + 1].isspace():
+            separator_end = _space_end(body, index + 1)
+            parts.append(body[start:index])
+            start = separator_end
+            index = separator_end
+            continue
+
+        index += 1
+
+    parts.append(body[start:])
+    return parts
+
+
+def _first_person_at(value: str, start: int) -> bool:
+    # ``I\b`` intentionally also covers "I'm": apostrophes are non-word
+    # characters, matching the previous lookahead.
+    return _word_at(value, start, "i") or _word_at(value, start, "my")
+
+
+def _comma_connector_end(value: str, comma: int) -> int | None:
+    if comma + 1 >= len(value) or not value[comma + 1].isspace():
+        return None
+
+    word_start = _space_end(value, comma + 1)
+    for connector in _COMMA_CONNECTORS:
+        if _word_at(value, word_start, connector):
+            return _space_end(value, word_start + len(connector))
+
+    if _word_at(value, word_start, "and"):
+        whitespace_start = word_start + len("and")
+        if whitespace_start < len(value) and value[whitespace_start].isspace():
+            clause_start = _space_end(value, whitespace_start)
+            if _first_person_at(value, clause_start):
+                return clause_start
+    return None
+
+
+def _whitespace_connector_end(value: str, whitespace_start: int) -> int | None:
+    word_start = _space_end(value, whitespace_start)
+    for connector in ("because", "and"):
+        if not _word_at(value, word_start, connector):
+            continue
+        trailing_start = word_start + len(connector)
+        if trailing_start >= len(value) or not value[trailing_start].isspace():
+            continue
+        clause_start = _space_end(value, trailing_start)
+        if connector == "because" or _first_person_at(value, clause_start):
+            return clause_start
+    return None
+
+
+def _split_clauses(segment: str) -> list[str]:
+    """Split conservative clause connectors in a single linear scan."""
+    parts: list[str] = []
+    start = 0
+    index = 0
+    while index < len(segment):
+        char = segment[index]
+        if char == ",":
+            separator_end = _comma_connector_end(segment, index)
+            if separator_end is not None:
+                parts.append(segment[start:index])
+                start = separator_end
+                index = separator_end
+                continue
+        elif char.isspace():
+            separator_end = _whitespace_connector_end(segment, index)
+            if separator_end is not None:
+                parts.append(segment[start:index])
+                start = separator_end
+                index = separator_end
+                continue
+            index = _space_end(segment, index)
+            continue
+        index += 1
+
+    parts.append(segment[start:])
+    return parts
 
 # Aside markers: the clause is an explicit "store this" interjection — trim to
 # the marker so the stored fact starts at the request, not the task chatter.
@@ -75,11 +215,11 @@ def _clauses(body: str) -> list[tuple[str, str]]:
     left too short ("my day rate is $900" before ", so we can build off that")
     falls back to its segment, so the fact is never dropped on a length gate."""
     out: list[tuple[str, str]] = []
-    for segment in _SEGMENT_SPLIT.split(body):
+    for segment in _split_segments(body):
         segment = (segment or "").strip(" ,;")
         if not segment:
             continue
-        for clause in _CLAUSE_SPLIT.split(segment):
+        for clause in _split_clauses(segment):
             clause = (clause or "").strip(" ,;")
             if clause:
                 out.append((clause, segment))
@@ -95,7 +235,7 @@ def extract_interjections(content: str, max_clauses: int = _MAX_CLAUSES) -> list
     if not content:
         return []
 
-    speaker: Optional[str] = None
+    speaker: str | None = None
     body = content.strip()
     m = _SPEAKER_RE.match(body)
     if m:

--- a/agentmem/tests/test_adapters.py
+++ b/agentmem/tests/test_adapters.py
@@ -10,18 +10,24 @@ Verifies:
 - get_adapter() returns the configured adapter (finance by default)
 - Adapter can be overridden at runtime (for custom verticals)
 """
-import pytest
+import re
 
-from src.lians.adapters import get_adapter, register_adapter
-from src.lians.adapters.finance import FinanceAdapter
-from src.lians.adapters.passthrough import PassthroughAdapter
-from src.lians.adapters.healthcare import HealthcareAdapter
-from src.lians.adapters.legal import LegalAdapter
+import pytest
 from src.lians._types import (
     _FINANCE_STRUCTURED_KEYS,
-    _PASSTHROUGH_STRUCTURED_KEYS,
     _HEALTHCARE_STRUCTURED_KEYS,
     _LEGAL_STRUCTURED_KEYS,
+    _PASSTHROUGH_STRUCTURED_KEYS,
+)
+from src.lians.adapters import get_adapter, register_adapter
+from src.lians.adapters.finance import FinanceAdapter
+from src.lians.adapters.healthcare import HealthcareAdapter
+from src.lians.adapters.legal import LegalAdapter
+from src.lians.adapters.passthrough import PassthroughAdapter
+
+_REFERENCE_MEDICATION_SUFFIX = re.compile(
+    r"\s+\d+\s*(mg|mcg|ml|g|iu|units?|tab(let)?s?|cap(sule)?s?)\b.*$",
+    re.IGNORECASE,
 )
 
 
@@ -118,8 +124,8 @@ def test_get_adapter_returns_finance_by_default(monkeypatch):
 
 
 def test_get_adapter_returns_passthrough_when_configured(monkeypatch):
-    from src.lians.config import get_settings
     from src.lians.adapters import _registry
+    from src.lians.config import get_settings
     _registry.clear()
     monkeypatch.setattr(get_settings(), "domain_adapter", "passthrough", raising=False)
     # Directly instantiate to avoid settings cache issues in tests
@@ -207,6 +213,40 @@ class TestHealthcareAdapter:
     def test_normalize_medication_preserves_salt(self):
         # Salt forms must survive to distinguish metformin HCl from metformin ER
         assert self.adapter.normalize("medication", "Metformin HCl") == "metformin hcl"
+
+    def test_normalize_medication_handles_maximum_unmatched_whitespace_run(self):
+        prefix = "Metformin HCl"
+        suffix = "not-a-dosage"
+        value = prefix + (" " * (100_000 - len(prefix) - len(suffix))) + suffix
+
+        assert len(value) == 100_000
+        assert self.adapter.normalize("medication", value) == value.strip().lower()
+
+    def test_normalize_medication_strips_dosage_after_maximum_whitespace_run(self):
+        prefix = "Metformin HCl"
+        suffix = "500mg tablets"
+        value = prefix + (" " * (100_000 - len(prefix) - len(suffix))) + suffix
+
+        assert len(value) == 100_000
+        assert self.adapter.normalize("medication", value) == "metformin hcl"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Metformin HCl 500mg tabs",
+            "Lisinopril 10 mg tablet after breakfast",
+            "Insulin Glargine 100 units",
+            "Medication 5 capsules nightly",
+            "Medication 5 milligrams",
+            "Medication500mg",
+            "Medication 5 mg\n",
+            "Medication 5 mg\ncontinued",
+            "Medication 5 mg\ncontinued 10 mg",
+        ],
+    )
+    def test_normalize_medication_matches_bounded_reference_semantics(self, value):
+        expected = _REFERENCE_MEDICATION_SUFFIX.sub("", value).strip().lower()
+        assert self.adapter.normalize("medication", value) == expected
 
     def test_normalize_patient_id_strips_whitespace(self):
         assert self.adapter.normalize("patient_id", "  MRN-0012345  ") == "MRN-0012345"

--- a/agentmem/tests/test_interjection.py
+++ b/agentmem/tests/test_interjection.py
@@ -10,10 +10,24 @@ Two layers under test:
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import re
+from datetime import UTC, datetime
 
-from src.lians.interjection import extract_interjections
-from src.lians.ranking import _collapse_derived, _stale_clause_penalty, STALE_CLAUSE_PENALTY
+import pytest
+from src.lians.interjection import _split_clauses, _split_segments, extract_interjections
+from src.lians.ranking import STALE_CLAUSE_PENALTY, _collapse_derived, _stale_clause_penalty
+
+# Test-only references over bounded literals.  Production parsing must use the
+# linear scanners; these preserve an executable record of their former regex
+# semantics without applying the expressions to untrusted input.
+_REFERENCE_SEGMENT_SPLIT = re.compile(
+    r"(?<=[.!?…])\s+|\s+[—–]\s*|\s*[—–]\s+|\s+--\s+"
+)
+_REFERENCE_CLAUSE_SPLIT = re.compile(
+    r",\s+(?:so|since|because|but|although|though|anyway)\b\s*|\s+because\s+"
+    r"|,?\s+and\s+(?=I\b|I'm\b|my\b)",
+    re.IGNORECASE,
+)
 
 
 # ── Layer 1: pure deterministic extractor ────────────────────────────────────
@@ -102,6 +116,66 @@ def test_task_chatter_ignored():
     assert extract_interjections(turn) == []
 
 
+def test_maximum_size_unmatched_whitespace_run_is_ignored():
+    """A maximum-size write with no separator remains a single clause."""
+    prefix = "User: keep planning"
+    suffix = "then finish the task"
+    turn = prefix + (" " * (100_000 - len(prefix) - len(suffix))) + suffix
+
+    assert len(turn) == 100_000
+    assert extract_interjections(turn) == []
+
+
+def test_maximum_size_whitespace_run_preserves_connector_semantics():
+    prefix = "User: keep planning"
+    suffix = "because my studio in Portland is ready."
+    turn = prefix + (" " * (100_000 - len(prefix) - len(suffix))) + suffix
+
+    assert len(turn) == 100_000
+    assert extract_interjections(turn) == ["User: my studio in Portland is ready."]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "first.   second",
+        "first?\tsecond",
+        "first…\nsecond",
+        "first   —second",
+        "first—   second",
+        "first   –   second",
+        "first   --   second",
+        "first—second",
+        "first-- second",
+    ],
+)
+def test_segment_scanner_matches_bounded_reference_semantics(value):
+    assert _split_segments(value) == _REFERENCE_SEGMENT_SPLIT.split(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "first, so second",
+        "first, since second",
+        "first, because second",
+        "first, but second",
+        "first, although second",
+        "first, though second",
+        "first, anyway second",
+        "first because second",
+        "first and I moved",
+        "first, and I'm ready",
+        "first and my studio moved",
+        "first and they moved",
+        "first becauseful second",
+        "first, somehow second",
+    ],
+)
+def test_clause_scanner_matches_bounded_reference_semantics(value):
+    assert _split_clauses(value) == _REFERENCE_CLAUSE_SPLIT.split(value)
+
+
 # ── Layer 2: ranking helpers ─────────────────────────────────────────────────
 
 
@@ -129,10 +203,10 @@ def test_collapse_noop_without_derived_rows():
 
 
 def test_stale_penalty_is_time_aware():
-    closure = datetime(2026, 6, 9, tzinfo=timezone.utc)
+    closure = datetime(2026, 6, 9, tzinfo=UTC)
     meta = {"_stale_clauses": [closure.isoformat()]}
-    before = datetime(2026, 5, 25, tzinfo=timezone.utc)
-    after = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    before = datetime(2026, 5, 25, tzinfo=UTC)
+    after = datetime(2026, 7, 1, tzinfo=UTC)
     assert _stale_clause_penalty(meta, before) == 0.0
     assert _stale_clause_penalty(meta, after) == STALE_CLAUSE_PENALTY
     assert _stale_clause_penalty({}, after) == 0.0


### PR DESCRIPTION
## What changed

- replace the interjection segment and clause separator regexes with explicit single-pass scanners
- replace healthcare medication dosage-suffix normalization with a single-pass scanner
- preserve the prior separator, connector, unit, word-boundary, and newline semantics through bounded parity tests
- add adversarial functional regressions at the full 100,000-character `MemoryAdd.content` limit without wall-clock assertions

## Why

The former unanchored, overlapping whitespace regexes could take polynomial time on attacker-controlled content. A caller with a valid write key could therefore monopolize the single production worker with a long whitespace-heavy memory write.

Each replacement advances monotonically over the input and performs only constant-size connector/unit comparisons, making parsing linear in input length.

## Impact

Normal interjection extraction and healthcare medication normalization retain their existing outputs. Whitespace-heavy inputs at the public content limit no longer cause regex backtracking amplification.

## Validation

- `93 passed` across interjection and adapter tests, including bounded reference parity matrices and 100k-character adversarial cases
- 30,000 randomized bounded parity cases passed for each former splitter and medication normalizer
- Ruff passed for all changed production and test files
- repository CI Ruff selection and Python compileall passed
- GitHub required test matrix and CodeQL are expected to run on this PR
