### PR TITLE
Harden release dependencies and demo key handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ node_modules/
 agentmem/docker-compose.override.yml
 # Local docker-stack env holding a real MASTER_ENCRYPTION_KEY — never commit.
 agentmem/.env.dockerstack
+# Example owner-only bearer-key export from agentmem/scripts/seed_demo.py.
+.demo-read-key
 # Scratch live-smoke script used for cross-language SDK testing.
 agentmem/sdk/typescript/live_smoke.mjs
 

--- a/agentmem/scripts/seed_demo.py
+++ b/agentmem/scripts/seed_demo.py
@@ -14,30 +14,38 @@ Usage:
 
     # Or point at a different host:
     python scripts/seed_demo.py --api-url https://agentmem.fly.dev --admin-secret <secret>
+
+    # Export a read key to a new owner-only file (never printed to stdout):
+    python scripts/seed_demo.py --read-key-output .demo-read-key
 """
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from pathlib import Path
 
 import httpx
 
-# ── CLI ───────────────────────────────────────────────────────────────────────
-parser = argparse.ArgumentParser(description="Seed AgentMem demo data")
-parser.add_argument("--api-url", default="http://localhost:8000", help="Base URL of the AgentMem API")
-parser.add_argument("--admin-secret", default="demo-admin-secret", help="X-Admin-Secret header value")
-parser.add_argument("--namespace", default="demo", help="Namespace to seed")
-args = parser.parse_args()
 
-API = args.api_url.rstrip("/")
-ADMIN_SECRET = args.admin_secret
-NS = args.namespace
+# ── CLI ───────────────────────────────────────────────────────────────────────
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed AgentMem demo data")
+    parser.add_argument("--api-url", default="http://localhost:8000", help="Base URL of the AgentMem API")
+    parser.add_argument("--admin-secret", default="demo-admin-secret", help="X-Admin-Secret header value")
+    parser.add_argument("--namespace", default="demo", help="Namespace to seed")
+    parser.add_argument(
+        "--read-key-output",
+        type=Path,
+        help="Write a read bearer key to a new owner-only file (the key is never logged)",
+    )
+    return parser
 
 
 def _ts(year: int, month: int, day: int) -> str:
-    return datetime(year, month, day, 16, 0, 0, tzinfo=timezone.utc).isoformat()
+    return datetime(year, month, day, 16, 0, 0, tzinfo=UTC).isoformat()
 
 
 # ── Demo data ─────────────────────────────────────────────────────────────────
@@ -174,11 +182,16 @@ FED_RATES = [
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _wait_for_api(client: httpx.Client, retries: int = 30, delay: float = 2.0) -> None:
-    print(f"Waiting for API at {API} ...", end="", flush=True)
+def _wait_for_api(
+    client: httpx.Client,
+    api: str,
+    retries: int = 30,
+    delay: float = 2.0,
+) -> None:
+    print(f"Waiting for API at {api} ...", end="", flush=True)
     for _ in range(retries):
         try:
-            r = client.get(f"{API}/health", timeout=3)
+            r = client.get(f"{api}/health", timeout=3)
             if r.status_code == 200:
                 print(" ready.")
                 return
@@ -191,20 +204,34 @@ def _wait_for_api(client: httpx.Client, retries: int = 30, delay: float = 2.0) -
     sys.exit(1)
 
 
-def _provision_key(client: httpx.Client, label: str, scopes: list[str]) -> str:
+def _provision_key(
+    client: httpx.Client,
+    *,
+    api: str,
+    admin_secret: str,
+    namespace: str,
+    label: str,
+    scopes: list[str],
+) -> str:
     r = client.post(
-        f"{API}/v1/admin/api-keys",
-        json={"namespace": NS, "scopes": scopes, "label": label},
-        headers={"X-Admin-Secret": ADMIN_SECRET},
+        f"{api}/v1/admin/api-keys",
+        json={"namespace": namespace, "scopes": scopes, "label": label},
+        headers={"X-Admin-Secret": admin_secret},
     )
     r.raise_for_status()
     return r.json()["key"]
 
 
-def _ingest(client: httpx.Client, key: str, memories: list[dict]) -> None:
+def _ingest(
+    client: httpx.Client,
+    key: str,
+    memories: list[dict],
+    *,
+    api: str,
+) -> None:
     for mem in memories:
         r = client.post(
-            f"{API}/v1/memories",
+            f"{api}/v1/memories",
             json=mem,
             headers={"X-API-Key": key},
         )
@@ -219,50 +246,104 @@ def _ingest(client: httpx.Client, key: str, memories: list[dict]) -> None:
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-def main() -> None:
-    with httpx.Client() as client:
-        _wait_for_api(client)
+def _write_read_key(path: Path, key: str) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as output:
+            descriptor = -1
+            output.write(f"{key}\n")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
 
-        print(f"\nProvisioning API keys for namespace '{NS}' ...")
-        write_key = _provision_key(client, "seed-write", ["read", "write"])
-        read_key = _provision_key(client, "demo-readonly", ["read"])
-        print(f"  write key: {write_key[:24]}... (used for seeding, keep private)")
-        print(f"  read  key: {read_key[:24]}... (safe to share for demo)")
 
-        print("\n── NVDA FY2026 Revenue Guidance (5 revisions) ──────────────────")
-        _ingest(client, write_key, NVDA_GUIDANCE)
+def _demo_instructions(*, api: str, namespace: str, read_key_path: Path | None) -> str:
+    if read_key_path is None:
+        key_notice = (
+            "No read key was provisioned. Use --read-key-output PATH to create one "
+            "in a new owner-only file."
+        )
+    else:
+        key_notice = f"Read key written to {read_key_path} (contents never logged)."
 
-        print("\n── TSLA Quarterly Deliveries (4 quarters) ──────────────────────")
-        _ingest(client, write_key, TSLA_DELIVERIES)
+    return f"""{key_notice}
 
-        print("\n── Fed Funds Rate Decisions (6 FOMC meetings) ───────────────────")
-        _ingest(client, write_key, FED_RATES)
+Try it with curl:
 
-    print("\n" + "=" * 70)
-    print("Demo data loaded. Read-only API key for the demo page:")
-    print(f"\n  {read_key}\n")
-    print("Try it with curl:")
-    print(f"""
-  # Present-time recall — should return ONLY the latest NVDA guidance ($40B)
-  curl -s -X POST {API}/v1/recall \\
-    -H "X-API-Key: {read_key}" \\
+  # Present-time recall - should return ONLY the latest NVDA guidance ($40B)
+  curl -s -X POST {api}/v1/recall \\
+    -H "X-API-Key: <read-key>" \\
     -H "Content-Type: application/json" \\
     -d '{{"agent_id":"market-analyst","query":"NVDA FY2026 revenue guidance","k":5}}' \\
     | python -m json.tool
 
-  # Point-in-time — what did we know about NVDA guidance on 2025-03-01?
-  curl -s -X POST {API}/v1/recall \\
-    -H "X-API-Key: {read_key}" \\
+  # Point-in-time - what did we know about NVDA guidance on 2025-03-01?
+  curl -s -X POST {api}/v1/recall \\
+    -H "X-API-Key: <read-key>" \\
     -H "Content-Type: application/json" \\
     -d '{{"agent_id":"market-analyst","query":"NVDA FY2026 revenue guidance","k":5,"as_of":"2025-03-01T00:00:00Z"}}' \\
     | python -m json.tool
 
-  # Audit chain verification
-  curl -s "{API}/v1/admin/audit/verify?namespace={NS}" \\
-    -H "X-Admin-Secret: {ADMIN_SECRET}" \\
+  # Audit chain verification (substitute the admin secret without echoing it here)
+  curl -s "{api}/v1/admin/audit/verify?namespace={namespace}" \\
+    -H "X-Admin-Secret: <admin-secret>" \\
     | python -m json.tool
-""")
-    print(f"Open demo/index.html in a browser and paste the key above.")
+
+Open demo/index.html in a browser and paste the read key from the owner-only file.
+"""
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+    api = args.api_url.rstrip("/")
+
+    with httpx.Client() as client:
+        _wait_for_api(client, api)
+
+        print(f"\nProvisioning API keys for namespace '{args.namespace}' ...")
+        write_key = _provision_key(
+            client,
+            api=api,
+            admin_secret=args.admin_secret,
+            namespace=args.namespace,
+            label="seed-write",
+            scopes=["read", "write"],
+        )
+        print("  write key: [redacted]")
+
+        if args.read_key_output is not None:
+            read_key = _provision_key(
+                client,
+                api=api,
+                admin_secret=args.admin_secret,
+                namespace=args.namespace,
+                label="demo-readonly",
+                scopes=["read"],
+            )
+            _write_read_key(args.read_key_output, read_key)
+            print(f"  read key written to {args.read_key_output} (contents not logged)")
+        else:
+            print("  read key: not provisioned (use --read-key-output PATH)")
+
+        print("\n── NVDA FY2026 Revenue Guidance (5 revisions) ──────────────────")
+        _ingest(client, write_key, NVDA_GUIDANCE, api=api)
+
+        print("\n── TSLA Quarterly Deliveries (4 quarters) ──────────────────────")
+        _ingest(client, write_key, TSLA_DELIVERIES, api=api)
+
+        print("\n── Fed Funds Rate Decisions (6 FOMC meetings) ───────────────────")
+        _ingest(client, write_key, FED_RATES, api=api)
+
+    print("\n" + "=" * 70)
+    print("Demo data loaded.")
+    print(
+        _demo_instructions(
+            api=api,
+            namespace=args.namespace,
+            read_key_path=args.read_key_output,
+        )
+    )
     print("=" * 70)
 
 

--- a/agentmem/sdk/java/pom.xml
+++ b/agentmem/sdk/java/pom.xml
@@ -38,7 +38,7 @@
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jackson.version>2.17.1</jackson.version>
+    <jackson.version>2.18.9</jackson.version>
     <junit.version>5.10.2</junit.version>
   </properties>
 

--- a/agentmem/sdk/typescript/package-lock.json
+++ b/agentmem/sdk/typescript/package-lock.json
@@ -1230,9 +1230,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2726,9 +2726,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/agentmem/tests/test_seed_demo_script.py
+++ b/agentmem/tests/test_seed_demo_script.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Self
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "seed_demo.py"
+SPEC = importlib.util.spec_from_file_location("seed_demo", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_read_key_is_never_rendered_in_instructions() -> None:
+    output = MODULE._demo_instructions(
+        api="https://example.test",
+        namespace="demo",
+        read_key_path=None,
+    )
+
+    assert "<read-key>" in output
+    assert "--read-key-output" in output
+    assert "was provisioned" in output
+
+
+def test_read_key_output_is_new_owner_only_file(tmp_path: Path) -> None:
+    key = "lians_read_bearer_key_for_owner_only_file"
+    output_path = tmp_path / "read-key"
+
+    MODULE._write_read_key(output_path, key)
+
+    assert output_path.read_text(encoding="utf-8") == f"{key}\n"
+    if os.name != "nt":
+        assert output_path.stat().st_mode & 0o777 == 0o600
+    with pytest.raises(FileExistsError):
+        MODULE._write_read_key(output_path, "replacement")
+    assert output_path.read_text(encoding="utf-8") == f"{key}\n"
+
+
+def test_read_key_output_requires_explicit_path(tmp_path: Path) -> None:
+    parser = MODULE._build_parser()
+
+    assert parser.parse_args([]).read_key_output is None
+    assert parser.parse_args(["--read-key-output", str(tmp_path / "key")]).read_key_output == (
+        tmp_path / "key"
+    )
+
+
+def test_main_never_logs_provisioned_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    read_key = "read_bearer_value_that_must_not_reach_stdout"
+    write_key = "write_bearer_value_that_must_not_reach_stdout"
+    output_path = tmp_path / "read-key"
+
+    class FakeClient:
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(MODULE.httpx, "Client", FakeClient)
+    monkeypatch.setattr(MODULE, "_wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setattr(MODULE, "_ingest", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        MODULE,
+        "_provision_key",
+        lambda *args, **kwargs: read_key if kwargs["label"] == "demo-readonly" else write_key,
+    )
+
+    MODULE.main(["--read-key-output", str(output_path)])
+
+    stdout = capsys.readouterr().out
+    assert read_key not in stdout
+    assert write_key not in stdout
+    assert output_path.read_text(encoding="utf-8") == f"{read_key}\n"


### PR DESCRIPTION
## What changed

- Raise the Java SDK's Jackson line from `2.17.1` to `2.18.9`; Maven resolves `jackson-databind`, `jackson-core`, and `jackson-annotations` at the same version, so no separate BOM is needed.
- Refresh only the TypeScript SDK's development lock entries for `js-yaml` (`3.15.1`) and `brace-expansion` (`1.1.18`). The published package still declares zero runtime dependencies.
- Stop the demo seeder from logging bearer credentials. Default runs no longer provision an unused read key; `--read-key-output PATH` exports one only to a newly created, non-overwritable `0600` file. Admin-secret examples are placeholders, the example key file is ignored, and regressions cover stdout redaction and exclusive file creation.

## Why

The pre-release audit found vulnerable Java and npm development dependencies plus CodeQL alert #3 (`py/clear-text-logging-sensitive-data`) in `seed_demo.py`. The seeder printed a full read bearer credential and repeated it in copyable command examples.

## Impact

This is release hardening only. There is no version bump, package publication, deployment change, or Grafana override work. Existing seeding behavior is unchanged except that callers must explicitly choose a secure output file if they want a demo read key.

## Validation

- `mvn -B --no-transfer-progress clean verify` on Temurin 11, 17, and 21: 7/7 tests passed on each JDK
- Maven dependency tree: Jackson databind/core/annotations all `2.18.9`
- Node 18.20.8, 20.20.2, and 22.23.2: 18/18 Jest tests plus `tsc --noEmit` passed on each runtime
- `npm ci` and `npm audit --audit-level=moderate`: 0 vulnerabilities
- `npm run build` and `npm pack --dry-run --json`: 22 expected files; zero runtime dependencies
- `python -m pytest` for the seeder and rebased deployment-script tests: 18 passed
- release contract check: synchronized at `0.5.0`
- targeted Ruff and diff checks: passed