### PR TITLE
Harden Grafana 12 dependency boundary

### DIFF
--- a/.github/workflows/grafana-plugin.yml
+++ b/.github/workflows/grafana-plugin.yml
@@ -24,8 +24,8 @@ jobs:
       run:
         working-directory: integrations/grafana-lians-app
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/grafana-plugin.yml
+++ b/.github/workflows/grafana-plugin.yml
@@ -1,0 +1,38 @@
+name: Grafana plugin
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master", "main"]
+    paths:
+      - "integrations/grafana-lians-app/**"
+      - ".github/workflows/grafana-plugin.yml"
+  pull_request:
+    branches: ["master", "main"]
+    paths:
+      - "integrations/grafana-lians-app/**"
+      - ".github/workflows/grafana-plugin.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Grafana 12.4.6 compatibility
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: integrations/grafana-lians-app
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: integrations/grafana-lians-app/package-lock.json
+      - name: Install the locked dependency graph
+        run: npm ci
+      - name: Reject high or critical dependency findings
+        run: npm run audit:ci
+      - name: Typecheck and inspect the production bundle
+        run: npm run verify

--- a/integrations/grafana-lians-app/README.md
+++ b/integrations/grafana-lians-app/README.md
@@ -9,9 +9,31 @@ Grafana Labs must review and sign a public plugin before it can be listed.
 ## Development
 
 ```bash
-npm install
-npm run build
+npm ci
+npm run verify
 ```
+
+The lab build target is Grafana 12.4.6. Grafana, React, and their shared browser
+libraries are supplied by the Grafana host through SystemJS; they are installed
+as development dependencies only for typechecking and compilation. The
+production build fails if React, any `@grafana` package, or an audited host
+library is copied into `dist/module.js`.
+
+## Dependency security boundary
+
+The lockfile applies only compatible patch/minor refreshes on top of Grafana
+12.4.6: DOMPurify 3.4.12, Immutable 5.1.9, Lodash 4.18.1, react-use 17.6.1
+(which moves js-cookie to 3.0.8), UUID 11.1.1, and OpenTelemetry Core 2.8.0.
+This clears 26 of the 28 Dependabot findings that existed in this directory.
+
+`npm audit` retains two moderate React Router advisories in the development-only
+`@grafana/ui -> react-router-dom-v5-compat -> react-router@6.30.4` path. The
+published fix requires React Router 7.18.0, an incompatible major that Grafana
+12.4.6 does not request. Lians imports no router API, and the production bundle
+inspection proves that this host-owned graph is not shipped in the plugin. Do
+not force React Router 7 into the Grafana 12 lab; consume Grafana's compatible
+upstream update instead. See Grafana's documentation on
+[dynamically linked plugin dependencies](https://grafana.com/developers/plugin-tools/key-concepts/npm-dependencies).
 
 Provision Alloy with [`provisioning/alloy-lians.alloy`](provisioning/alloy-lians.alloy).
 Set `LIANS_OTLP_ENDPOINT` to the Lians origin (without `/v1/traces`) and pass a

--- a/integrations/grafana-lians-app/package-lock.json
+++ b/integrations/grafana-lians-app/package-lock.json
@@ -7,18 +7,15 @@
     "": {
       "name": "lians-lians-app",
       "version": "0.1.0",
-      "dependencies": {
-        "@grafana/data": "12.3.0",
-        "@grafana/runtime": "12.3.0",
-        "@grafana/ui": "12.3.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
       "devDependencies": {
+        "@grafana/data": "12.4.6",
+        "@grafana/ui": "12.4.6",
         "@swc/core": "^1.15.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "copy-webpack-plugin": "^14.0.0",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
         "swc-loader": "^0.2.6",
         "typescript": "^5.9.0",
         "webpack": "^5.101.0",
@@ -26,11 +23,64 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "peerDependencies": {
+        "@grafana/data": "12.4.6",
+        "@grafana/ui": "12.4.6",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@adobe/react-spectrum": {},
+    "node_modules/@adobe/react-spectrum": {
+      "version": "3.47.3",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.47.3.tgz",
+      "integrity": "sha512-tWZG59+xTbXIqeZB4uyuo2qljk3nRK66IkdBmMgbl2p6peApkKbrtJ/YOM8rW4gemdmv7qoJlbIHvy8aJkYsCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.3",
+        "@react-types/shared": "^3.36.1",
+        "@spectrum-icons/ui": "^3.7.1",
+        "@spectrum-icons/workflow": "^4.3.1",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "clsx": "^2.0.0",
+        "react-aria": "3.51.0",
+        "react-aria-components": "1.20.0",
+        "react-stately": "3.49.0",
+        "react-transition-group": "^4.4.5",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@adobe/react-spectrum-ui": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum-ui/-/react-spectrum-ui-1.2.1.tgz",
+      "integrity": "sha512-wcrbEE2O/9WnEn6avBnaVRRx88S5PLFsPLr4wffzlbMfXeQsy+RMQwaJd3cbzrn18/j04Isit7f7Emfn0dhrJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@adobe/react-spectrum-workflow": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum-workflow/-/react-spectrum-workflow-2.3.5.tgz",
+      "integrity": "sha512-b53VIPwPWKb/T5gzE3qs+QlGP5gVrw/LnWV3xMksDU+CRl3rzOKUwxIGiZO8ICyYh1WiyqY4myGlPU/nAynBUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -43,6 +93,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -57,6 +108,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -64,6 +116,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -75,6 +128,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -82,6 +136,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -89,6 +144,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -102,6 +158,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -109,6 +166,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -121,6 +179,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -137,6 +196,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -148,6 +208,7 @@
     },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -160,6 +221,7 @@
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
@@ -177,6 +239,7 @@
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
@@ -188,6 +251,7 @@
     },
     "node_modules/@emotion/css": {
       "version": "11.13.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/babel-plugin": "^11.13.5",
@@ -199,14 +263,17 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -229,6 +296,7 @@
     },
     "node_modules/@emotion/serialize": {
       "version": "1.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
@@ -240,14 +308,17 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
@@ -255,14 +326,19 @@
     },
     "node_modules/@emotion/utils": {
       "version": "1.4.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -279,6 +355,9 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -287,6 +366,9 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -300,6 +382,9 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -311,6 +396,9 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -322,6 +410,9 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -330,6 +421,9 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -342,6 +436,7 @@
     },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.12"
@@ -349,6 +444,7 @@
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.8.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
@@ -357,6 +453,7 @@
     },
     "node_modules/@floating-ui/react": {
       "version": "0.27.16",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
@@ -370,6 +467,7 @@
     },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.8.0"
@@ -381,10 +479,14 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.12",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@formatjs/fast-memoize": "2.2.7",
@@ -395,6 +497,9 @@
     },
     "node_modules/@formatjs/fast-memoize": {
       "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -402,6 +507,7 @@
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
       "version": "2.11.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
@@ -411,6 +517,7 @@
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.8.16",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
@@ -419,6 +526,9 @@
     },
     "node_modules/@formatjs/intl-durationformat": {
       "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-durationformat/-/intl-durationformat-0.7.6.tgz",
+      "integrity": "sha512-jatAN3E84X6aP2UOGK1jTrwD1a7BiG3qWUSEDAhtyNd1BgYeS5wQPtXlnuGF1QRx0DjnwwNOIssyd7oQoRlQeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
@@ -428,34 +538,41 @@
     },
     "node_modules/@formatjs/intl-localematcher": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@grafana/data": {
-      "version": "12.3.0",
+      "version": "12.4.6",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-12.4.6.tgz",
+      "integrity": "sha512-Ol3LP3stGKZvDP59KsQ6BF+KQQiEc4sbt+V38IaSj59I26WkadFC+RPn3oByU40JXBdnOcYjUdGYqH3dI2ksKQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@braintree/sanitize-url": "7.0.1",
-        "@grafana/i18n": "12.3.0",
-        "@grafana/schema": "12.3.0",
+        "@grafana/i18n": "12.4.6",
+        "@grafana/schema": "12.4.6",
         "@leeoniya/ufuzzy": "1.0.19",
         "@types/d3-interpolate": "^3.0.0",
         "@types/string-hash": "1.1.3",
         "@types/systemjs": "6.15.3",
         "d3-interpolate": "3.0.1",
+        "d3-scale-chromatic": "3.1.0",
         "date-fns": "4.1.0",
         "dompurify": "3.3.0",
         "eventemitter3": "5.0.1",
         "fast_array_intersect": "1.1.0",
         "history": "4.10.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.18.1",
         "marked": "16.3.0",
-        "marked-mangle": "1.1.11",
+        "marked-mangle": "1.1.12",
         "moment": "2.30.1",
         "moment-timezone": "0.5.47",
-        "ol": "10.6.1",
+        "ol": "10.7.0",
         "papaparse": "5.5.3",
         "react-use": "17.6.0",
         "rxjs": "7.8.2",
@@ -463,52 +580,29 @@
         "tinycolor2": "1.6.0",
         "tslib": "2.8.1",
         "uplot": "1.6.32",
-        "xss": "^1.0.14"
+        "xss": "^1.0.14",
+        "zod": "^4.3.0"
       },
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@grafana/e2e-selectors": {
-      "version": "12.3.0",
+    "node_modules/@grafana/data/node_modules/@grafana/schema": {
+      "version": "12.4.6",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.4.6.tgz",
+      "integrity": "sha512-BnE06nS8JL4PiEdCarsvFlL2Hvdv6HJUjOo497+FPJD+vIF4wuz6QNpp1y5qRwbD2tjVXuwUTeQH9VaAp3Lf9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "semver": "^7.7.0",
-        "tslib": "2.8.1",
-        "typescript": "5.9.2"
-      }
-    },
-    "node_modules/@grafana/e2e-selectors/node_modules/typescript": {
-      "version": "5.9.2",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@grafana/faro-core": {
-      "version": "1.19.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/otlp-transformer": "^0.202.0"
-      }
-    },
-    "node_modules/@grafana/faro-web-sdk": {
-      "version": "1.19.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grafana/faro-core": "^1.19.0",
-        "ua-parser-js": "^1.0.32",
-        "web-vitals": "^4.0.1"
+        "tslib": "2.8.1"
       }
     },
     "node_modules/@grafana/i18n": {
-      "version": "12.3.0",
+      "version": "12.4.6",
+      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-12.4.6.tgz",
+      "integrity": "sha512-ujhmewX1Uq74Xg+TdkovTxB4ugo8Z7cPnP4HBAFppSqrT1ftCfvgN4I1MRSR7FeKJkQWtcclmn5MOsBRN4zTmQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@formatjs/intl-durationformat": "^0.7.0",
@@ -524,56 +618,45 @@
         "react": ">=18"
       }
     },
-    "node_modules/@grafana/runtime": {
-      "version": "12.3.0",
-      "license": "Apache-2.0",
+    "node_modules/@grafana/react-data-grid": {
+      "version": "7.0.0-beta.57",
+      "resolved": "https://registry.npmjs.org/@grafana/react-data-grid/-/react-data-grid-7.0.0-beta.57.tgz",
+      "integrity": "sha512-v3DuW+TF16Jq5/dNJc0ifReBuknZb4+deB7M+liLMUU8sr2RavguNHpxCk4L/AdqLeXJFGhhqEDUYpeeQm2DzA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@grafana/data": "12.3.0",
-        "@grafana/e2e-selectors": "12.3.0",
-        "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/schema": "12.3.0",
-        "@grafana/ui": "12.3.0",
-        "@openfeature/core": "^1.9.0",
-        "@openfeature/ofrep-web-provider": "^0.3.3",
-        "@openfeature/web-sdk": "^1.6.1",
-        "@types/systemjs": "6.15.3",
-        "history": "4.10.1",
-        "lodash": "4.17.21",
-        "react-loading-skeleton": "3.5.0",
-        "react-use": "17.6.0",
-        "rxjs": "7.8.2",
-        "tslib": "2.8.1"
+        "clsx": "^2.0.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@grafana/schema": {
-      "version": "12.3.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "2.8.1"
+        "react": "^18.0 || ^19.0",
+        "react-dom": "^18.0 || ^19.0"
       }
     },
     "node_modules/@grafana/ui": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.3.0.tgz",
-      "integrity": "sha512-T6673OHV8nEBQptAKFr0XuPdP0KvCawGhcfvfbGM5ThXzoagEMQjA7eDvqWKq0fPg0fy0AbAE8Ypp/tC51hkWQ==",
+      "version": "12.4.6",
+      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-12.4.6.tgz",
+      "integrity": "sha512-HzSTitsAMVzwaa/rNIPVLqeWyXMB+5lRXMlk88umTOVnH9dSK0CikX5pFTXNG4UrfBDJjuifJWC0AZ+jD1FzYg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
         "@emotion/react": "11.14.0",
         "@emotion/serialize": "1.3.3",
         "@floating-ui/react": "0.27.16",
-        "@grafana/data": "12.3.0",
-        "@grafana/e2e-selectors": "12.3.0",
-        "@grafana/faro-web-sdk": "^1.13.2",
-        "@grafana/i18n": "12.3.0",
-        "@grafana/schema": "12.3.0",
+        "@grafana/data": "12.4.6",
+        "@grafana/e2e-selectors": "12.4.6",
+        "@grafana/faro-web-sdk": "^2.2.4",
+        "@grafana/i18n": "12.4.6",
+        "@grafana/react-data-grid": "7.0.0-beta.57",
+        "@grafana/schema": "12.4.6",
         "@hello-pangea/dnd": "18.0.1",
         "@monaco-editor/react": "4.7.0",
         "@popperjs/core": "2.11.8",
+        "@rc-component/cascader": "1.9.0",
+        "@rc-component/drawer": "1.3.0",
+        "@rc-component/picker": "1.7.1",
+        "@rc-component/slider": "1.0.1",
+        "@rc-component/tooltip": "1.4.0",
         "@react-aria/dialog": "3.5.31",
         "@react-aria/focus": "3.21.2",
         "@react-aria/overlays": "3.30.0",
@@ -594,21 +677,15 @@
         "immutable": "5.1.4",
         "is-hotkey": "0.2.0",
         "jquery": "3.7.1",
-        "lodash": "4.17.21",
+        "lodash": "^4.18.1",
         "micro-memoize": "^4.1.2",
         "moment": "2.30.1",
         "monaco-editor": "0.34.1",
-        "ol": "10.6.1",
+        "ol": "10.7.0",
         "prismjs": "1.30.0",
-        "rc-cascader": "3.34.0",
-        "rc-drawer": "7.3.0",
-        "rc-picker": "4.11.3",
-        "rc-slider": "11.1.9",
-        "rc-tooltip": "6.4.0",
         "react-calendar": "^6.0.0",
         "react-colorful": "5.6.1",
         "react-custom-scrollbars-2": "4.5.0",
-        "react-data-grid": "github:grafana/react-data-grid#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
         "react-dropzone": "14.3.8",
         "react-highlight-words": "0.21.0",
         "react-hook-form": "^7.49.2",
@@ -637,8 +714,196 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@grafana/ui/node_modules/@grafana/e2e-selectors": {
+      "version": "12.4.6",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.6.tgz",
+      "integrity": "sha512-noMHaQHZ2lao2m/LyJbo0JolPv3IU76yc0iIztI/YvIGMfguWbR13ybrPTnNyezh3EPiWYnxov5moaz3OraWFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^7.7.0",
+        "tslib": "2.8.1",
+        "typescript": "5.9.2"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@grafana/faro-core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-2.9.0.tgz",
+      "integrity": "sha512-v7vrNYuoW273hOQ3rQgo3wYYBD8kH5TTfFes0dbsx2/8L+BclIsrsRCUHdlCqme2ZP42iyLkyPgCSDav8S0Niw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/otlp-transformer": "^0.219.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@grafana/faro-web-sdk": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-2.9.0.tgz",
+      "integrity": "sha512-CfeIoW8m/9Y4LEASQpflhRSg1hJRqJ0gUADdmSFVI6f134+DWoT9e9qsO3v64mSuUPsdD3qYi2EkO+16u7hhTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/faro-core": "^2.9.0",
+        "ua-parser-js": "1.0.41",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@grafana/schema": {
+      "version": "12.4.6",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-12.4.6.tgz",
+      "integrity": "sha512-BnE06nS8JL4PiEdCarsvFlL2Hvdv6HJUjOo497+FPJD+vIF4wuz6QNpp1y5qRwbD2tjVXuwUTeQH9VaAp3Lf9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/api-logs": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
+      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
+      "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/sdk-logs": "0.219.0",
+        "@opentelemetry/sdk-metrics": "2.8.0",
+        "@opentelemetry/sdk-trace-base": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
+      "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz",
+      "integrity": "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@hello-pangea/dnd": {
       "version": "18.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.7",
@@ -654,6 +919,9 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -665,6 +933,9 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -678,6 +949,9 @@
     },
     "node_modules/@humanfs/types": {
       "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -686,6 +960,9 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -698,6 +975,9 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -709,7 +989,10 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.12.2",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
+      "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -717,6 +1000,7 @@
     },
     "node_modules/@internationalized/message": {
       "version": "3.1.10",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -725,13 +1009,17 @@
     },
     "node_modules/@internationalized/number": {
       "version": "3.6.7",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/string": {
-      "version": "3.2.9",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.10.tgz",
+      "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -739,6 +1027,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -747,6 +1036,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -763,10 +1053,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -775,10 +1067,12 @@
     },
     "node_modules/@leeoniya/ufuzzy": {
       "version": "1.0.19",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "state-local": "^1.0.6"
@@ -786,6 +1080,7 @@
     },
     "node_modules/@monaco-editor/react": {
       "version": "4.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/loader": "^1.5.0"
@@ -796,143 +1091,17 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@openfeature/core": {
-      "version": "1.11.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@openfeature/ofrep-core": {
-      "version": "2.2.1",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@openfeature/core": "^1.6.0"
-      }
-    },
-    "node_modules/@openfeature/ofrep-web-provider": {
-      "version": "0.3.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openfeature/ofrep-core": "^2.1.0"
-      },
-      "peerDependencies": {
-        "@openfeature/web-sdk": "^1.4.0"
-      }
-    },
-    "node_modules/@openfeature/web-sdk": {
-      "version": "1.9.0",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@openfeature/core": "^1.11.0"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/api-logs": {
-      "version": "0.202.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.202.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/sdk-logs": "0.202.0",
-        "@opentelemetry/sdk-metrics": "2.0.1",
-        "@opentelemetry/sdk-trace-base": "2.0.1",
-        "protobufjs": "^7.3.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.202.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.0.1",
-        "@opentelemetry/resources": "2.0.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.43.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -940,62 +1109,187 @@
     },
     "node_modules/@petamoriken/float16": {
       "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@rc-component/portal": {
-      "version": "1.1.2",
+    "node_modules/@rc-component/cascader": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.9.0.tgz",
+      "integrity": "sha512-2jbthe1QZrMBgtCvNKkJFjZYC3uKl4N/aYm5SsMvO3T+F+qRT1CGsSM9bXnh1rLj7jDk/GK0natShWF/jinhWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
+        "@rc-component/select": "~1.3.0",
+        "@rc-component/tree": "~1.1.0",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/drawer": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.3.0.tgz",
+      "integrity": "sha512-rE+sdXEmv2W25VBQ9daGbnb4J4hBIEKmdbj0b3xpY+K7TUmLXDIlSnoXraIbFZdGyek9WxxGKK887uRnFgI+pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.0.0",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/motion": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.3.tgz",
+      "integrity": "sha512-Xh3IszxvlSv3/PLYFyC2UZi9LNB83yOnkB/LNmRzaypZLvkhqUIPS7MQpGZcCMWrNsXV2p6YTSWbSGvFpEle9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.11.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/overflow": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.1.tgz",
+      "integrity": "sha512-syfmgAABaHCnCDzPwHZ/2tuvIcpOO3jefYZMmfkN+pmo8HKTzsfhS57vxo4ksPdN0By+uWVJhJWNFozNBxi2eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/picker": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.7.1.tgz",
+      "integrity": "sha512-u75rwgbYbH3M2+k22dWOCXv1YUtdb5bgrD7YXCV19H6qS6mUHxQOcqRVTU2JmUPKkq+TOaHC4kDgU83mN2G01w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/trigger": "^3.6.15",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1",
+        "rc-overflow": "^1.3.2"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.1.tgz",
+      "integrity": "sha512-ck+r1kW/JSv0wxPji3KN2ss9K6Z0qqwusw/mf/0JobXhZ8hC2ejZwCJObW/SvDi0uhA0VzmCnx0CaCci95tcmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.11.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/resize-observer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
+      "integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/select": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.3.6.tgz",
+      "integrity": "sha512-CzbJ9TwmWcF5asvTMZ9BMiTE9CkkrigeOGRPpzCNmeZP7KBwwmYrmOIiKh9tMG7d6DyGAEAQ75LBxzPx+pGTHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/slider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
+      "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -1003,29 +1297,117 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tooltip": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+      "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/trigger": "^3.7.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.1.0.tgz",
+      "integrity": "sha512-HZs3aOlvFgQdgrmURRc/f4IujiNBf4DdEeXUlkS0lPoLlx9RoqsZcF0caXIAMVb+NaWqKtGQDnrH8hqLCN5zlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/util": "^1.2.1",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "2.3.1",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.10.1.tgz",
+      "integrity": "sha512-mXlDN0IXdtV8Yqqm8195ECCyrbmfvvfKvwVvSlH0+qvKD6BUF8gRhEjSy0FOcD1+CcDRHgTiX99LoxfQrmh3Cw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@rc-component/portal": "^1.1.0",
-        "classnames": "^2.3.2",
-        "rc-motion": "^2.0.0",
-        "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.44.0"
+        "@rc-component/motion": "^1.3.3",
+        "@rc-component/portal": "^2.2.1",
+        "@rc-component/resize-observer": "^1.1.2",
+        "@rc-component/util": "^1.11.1",
+        "clsx": "^2.1.1"
       },
       "engines": {
         "node": ">=8.x"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
+    },
+    "node_modules/@rc-component/util": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.12.0.tgz",
+      "integrity": "sha512-AEjPL8JVdohIITaiXokyjL9WQ6tKWWjAYK9QU16tGNE9JaQABBQy+hA4H2Lup5MgXy9yY3iLrbZJheuU13hTdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-mobile": "^5.0.0",
+        "react-is": "^19.2.7"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/util/node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rc-component/virtual-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.5.1.tgz",
+      "integrity": "sha512-boqHxdtyWC88u8quYgEO49bcBy5fzRiOcnBge+N4nLzs2k8hUQ/yw7JE9dM6yCBE4jSm5YSHVCVMS+suBuJGKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^8.0.0",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/virtual-list/node_modules/@babel/runtime": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-8.0.0.tgz",
+      "integrity": "sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@react-aria/button": {
       "version": "3.15.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1038,6 +1420,7 @@
     },
     "node_modules/@react-aria/dialog": {
       "version": "3.5.31",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-aria/interactions": "^3.25.6",
@@ -1054,6 +1437,7 @@
     },
     "node_modules/@react-aria/focus": {
       "version": "3.21.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-aria/interactions": "^3.25.6",
@@ -1069,6 +1453,7 @@
     },
     "node_modules/@react-aria/i18n": {
       "version": "3.13.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@internationalized/date": "^3.12.1",
@@ -1084,6 +1469,7 @@
     },
     "node_modules/@react-aria/interactions": {
       "version": "3.28.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-types/shared": "^3.34.0",
@@ -1097,6 +1483,7 @@
     },
     "node_modules/@react-aria/overlays": {
       "version": "3.30.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-aria/focus": "^3.21.2",
@@ -1118,6 +1505,7 @@
     },
     "node_modules/@react-aria/ssr": {
       "version": "3.10.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1133,6 +1521,7 @@
     },
     "node_modules/@react-aria/utils": {
       "version": "3.31.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-aria/ssr": "^3.9.10",
@@ -1149,6 +1538,7 @@
     },
     "node_modules/@react-aria/visually-hidden": {
       "version": "3.9.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1161,6 +1551,7 @@
     },
     "node_modules/@react-spectrum/button": {
       "version": "3.18.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.47.0",
@@ -1173,6 +1564,7 @@
     },
     "node_modules/@react-spectrum/dialog": {
       "version": "3.10.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.47.0",
@@ -1185,6 +1577,7 @@
     },
     "node_modules/@react-spectrum/overlays": {
       "version": "5.10.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.47.0",
@@ -1197,6 +1590,7 @@
     },
     "node_modules/@react-spectrum/provider": {
       "version": "3.11.1",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1210,6 +1604,7 @@
     },
     "node_modules/@react-stately/flags": {
       "version": "3.2.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1222,6 +1617,7 @@
     },
     "node_modules/@react-stately/overlays": {
       "version": "3.7.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1234,6 +1630,7 @@
     },
     "node_modules/@react-stately/utils": {
       "version": "3.12.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1246,6 +1643,7 @@
     },
     "node_modules/@react-types/button": {
       "version": "3.16.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-aria/button": "^3.15.0",
@@ -1259,6 +1657,7 @@
     },
     "node_modules/@react-types/dialog": {
       "version": "3.6.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-aria/dialog": "^3.6.0",
@@ -1272,6 +1671,7 @@
     },
     "node_modules/@react-types/dialog/node_modules/@react-aria/dialog": {
       "version": "3.6.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1284,6 +1684,7 @@
     },
     "node_modules/@react-types/overlays": {
       "version": "3.10.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@react-aria/overlays": "^3.32.0",
@@ -1299,6 +1700,7 @@
     },
     "node_modules/@react-types/overlays/node_modules/@react-aria/overlays": {
       "version": "3.32.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
@@ -1310,7 +1712,10 @@
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.36.0",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.1.tgz",
+      "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
+      "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
@@ -1318,9 +1723,43 @@
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@spectrum-icons/ui": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/ui/-/ui-3.7.1.tgz",
+      "integrity": "sha512-veQymocUYo5OciXQajSailOdbWe+k6+2ehfF8D4d0V923D4xOUadtT253xXZ5vEQjPat6Kyp2WDKeQNjd7kL1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum-ui": "1.2.1",
+        "@babel/runtime": "^7.24.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@adobe/react-spectrum": "^3.47.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@spectrum-icons/workflow": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/workflow/-/workflow-4.3.1.tgz",
+      "integrity": "sha512-kDF+/EbFVyLGytotqqdYt4uSij4j/PQmDQO5km/C6DyzKjyuic3FnSBFinR+mA6oFv1OjMcLvrrDBqK3wbqRlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum-workflow": "2.3.5",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@adobe/react-spectrum": "^3.47.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@swc/core": {
@@ -1571,6 +2010,7 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -1586,6 +2026,7 @@
     },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.14.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tanstack/virtual-core": "3.17.6"
@@ -1601,6 +2042,7 @@
     },
     "node_modules/@tanstack/virtual-core": {
       "version": "3.17.6",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1609,10 +2051,12 @@
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"
@@ -1620,34 +2064,45 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jquery": {
       "version": "3.5.33",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/sizzle": "*"
       }
     },
     "node_modules/@types/js-cookie": {
-      "version": "2.2.7",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.20",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1655,18 +2110,24 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/rbush": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1683,6 +2144,7 @@
     },
     "node_modules/@types/react-table": {
       "version": "7.7.20",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -1690,6 +2152,7 @@
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
@@ -1697,27 +2160,37 @@
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.10",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/string-hash": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/systemjs": {
       "version": "6.15.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.65.0",
@@ -1737,6 +2210,9 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.65.0",
@@ -1752,6 +2228,9 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1766,6 +2245,9 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1777,6 +2259,9 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.65.0",
@@ -1802,6 +2287,9 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
@@ -1823,6 +2311,9 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.65.0",
@@ -1838,6 +2329,9 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -2020,6 +2514,7 @@
     },
     "node_modules/@wojtekmaj/date-utils": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
@@ -2027,6 +2522,7 @@
     },
     "node_modules/@xobotyi/scrollbar-width": {
       "version": "1.9.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
@@ -2041,6 +2537,7 @@
     },
     "node_modules/acorn": {
       "version": "8.17.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2051,6 +2548,9 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -2059,10 +2559,14 @@
     },
     "node_modules/add-px-to-style": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2112,8 +2616,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/attr-accept": {
       "version": "2.2.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2121,6 +2639,7 @@
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -2134,6 +2653,9 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2151,7 +2673,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2199,10 +2724,12 @@
     },
     "node_modules/calculate-size": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2237,6 +2764,16 @@
     },
     "node_modules/classnames": {
       "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/clone-deep": {
@@ -2254,6 +2791,7 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2266,6 +2804,7 @@
     },
     "node_modules/commander": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -2273,14 +2812,17 @@
     },
     "node_modules/compute-scroll-into-view": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
@@ -2310,6 +2852,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -2324,6 +2867,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2336,6 +2880,7 @@
     },
     "node_modules/css-box-model": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tiny-invariant": "^1.0.6"
@@ -2343,6 +2888,7 @@
     },
     "node_modules/css-in-js-utils": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
@@ -2350,6 +2896,7 @@
     },
     "node_modules/css-tree": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.14",
@@ -2361,6 +2908,7 @@
     },
     "node_modules/css-tree/node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2368,14 +2916,17 @@
     },
     "node_modules/cssfilter": {
       "version": "0.0.10",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3": {
       "version": "7.9.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "3",
@@ -2415,6 +2966,7 @@
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
@@ -2425,6 +2977,7 @@
     },
     "node_modules/d3-axis": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2432,6 +2985,7 @@
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -2446,6 +3000,7 @@
     },
     "node_modules/d3-chord": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "1 - 3"
@@ -2456,6 +3011,7 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2463,6 +3019,7 @@
     },
     "node_modules/d3-contour": {
       "version": "4.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "^3.2.0"
@@ -2473,6 +3030,7 @@
     },
     "node_modules/d3-delaunay": {
       "version": "6.0.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -2483,6 +3041,7 @@
     },
     "node_modules/d3-dispatch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2490,6 +3049,7 @@
     },
     "node_modules/d3-drag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -2501,6 +3061,7 @@
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "7",
@@ -2524,6 +3085,7 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12"
@@ -2531,6 +3093,7 @@
     },
     "node_modules/d3-fetch": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dsv": "1 - 3"
@@ -2541,6 +3104,7 @@
     },
     "node_modules/d3-force": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -2553,6 +3117,7 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2560,6 +3125,7 @@
     },
     "node_modules/d3-geo": {
       "version": "3.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -2570,6 +3136,7 @@
     },
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2577,6 +3144,7 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -2587,6 +3155,7 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2594,6 +3163,7 @@
     },
     "node_modules/d3-polygon": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2601,6 +3171,7 @@
     },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2608,6 +3179,7 @@
     },
     "node_modules/d3-random": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2615,6 +3187,7 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.10.0 - 3",
@@ -2629,6 +3202,7 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -2640,6 +3214,7 @@
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2647,6 +3222,7 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-path": "^3.1.0"
@@ -2657,6 +3233,7 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2 - 3"
@@ -2667,6 +3244,7 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-time": "1 - 3"
@@ -2677,6 +3255,7 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -2684,6 +3263,7 @@
     },
     "node_modules/d3-transition": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -2701,6 +3281,7 @@
     },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-dispatch": "1 - 3",
@@ -2717,6 +3298,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2725,6 +3307,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2740,15 +3323,22 @@
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/delaunator": {
       "version": "5.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -2756,6 +3346,7 @@
     },
     "node_modules/direction": {
       "version": "0.1.5",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "direction": "cli.js"
@@ -2763,6 +3354,7 @@
     },
     "node_modules/dom-css": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "add-px-to-style": "1.0.0",
@@ -2772,6 +3364,7 @@
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
@@ -2779,7 +3372,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.0",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2787,6 +3383,7 @@
     },
     "node_modules/downshift": {
       "version": "9.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -2801,6 +3398,9 @@
     },
     "node_modules/earcut": {
       "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
@@ -2833,6 +3433,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -2840,6 +3441,7 @@
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
@@ -2847,6 +3449,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2867,6 +3470,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2877,6 +3481,9 @@
     },
     "node_modules/eslint": {
       "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "workspaces": [
@@ -2934,6 +3541,9 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -2951,6 +3561,9 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2961,6 +3574,9 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -2972,6 +3588,9 @@
     },
     "node_modules/espree": {
       "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -2988,6 +3607,9 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -2999,6 +3621,9 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -3010,6 +3635,7 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -3020,6 +3646,7 @@
     },
     "node_modules/esrever": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "esrever": "bin/esrever"
@@ -3027,6 +3654,7 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -3034,6 +3662,9 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
@@ -3042,6 +3673,7 @@
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -3054,24 +3686,33 @@
     },
     "node_modules/fast_array_intersect": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/fast-shallow-equal": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.4",
@@ -3098,10 +3739,12 @@
     },
     "node_modules/fastest-stable-stringify": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3117,6 +3760,9 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3128,6 +3774,7 @@
     },
     "node_modules/file-selector": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.7.0"
@@ -3138,10 +3785,14 @@
     },
     "node_modules/find-root": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3165,6 +3816,9 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3176,12 +3830,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.3",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3189,6 +3847,9 @@
     },
     "node_modules/geotiff": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
@@ -3205,10 +3866,12 @@
       }
     },
     "node_modules/get-document": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "node_modules/get-user-locale": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "memoize": "^10.0.0"
@@ -3219,6 +3882,7 @@
     },
     "node_modules/get-window": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-document": "1"
@@ -3226,6 +3890,7 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -3249,6 +3914,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3259,10 +3925,12 @@
     },
     "node_modules/highlight-words-core": {
       "version": "1.2.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/history": {
       "version": "4.10.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2",
@@ -3275,6 +3943,7 @@
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
@@ -3282,10 +3951,14 @@
     },
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+      "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
@@ -3293,10 +3966,14 @@
     },
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/i18next": {
       "version": "25.10.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3326,6 +4003,9 @@
     },
     "node_modules/i18next-browser-languagedetector": {
       "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
@@ -3333,6 +4013,9 @@
     },
     "node_modules/i18next-pseudo": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-pseudo/-/i18next-pseudo-2.2.1.tgz",
+      "integrity": "sha512-wGybHZl+D7GXZLxLAWN5AhyrmVBxPd5kPpHgcgPw1yOoJcEEvxRk5+ZpbaAc8R59JHeyXLl99rWIXdg/zCvKFQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "i18next": "^19.1.0"
@@ -3340,6 +4023,9 @@
     },
     "node_modules/i18next-pseudo/node_modules/i18next": {
       "version": "19.9.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
+      "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
@@ -3347,6 +4033,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3357,6 +4044,9 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3364,11 +4054,15 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -3401,6 +4095,9 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3409,6 +4106,7 @@
     },
     "node_modules/inline-style-prefixer": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-in-js-utils": "^3.1.0"
@@ -3416,6 +4114,7 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3431,6 +4130,7 @@
     },
     "node_modules/intl-messageformat": {
       "version": "10.7.18",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
@@ -3441,6 +4141,7 @@
     },
     "node_modules/invariant": {
       "version": "2.2.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
@@ -3448,10 +4149,12 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -3465,6 +4168,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3472,6 +4176,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3482,14 +4187,24 @@
     },
     "node_modules/is-hotkey": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-in-browser": {
       "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -3500,18 +4215,22 @@
     },
     "node_modules/is-window": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3519,6 +4238,7 @@
     },
     "node_modules/isomorphic-base64": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-worker": {
@@ -3536,18 +4256,24 @@
     },
     "node_modules/jquery": {
       "version": "3.7.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -3558,25 +4284,38 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3593,10 +4332,16 @@
     },
     "node_modules/lerc": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3609,10 +4354,14 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3626,15 +4375,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -3645,6 +4394,9 @@
     },
     "node_modules/marked": {
       "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
+      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -3654,18 +4406,23 @@
       }
     },
     "node_modules/marked-mangle": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.12.tgz",
+      "integrity": "sha512-bRrqNcfU9v3iRECb7YPvA+/xKZMjHojd9R92YwHbFjdPQ+Wc7vozkbGKAv4U8AUl798mNUuY3DTBQkedsV3TeQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "marked": ">=4 <17"
+        "marked": ">=4 <18"
       }
     },
     "node_modules/mdn-data": {
       "version": "2.0.14",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/memoize": {
       "version": "10.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.1"
@@ -3679,6 +4436,7 @@
     },
     "node_modules/memoize-one": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge-stream": {
@@ -3688,6 +4446,7 @@
     },
     "node_modules/micro-memoize": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mime-db": {
@@ -3700,6 +4459,7 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3709,10 +4469,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3782,6 +4545,7 @@
     },
     "node_modules/moment": {
       "version": "2.30.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3789,6 +4553,7 @@
     },
     "node_modules/moment-timezone": {
       "version": "0.5.47",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -3801,14 +4566,17 @@
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
       "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nano-css": {
       "version": "5.6.2",
+      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -3827,10 +4595,14 @@
     },
     "node_modules/nano-css/node_modules/stylis": {
       "version": "4.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3857,13 +4629,17 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/ol": {
-      "version": "10.6.1",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
+      "integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/rbush": "4.0.0",
@@ -3879,6 +4655,9 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3895,6 +4674,9 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3909,6 +4691,9 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3931,6 +4716,9 @@
     },
     "node_modules/pako": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3945,10 +4733,12 @@
     },
     "node_modules/papaparse": {
       "version": "5.5.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -3959,10 +4749,14 @@
     },
     "node_modules/parse-headers": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -3979,6 +4773,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3986,6 +4781,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3993,10 +4789,12 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "0.0.1"
@@ -4004,6 +4802,7 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4011,6 +4810,9 @@
     },
     "node_modules/pbf": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -4021,14 +4823,17 @@
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4098,10 +4903,14 @@
     },
     "node_modules/prefix-style": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4110,6 +4919,7 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4117,6 +4927,7 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4126,35 +4937,21 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -4163,6 +4960,9 @@
     },
     "node_modules/quick-lru": {
       "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4173,10 +4973,14 @@
     },
     "node_modules/quickselect": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/raf": {
       "version": "3.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "performance-now": "^2.1.0"
@@ -4184,60 +4988,24 @@
     },
     "node_modules/raf-schd": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rbush": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quickselect": "^3.0.0"
       }
     },
-    "node_modules/rc-cascader": {
-      "version": "3.34.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "classnames": "^2.3.1",
-        "rc-select": "~14.16.2",
-        "rc-tree": "~5.13.0",
-        "rc-util": "^5.43.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-drawer": {
-      "version": "7.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@rc-component/portal": "^1.1.1",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.6.1",
-        "rc-util": "^5.38.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-motion": {
-      "version": "2.9.5",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/rc-overflow": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.5.0.tgz",
+      "integrity": "sha512-Lm/v9h0LymeUYJf0x39OveU52InkdRXqnn2aYXfWmo8WdOonIKB2kfau+GF0fWq6jPgtdO9yMqveGcK6aIhJmg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
@@ -4250,45 +5018,11 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-picker": {
-      "version": "4.11.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.1",
-        "rc-overflow": "^1.3.2",
-        "rc-resize-observer": "^1.4.0",
-        "rc-util": "^5.43.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "date-fns": ">= 2.x",
-        "dayjs": ">= 1.x",
-        "luxon": ">= 3.x",
-        "moment": ">= 2.x",
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      },
-      "peerDependenciesMeta": {
-        "date-fns": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/rc-resize-observer": {
       "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
+      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
@@ -4301,76 +5035,11 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-select": {
-      "version": "14.16.8",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^2.1.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.3.1",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.5.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-slider": {
-      "version": "11.1.9",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.36.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tooltip": {
-      "version": "6.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.3.1",
-        "rc-util": "^5.44.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tree": {
-      "version": "5.13.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.5.1"
-      },
-      "engines": {
-        "node": ">=10.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
     "node_modules/rc-util": {
       "version": "5.44.4",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
+      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -4381,25 +5050,9 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/rc-virtual-list": {
-      "version": "3.19.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.0",
-        "classnames": "^2.2.6",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.36.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -4408,9 +5061,51 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-aria": {},
+    "node_modules/react-aria": {
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.51.0.tgz",
+      "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.3",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.49.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria-components": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.20.0.tgz",
+      "integrity": "sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.3",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "react-aria": "3.51.0",
+        "react-stately": "3.49.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-calendar": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@wojtekmaj/date-utils": "^2.0.2",
@@ -4434,6 +5129,7 @@
     },
     "node_modules/react-colorful": {
       "version": "5.6.1",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -4442,6 +5138,7 @@
     },
     "node_modules/react-custom-scrollbars-2": {
       "version": "4.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dom-css": "^2.0.0",
@@ -4453,21 +5150,9 @@
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-data-grid": {
-      "version": "7.0.0-beta.56",
-      "resolved": "git+ssh://git@github.com/grafana/react-data-grid.git#a922856b5ede21d55db3fdffb6d38dc76bdc7c58",
-      "integrity": "sha512-kE4U/hBd5rNeKT2poz+uMfVlaSqjVLVXs0ZAP674DImFnri/6ARhEtr+6szEboNepQgWXEJYIWtdZ7GbaBpexw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0 || ^19.0",
-        "react-dom": "^18.0 || ^19.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -4479,6 +5164,7 @@
     },
     "node_modules/react-dropzone": {
       "version": "14.3.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "attr-accept": "^2.2.4",
@@ -4494,6 +5180,7 @@
     },
     "node_modules/react-from-dom": {
       "version": "0.7.5",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "16.8 - 19"
@@ -4501,6 +5188,7 @@
     },
     "node_modules/react-highlight-words": {
       "version": "0.21.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "highlight-words-core": "^1.2.0",
@@ -4512,6 +5200,7 @@
     },
     "node_modules/react-hook-form": {
       "version": "7.83.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4526,6 +5215,9 @@
     },
     "node_modules/react-i18next": {
       "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
+      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",
@@ -4550,6 +5242,7 @@
     },
     "node_modules/react-immutable-proptypes": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.2"
@@ -4560,6 +5253,7 @@
     },
     "node_modules/react-inlinesvg": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "react-from-dom": "^0.7.5"
@@ -4570,10 +5264,12 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-loading-skeleton": {
       "version": "3.5.0",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
@@ -4581,6 +5277,7 @@
     },
     "node_modules/react-redux": {
       "version": "9.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
@@ -4602,6 +5299,7 @@
     },
     "node_modules/react-router": {
       "version": "5.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.13",
@@ -4620,6 +5318,7 @@
     },
     "node_modules/react-router-dom": {
       "version": "5.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.13",
@@ -4636,6 +5335,7 @@
     },
     "node_modules/react-router-dom-v5-compat": {
       "version": "6.30.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.3",
@@ -4653,6 +5353,7 @@
     },
     "node_modules/react-router-dom-v5-compat/node_modules/history": {
       "version": "5.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.6"
@@ -4660,6 +5361,7 @@
     },
     "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
       "version": "6.30.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.3"
@@ -4673,10 +5375,12 @@
     },
     "node_modules/react-router/node_modules/react-is": {
       "version": "16.13.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-select": {
       "version": "5.10.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
@@ -4696,16 +5400,20 @@
     },
     "node_modules/react-select/node_modules/memoize-one": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-stately": {
-      "version": "3.48.0",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.49.0.tgz",
+      "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.2",
+        "@internationalized/date": "^3.12.3",
         "@internationalized/number": "^3.6.7",
-        "@internationalized/string": "^3.2.9",
-        "@react-types/shared": "^3.36.0",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
         "@swc/helpers": "^0.5.0",
         "use-sync-external-store": "^1.6.0"
       },
@@ -4715,6 +5423,7 @@
     },
     "node_modules/react-table": {
       "version": "7.8.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4726,6 +5435,7 @@
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
@@ -4740,21 +5450,25 @@
     },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
+      "dev": true,
       "peerDependencies": {
         "react": "*",
         "tslib": "*"
       }
     },
     "node_modules/react-use": {
-      "version": "17.6.0",
+      "version": "17.6.1",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.1.tgz",
+      "integrity": "sha512-uibb3pgzV4LFsYPHyXYGu7dD2+pyk/ZJlPH+AizBR3zolqPWyCleKcWWbUQaKSKfydwgnQ3ymGm1Ab3/saGHCA==",
+      "dev": true,
       "license": "Unlicense",
       "dependencies": {
-        "@types/js-cookie": "^2.2.6",
+        "@types/js-cookie": "^3.0.0",
         "@xobotyi/scrollbar-width": "^1.9.5",
         "copy-to-clipboard": "^3.3.1",
         "fast-deep-equal": "^3.1.3",
         "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
+        "js-cookie": "^3.0.0",
         "nano-css": "^5.6.2",
         "react-universal-interface": "^0.6.2",
         "resize-observer-polyfill": "^1.5.1",
@@ -4771,6 +5485,7 @@
     },
     "node_modules/react-window": {
       "version": "1.8.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
@@ -4797,6 +5512,7 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/require-from-string": {
@@ -4809,10 +5525,12 @@
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4851,6 +5569,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4858,10 +5577,14 @@
     },
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-protobuf-schema": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
@@ -4869,10 +5592,12 @@
     },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/rtl-css-js": {
       "version": "1.16.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
@@ -4880,10 +5605,12 @@
     },
     "node_modules/rw": {
       "version": "1.3.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -4891,10 +5618,12 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -4951,6 +5680,7 @@
     },
     "node_modules/screenfull": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4961,10 +5691,12 @@
     },
     "node_modules/selection-is-backward": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4983,6 +5715,7 @@
     },
     "node_modules/set-harmonic-interval": {
       "version": "1.0.1",
+      "dev": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=6.9"
@@ -5001,6 +5734,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5011,6 +5745,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5018,6 +5753,7 @@
     },
     "node_modules/slate": {
       "version": "0.47.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.1.0",
@@ -5035,6 +5771,7 @@
     },
     "node_modules/slate-base64-serializer": {
       "version": "0.2.115",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isomorphic-base64": "^1.0.2"
@@ -5045,6 +5782,7 @@
     },
     "node_modules/slate-dev-environment": {
       "version": "0.2.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-in-browser": "^1.1.3"
@@ -5052,6 +5790,7 @@
     },
     "node_modules/slate-hotkeys": {
       "version": "0.2.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-hotkey": "0.1.4",
@@ -5060,10 +5799,12 @@
     },
     "node_modules/slate-hotkeys/node_modules/is-hotkey": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/slate-plain-serializer": {
       "version": "0.7.13",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "immutable": ">=3.8.1",
@@ -5072,6 +5813,7 @@
     },
     "node_modules/slate-prop-types": {
       "version": "0.5.44",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "immutable": ">=3.8.1",
@@ -5080,6 +5822,7 @@
     },
     "node_modules/slate-react": {
       "version": "0.22.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.1.0",
@@ -5108,6 +5851,7 @@
     },
     "node_modules/slate-react/node_modules/debug": {
       "version": "3.2.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -5115,6 +5859,7 @@
     },
     "node_modules/slate-react/node_modules/slate-react-placeholder": {
       "version": "0.2.9",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.0.0",
@@ -5124,10 +5869,12 @@
     },
     "node_modules/slate-react/node_modules/tiny-warning": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/slate/node_modules/debug": {
       "version": "3.2.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -5135,10 +5882,12 @@
     },
     "node_modules/slate/node_modules/tiny-warning": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.5.7",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5163,6 +5912,7 @@
     },
     "node_modules/stack-generator": {
       "version": "2.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
@@ -5170,10 +5920,12 @@
     },
     "node_modules/stackframe": {
       "version": "1.3.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stacktrace-gps": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "source-map": "0.5.6",
@@ -5182,6 +5934,7 @@
     },
     "node_modules/stacktrace-gps/node_modules/source-map": {
       "version": "0.5.6",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5189,6 +5942,7 @@
     },
     "node_modules/stacktrace-js": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "error-stack-parser": "^2.0.6",
@@ -5198,14 +5952,17 @@
     },
     "node_modules/state-local": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-hash": {
       "version": "1.1.3",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/stylis": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -5224,6 +5981,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5246,6 +6004,7 @@
     },
     "node_modules/tabbable": {
       "version": "6.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -5284,6 +6043,7 @@
     },
     "node_modules/throttle-debounce": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5291,18 +6051,22 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -5317,6 +6081,7 @@
     },
     "node_modules/to-camel-case": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-space-case": "^1.0.0"
@@ -5324,10 +6089,12 @@
     },
     "node_modules/to-no-case": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-space-case": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-no-case": "^1.0.0"
@@ -5335,10 +6102,14 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -5349,14 +6120,19 @@
     },
     "node_modules/ts-easing": {
       "version": "0.2.0",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5368,10 +6144,12 @@
     },
     "node_modules/type-of": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5383,6 +6161,7 @@
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.41",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5407,6 +6186,7 @@
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -5440,10 +6220,14 @@
     },
     "node_modules/uplot": {
       "version": "1.6.32",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
@@ -5452,6 +6236,7 @@
     },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -5464,13 +6249,17 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -5482,14 +6271,19 @@
     },
     "node_modules/uwrap": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/value-equal": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5497,6 +6291,7 @@
     },
     "node_modules/warning": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
@@ -5513,12 +6308,11 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "license": "Apache-2.0"
-    },
     "node_modules/web-worker": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/webpack": {
@@ -5655,6 +6449,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5673,6 +6468,9 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5681,10 +6479,14 @@
     },
     "node_modules/xml-utils": {
       "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/xss": {
       "version": "1.0.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^2.20.3",
@@ -5699,10 +6501,12 @@
     },
     "node_modules/xss/node_modules/commander": {
       "version": "2.20.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "1.10.3",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -5710,6 +6514,9 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5719,8 +6526,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zstddec": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "dev": true,
       "license": "MIT AND BSD-3-Clause"
     }
   }

--- a/integrations/grafana-lians-app/package.json
+++ b/integrations/grafana-lians-app/package.json
@@ -3,26 +3,42 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.cjs --mode production",
+    "build": "node scripts/build-and-inspect.cjs",
     "dev": "webpack --config webpack.config.cjs --mode development --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run typecheck && npm run build",
+    "audit:ci": "npm audit --audit-level=high"
   },
   "devDependencies": {
+    "@grafana/data": "12.4.6",
+    "@grafana/ui": "12.4.6",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@swc/core": "^1.15.0",
     "copy-webpack-plugin": "^14.0.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "swc-loader": "^0.2.6",
     "typescript": "^5.9.0",
     "webpack": "^5.101.0",
     "webpack-cli": "^6.0.0"
   },
-  "dependencies": {
-    "@grafana/data": "12.3.0",
-    "@grafana/runtime": "12.3.0",
-    "@grafana/ui": "12.3.0",
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0"
+  "peerDependencies": {
+    "@grafana/data": "12.4.6",
+    "@grafana/ui": "12.4.6",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "overrides": {
+    "lodash": "4.18.1",
+    "react-use": "17.6.1",
+    "@grafana/data@12.4.6": {
+      "dompurify": "3.4.12"
+    },
+    "@grafana/ui@12.4.6": {
+      "immutable": "5.1.9",
+      "uuid": "11.1.1"
+    }
   },
   "engines": {
     "node": ">=22"

--- a/integrations/grafana-lians-app/scripts/build-and-inspect.cjs
+++ b/integrations/grafana-lians-app/scripts/build-and-inspect.cjs
@@ -1,0 +1,130 @@
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+
+const root = path.resolve(__dirname, '..');
+const config = {
+  ...require(path.join(root, 'webpack.config.cjs')),
+  context: root,
+  mode: 'production',
+};
+
+const hostProvidedPackages = [
+  '@grafana',
+  'react',
+  'react-dom',
+  'dompurify',
+  'immutable',
+  'lodash',
+  'uuid',
+  '@opentelemetry',
+  'js-cookie',
+  'react-router',
+  'react-router-dom',
+];
+
+function flattenModules(modules = []) {
+  return modules.flatMap((module) => [
+    module,
+    ...flattenModules(module.modules),
+    ...flattenModules(module.children),
+  ]);
+}
+
+function packageFromNodeModules(modulePath) {
+  const normalized = modulePath.replaceAll('\\', '/');
+  const marker = '/node_modules/';
+  const markerIndex = normalized.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const segments = normalized.slice(markerIndex + marker.length).split('/');
+  return segments[0].startsWith('@')
+    ? `${segments[0]}/${segments[1]}`
+    : segments[0];
+}
+
+function isHostProvided(packageName) {
+  return hostProvidedPackages.some(
+    (hostPackage) =>
+      packageName === hostPackage || packageName.startsWith(`${hostPackage}/`),
+  );
+}
+
+webpack(config, (error, stats) => {
+  if (error) {
+    console.error(error.stack || error);
+    process.exitCode = 1;
+    return;
+  }
+
+  const output = stats.toString({
+    all: false,
+    assets: true,
+    colors: process.stdout.isTTY,
+    errors: true,
+    timings: true,
+    warnings: true,
+  });
+  if (output) {
+    console.log(output);
+  }
+
+  if (stats.hasErrors()) {
+    process.exitCode = 1;
+    return;
+  }
+
+  const details = stats.toJson({
+    all: false,
+    assets: true,
+    errors: true,
+    modules: true,
+    nestedModules: true,
+    warnings: true,
+  });
+  const modules = flattenModules(details.modules);
+  const bundledHostModules = modules
+    .map((module) => module.nameForCondition || module.identifier || '')
+    .map((modulePath) => ({
+      modulePath,
+      packageName: packageFromNodeModules(modulePath),
+    }))
+    .filter(
+      ({ packageName }) => packageName && isHostProvided(packageName),
+    );
+
+  if (bundledHostModules.length > 0) {
+    console.error('Host-provided or audited libraries were bundled unexpectedly:');
+    for (const { modulePath } of bundledHostModules) {
+      console.error(`- ${modulePath}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const moduleAsset = path.join(root, 'dist', 'module.js');
+  const source = fs.readFileSync(moduleAsset, 'utf8');
+  const requiredExternals = [
+    '@grafana/data',
+    '@grafana/ui',
+    'react/jsx-runtime',
+  ];
+  const missingExternals = requiredExternals.filter(
+    (external) => !source.includes(external),
+  );
+  if (missingExternals.length > 0) {
+    console.error(
+      `Generated module is missing expected SystemJS externals: ${missingExternals.join(', ')}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const moduleAssetStats = fs.statSync(moduleAsset);
+  console.log(
+    `Bundle inspection passed: ${modules.length} module records, ` +
+      `${moduleAssetStats.size} byte module.js, no host-provided package sources bundled.`,
+  );
+});


### PR DESCRIPTION
## What changed

- compile against the actual Grafana 12.4.6 homelab target
- classify Grafana and React as host-provided peer dependencies plus development-only compiler inputs
- remove the unused `@grafana/runtime` package
- refresh compatible transitive versions for DOMPurify, Immutable, Lodash, react-use/js-cookie, UUID, and OpenTelemetry
- add a production bundle inspector that rejects bundled React, `@grafana/*`, and audited host-library sources
- add a path-scoped Node 22 CI gate for clean install, high/critical audit, typecheck, build, and bundle inspection

## Security result

This lock is expected to close 26 of the 28 open Dependabot alerts under `integrations/grafana-lians-app`.

Two moderate React Router advisories remain upstream in `@grafana/ui@12.4.6 -> react-router-dom-v5-compat@6.30.4 -> react-router@6.30.4`. The published patched version is React Router 7.18.0, an incompatible major. Lians does not import router APIs, Grafana supplies `@grafana/ui` at runtime, and the bundle inspector proves this graph is absent from `dist/module.js`. This PR intentionally does not force a v7 override or dismiss either alert.

## Validation

- `npm ci`
- `npx npm@10.9.4 ls --all` (clean dependency graph; npm 11.3 locally mislabels satisfied ranges)
- `npm run audit:ci` (passes; no high/critical findings)
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm run verify` (typecheck + production build + bundle inspection)
- emitted `module.js`: 1,805 bytes, six module records, no host-package sources bundled
- `python scripts/check_release_contract.py`
- `python scripts/check_openapi_contract.py`
- action SHA pin scan
- `git diff --check`

Draft only: no merge, deployment, alert dismissal, or publication is included.