### PR TITLE
Harden API-key security fingerprints

### DIFF
--- a/agentmem/.env.example
+++ b/agentmem/.env.example
@@ -72,7 +72,8 @@ KMS_PROVIDER=env
 # KMS_VAULT_PATH=agentmem/master-key
 
 # ── API authentication ────────────────────────────────────────────────────
-# Seed used to sign API keys — change before any real data is ingested.
+# HMAC key used for non-reversible API-key fingerprints. Change before any
+# real data is ingested and keep it consistent across API workers.
 # Generate: python -c "import secrets; print(secrets.token_hex(32))"
 API_SECRET_SEED=dev-seed-change-in-production
 

--- a/agentmem/.env.example
+++ b/agentmem/.env.example
@@ -72,7 +72,7 @@ KMS_PROVIDER=env
 # KMS_VAULT_PATH=agentmem/master-key
 
 # ── API authentication ────────────────────────────────────────────────────
-# HMAC key used for non-reversible API-key fingerprints. Change before any
+# Server-side key used for non-reversible API-key fingerprints. Change before any
 # real data is ingested and keep it consistent across API workers.
 # Generate: python -c "import secrets; print(secrets.token_hex(32))"
 API_SECRET_SEED=dev-seed-change-in-production

--- a/agentmem/benchmarks/decision_reconstruction_eval.py
+++ b/agentmem/benchmarks/decision_reconstruction_eval.py
@@ -37,13 +37,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
+from src.lians.config import get_settings
 from src.lians.db import get_db
 from src.lians.main import app
-from src.lians.models import ApiKey, Base, EventLog
+from src.lians.models import Base, EventLog
 
 
 NAMESPACE = "riad-benchmark"
-API_KEY = "riad-local-benchmark-key"
 AGENT = "underwriting-agent"
 SESSION = "loan-2026-0042"
 
@@ -90,29 +90,33 @@ async def run_benchmark(repetitions: int = 10) -> dict[str, Any]:
         await connection.run_sync(Base.metadata.create_all)
 
     sessions = async_sessionmaker(engine, expire_on_commit=False)
-    async with sessions() as seed:
-        seed.add(
-            ApiKey(
-                hashed_key=_sha(API_KEY),
-                namespace=NAMESPACE,
-                scopes=["read", "write", "admin"],
-            )
-        )
-        await seed.commit()
 
     async def benchmark_db():
         async with sessions() as session:
             yield session
 
     app.dependency_overrides[get_db] = benchmark_db
-    headers = {"X-API-Key": API_KEY}
 
     try:
         async with AsyncClient(
             transport=ASGITransport(app=app),
             base_url="http://benchmark",
-            headers=headers,
         ) as client:
+            provisioned = await _checked(
+                await client.post(
+                    "/v1/admin/api-keys",
+                    json={
+                        "namespace": NAMESPACE,
+                        "scopes": ["read", "write", "admin"],
+                        "label": "riad-ephemeral-benchmark",
+                    },
+                    headers={"X-Admin-Secret": get_settings().admin_secret},
+                ),
+                expected=201,
+            )
+            headers = {"X-API-Key": provisioned["key"]}
+            client.headers.update(headers)
+
             evidence_payloads = [
                 {
                     "content": "Applicant verified annual income is USD 120000.",

--- a/agentmem/src/lians/config.py
+++ b/agentmem/src/lians/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
     kms_vault_mount_point: str = "secret"
 
     # API
-    # Server-side HMAC key for non-reversible API-key fingerprints.
+    # Server-side key for non-reversible API-key fingerprints.
     api_secret_seed: str = "dev-seed-change-in-prod"
     admin_secret: str = "dev-admin-secret-change-in-prod"
     # None follows the environment: enabled in development, disabled in production.

--- a/agentmem/src/lians/config.py
+++ b/agentmem/src/lians/config.py
@@ -62,6 +62,7 @@ class Settings(BaseSettings):
     kms_vault_mount_point: str = "secret"
 
     # API
+    # Server-side HMAC key for non-reversible API-key fingerprints.
     api_secret_seed: str = "dev-seed-change-in-prod"
     admin_secret: str = "dev-admin-secret-change-in-prod"
     # None follows the environment: enabled in development, disabled in production.

--- a/agentmem/src/lians/main.py
+++ b/agentmem/src/lians/main.py
@@ -375,7 +375,11 @@ app.add_middleware(
 # Wire the configured limit through: without this argument the middleware silently
 # pins every deployment to its hardcoded 300/min default and RATE_LIMIT_PER_MINUTE
 # (documented as tunable in .env.example) has no effect.
-app.add_middleware(RateLimitMiddleware, requests_per_minute=get_settings().rate_limit_per_minute)
+app.add_middleware(
+    RateLimitMiddleware,
+    requests_per_minute=get_settings().rate_limit_per_minute,
+    fingerprint_secret=get_settings().api_secret_seed,
+)
 app.add_middleware(AccessLogMiddleware)
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(

--- a/agentmem/src/lians/middleware.py
+++ b/agentmem/src/lians/middleware.py
@@ -11,7 +11,6 @@ every request uniformly, including 4xx/5xx responses from FastAPI's own validati
 from __future__ import annotations
 
 import hashlib
-import hmac
 import json
 import logging
 import time
@@ -20,6 +19,9 @@ from collections import OrderedDict
 from contextvars import ContextVar
 from datetime import datetime, timezone
 
+from cryptography.hazmat.primitives import cmac, hashes
+from cryptography.hazmat.primitives.ciphers import algorithms
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -214,7 +216,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     Redis is unavailable, a bounded per-process fallback keeps throttling
     active instead of silently disabling the control.
 
-    The raw API key is never written to Redis. A server-keyed HMAC produces
+    The raw API key is never written to Redis. A server-keyed AES-CMAC produces
     a stable, non-reversible bucket discriminator shared by all workers.
     """
 
@@ -230,18 +232,20 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             raise ValueError("fingerprint_secret must not be empty")
         self._limit = requests_per_minute
         self._window = 60  # seconds
-        self._fingerprint_secret = fingerprint_secret.encode()
+        self._fingerprint_key = HKDF(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=b"lians-rate-limit-v1",
+            info=b"api-key-bucket",
+        ).derive(fingerprint_secret.encode())
         self._fallback: OrderedDict[str, tuple[int, int]] = OrderedDict()
         self._fallback_max_buckets = 10_000
 
     def _api_key_discriminator(self, raw_key: str) -> str:
         """Return a stable keyed bucket ID without exposing the API key."""
-        digest = hmac.new(
-            self._fingerprint_secret,
-            b"lians-rate-limit-v1\0" + raw_key.encode(),
-            hashlib.sha256,
-        ).hexdigest()
-        return f"api:{digest[:32]}"
+        mac = cmac.CMAC(algorithms.AES(self._fingerprint_key))
+        mac.update(raw_key.encode())
+        return f"api:{mac.finalize().hex()}"
 
     def _fallback_increment(self, discriminator: str) -> int:
         """Return the local count using a bounded fixed-minute window."""

--- a/agentmem/src/lians/middleware.py
+++ b/agentmem/src/lians/middleware.py
@@ -11,6 +11,7 @@ every request uniformly, including 4xx/5xx responses from FastAPI's own validati
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
 import time
@@ -213,16 +214,34 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     Redis is unavailable, a bounded per-process fallback keeps throttling
     active instead of silently disabling the control.
 
-    The raw API key is never written to Redis; only the first 16 hex chars
-    of its SHA-256 hash are used as the key discriminator.
+    The raw API key is never written to Redis. A server-keyed HMAC produces
+    a stable, non-reversible bucket discriminator shared by all workers.
     """
 
-    def __init__(self, app, requests_per_minute: int = 300):
+    def __init__(
+        self,
+        app,
+        requests_per_minute: int = 300,
+        *,
+        fingerprint_secret: str,
+    ):
         super().__init__(app)
+        if not fingerprint_secret:
+            raise ValueError("fingerprint_secret must not be empty")
         self._limit = requests_per_minute
         self._window = 60  # seconds
+        self._fingerprint_secret = fingerprint_secret.encode()
         self._fallback: OrderedDict[str, tuple[int, int]] = OrderedDict()
         self._fallback_max_buckets = 10_000
+
+    def _api_key_discriminator(self, raw_key: str) -> str:
+        """Return a stable keyed bucket ID without exposing the API key."""
+        digest = hmac.new(
+            self._fingerprint_secret,
+            b"lians-rate-limit-v1\0" + raw_key.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"api:{digest[:32]}"
 
     def _fallback_increment(self, discriminator: str) -> int:
         """Return the local count using a bounded fixed-minute window."""
@@ -259,7 +278,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         raw_key = request.headers.get("X-API-Key", "")
         if raw_key:
-            discriminator = f"api:{hashlib.sha256(raw_key.encode()).hexdigest()[:16]}"
+            discriminator = self._api_key_discriminator(raw_key)
         elif request.url.path.startswith("/v1/admin/"):
             # Admin auth uses a separate header. Keying this bucket by the
             # supplied secret would let an attacker evade throttling by changing

--- a/agentmem/tests/test_middleware.py
+++ b/agentmem/tests/test_middleware.py
@@ -287,7 +287,11 @@ class TestRateLimitMiddleware:
         async def limited():
             return {"ok": True}
 
-        limited_app.add_middleware(RateLimitMiddleware, requests_per_minute=1)
+        limited_app.add_middleware(
+            RateLimitMiddleware,
+            requests_per_minute=1,
+            fingerprint_secret="test-rate-limit-fingerprint-secret",
+        )
         with patch("src.lians.cache._get_redis") as mock_redis:
             mock_redis.return_value.incr = AsyncMock(
                 side_effect=ConnectionError("Redis down")
@@ -307,6 +311,37 @@ class TestRateLimitMiddleware:
         assert first.headers["X-RateLimit-Remaining"] == "0"
         assert second.status_code == 429
         assert second.headers["Retry-After"] == "60"
+
+    def test_api_key_discriminator_is_keyed_and_stable(self):
+        """Bucket IDs must not expose a reusable digest of the API key."""
+        from src.lians.middleware import RateLimitMiddleware
+
+        middleware_a = RateLimitMiddleware(
+            app=AsyncMock(),
+            fingerprint_secret="fingerprint-secret-a",
+        )
+        middleware_b = RateLimitMiddleware(
+            app=AsyncMock(),
+            fingerprint_secret="fingerprint-secret-b",
+        )
+
+        first = middleware_a._api_key_discriminator("customer-api-key")
+        repeated = middleware_a._api_key_discriminator("customer-api-key")
+        other_key = middleware_a._api_key_discriminator("other-api-key")
+        other_secret = middleware_b._api_key_discriminator("customer-api-key")
+
+        assert first == repeated
+        assert first.startswith("api:")
+        assert len(first.removeprefix("api:")) == 32
+        assert "customer-api-key" not in first
+        assert first != other_key
+        assert first != other_secret
+
+    def test_api_key_discriminator_rejects_an_empty_secret(self):
+        from src.lians.middleware import RateLimitMiddleware
+
+        with pytest.raises(ValueError, match="fingerprint_secret must not be empty"):
+            RateLimitMiddleware(app=AsyncMock(), fingerprint_secret="")
 
     async def test_health_exempt_from_rate_limit(self, client):
         """Health checks must never be rate-limited regardless of Redis state."""
@@ -373,6 +408,7 @@ class TestRateLimitMiddleware:
             "RateLimitMiddleware is not wired to the configured limit — "
             "RATE_LIMIT_PER_MINUTE is being ignored"
         )
+        assert entry.kwargs.get("fingerprint_secret") == get_settings().api_secret_seed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Replace the reusable SHA-256 rate-limit bucket derived from raw API keys with a domain-separated, server-keyed AES-CMAC discriminator. Its AES key is derived from `API_SECRET_SEED` with HKDF-SHA-256.
- Expand the opaque discriminator from 64 to 128 bits while keeping Redis/fallback behavior stable across workers.
- Make the RIAD benchmark provision an ephemeral API key through the real admin API instead of embedding and directly hashing a fixed credential.
- Add focused discriminator stability, separation, secrecy, empty-key, and application-wiring tests.

## Why

CodeQL identified two places where values treated as credentials flowed into plain SHA-256. The rate limiter only needs a stable bucket identifier, so a keyed cryptographic MAC prevents offline correlation or guessing from Redis keys. The benchmark did not need to construct credential storage directly; using the public provisioning path is safer and more representative.

## Impact

There is no database migration and no change to stored API-key hashes, authentication, headers, or public API contracts. Deploying this commit changes only opaque rate-limit bucket names, so in-flight counters reset once for at most the existing 60-second window. `API_SECRET_SEED` must remain consistent across workers; production already provides it as a secret. The mandatory `cryptography` dependency already supplies AES-CMAC and HKDF, so this adds no package.

## Validation

- `python -m pytest -q agentmem/tests/test_middleware.py agentmem/tests/test_decision_reconstruction_eval.py agentmem/tests/test_admin.py` — 59 passed
- `python -m pytest -q agentmem/tests/test_middleware.py agentmem/tests/test_decision_reconstruction_eval.py` — 26 passed after the AES-CMAC revision
- `python -m ruff check agentmem/src/lians agentmem/benchmarks scripts --select E9,F63,F7,F82` — passed
- `python -m compileall -q agentmem/src/lians agentmem/benchmarks` — passed

This PR intentionally does not touch `agentmem/scripts/seed_demo.py`; that separate CodeQL finding is handled by PR #78.
