### PR TITLE
Reduce the production image with CPU-only PyTorch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,33 @@ ENV PATH="/opt/venv/bin:${PATH}"
 # Install a wheel-style package into an isolated virtual environment. Avoid an
 # editable install whose .pth file would point back into the builder filesystem.
 ARG EXTRAS=local
+# Keep this aligned with the public torch release selected by the local extra;
+# the official PyTorch index publishes its Linux CPU build with the +cpu tag.
+ARG TORCH_CPU_VERSION=2.13.0+cpu
+ARG PYTORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu
 COPY pyproject.toml ./
 COPY agentmem/src/ ./agentmem/src/
 RUN python -m pip install --no-cache-dir --upgrade pip==25.3 \
     && if [ -n "$EXTRAS" ]; then package_spec=".[$EXTRAS]"; else package_spec="."; fi \
-    && python -m pip install --no-cache-dir "$package_spec"
+    && case ",$EXTRAS," in \
+      *,local,*) \
+        python -m pip install --no-cache-dir \
+          --index-url "$PYTORCH_CPU_INDEX_URL" \
+          "torch==$TORCH_CPU_VERSION" \
+        && printf 'torch==%s\n' "$TORCH_CPU_VERSION" > /tmp/torch-cpu-constraints.txt \
+        && python -m pip install --no-cache-dir \
+          --constraint /tmp/torch-cpu-constraints.txt \
+          "$package_spec" \
+        ;; \
+      *) python -m pip install --no-cache-dir "$package_spec" ;; \
+    esac \
+    && python -m pip check \
+    && case ",$EXTRAS," in \
+      *,local,*) \
+        TORCH_CPU_VERSION="$TORCH_CPU_VERSION" python -c \
+          "import os; from importlib import metadata; import torch; names = {d.metadata['Name'].lower() for d in metadata.distributions()}; banned = sorted(n for n in names if n.startswith(('nvidia-', 'cuda-')) or n == 'triton'); expected = os.environ['TORCH_CPU_VERSION']; assert metadata.version('torch') == expected, (metadata.version('torch'), expected); assert torch.version.cuda is None, torch.version.cuda; assert not banned, banned" \
+        ;; \
+    esac
 
 # Pre-download the local embedding model for zero-network runtime startup.
 ARG PREDOWNLOAD_MODEL=BAAI/bge-large-en-v1.5
@@ -47,11 +69,11 @@ ENV PATH="/opt/venv/bin:${PATH}" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-COPY --from=builder /opt/venv /opt/venv
-COPY --from=builder /app/.model_cache /app/.model_cache
-COPY agentmem/ /app/agentmem/
-
-RUN chown -R lians:lians /app /opt/venv /home/lians
+# Set final ownership as each layer is materialized. A recursive chown here
+# duplicates metadata for the multi-gigabyte environment and model layers.
+COPY --from=builder --chown=10001:10001 /opt/venv /opt/venv
+COPY --from=builder --chown=10001:10001 /app/.model_cache /app/.model_cache
+COPY --chown=10001:10001 agentmem/ /app/agentmem/
 
 ARG LIANS_BUILD_SHA=unknown
 ENV LIANS_BUILD_SHA="${LIANS_BUILD_SHA}"

--- a/agentmem/tests/test_check_production_deployment_script.py
+++ b/agentmem/tests/test_check_production_deployment_script.py
@@ -47,12 +47,23 @@ def test_fly_deploy_preserves_exact_image_and_build_evidence_contract() -> None:
 
 def test_build_sha_does_not_invalidate_heavy_runtime_layers() -> None:
     dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
-    assert dockerfile.index("RUN chown -R lians:lians") < dockerfile.index(
-        "ARG LIANS_BUILD_SHA=unknown"
-    )
-    assert dockerfile.index("ARG LIANS_BUILD_SHA=unknown") < dockerfile.index(
-        'ENV LIANS_BUILD_SHA="${LIANS_BUILD_SHA}"'
-    )
+    build_arg_index = dockerfile.index("ARG LIANS_BUILD_SHA=unknown")
+    build_env_index = dockerfile.index('ENV LIANS_BUILD_SHA="${LIANS_BUILD_SHA}"')
+
+    # Keep the commit-specific build argument after every materialized runtime
+    # artifact so a new SHA does not invalidate the venv, offline model, or app
+    # ownership layers.
+    for runtime_copy in (
+        "COPY --from=builder --chown=10001:10001 /opt/venv /opt/venv",
+        (
+            "COPY --from=builder --chown=10001:10001 "
+            "/app/.model_cache /app/.model_cache"
+        ),
+        "COPY --chown=10001:10001 agentmem/ /app/agentmem/",
+    ):
+        assert dockerfile.index(runtime_copy) < build_arg_index
+
+    assert build_arg_index < build_env_index
 
 
 def test_validate_health_requires_sanitized_success() -> None:

--- a/agentmem/tests/test_production_image_contract.py
+++ b/agentmem/tests/test_production_image_contract.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+DEPLOY_WORKFLOW = (ROOT / ".github" / "workflows" / "fly-deploy.yml").read_text(
+    encoding="utf-8"
+)
+MACHINE_SELECTOR = (ROOT / "scripts" / "select_fly_production_machine.py").read_text(
+    encoding="utf-8"
+)
+
+
+def test_local_embedding_image_is_cpu_only_by_contract() -> None:
+    """The CPU-only Fly runtime must not silently resolve CUDA PyPI wheels."""
+
+    assert "ARG TORCH_CPU_VERSION=2.13.0+cpu" in DOCKERFILE
+    assert (
+        "ARG PYTORCH_CPU_INDEX_URL=https://download.pytorch.org/whl/cpu"
+        in DOCKERFILE
+    )
+    assert '"torch==$TORCH_CPU_VERSION"' in DOCKERFILE
+    assert "--constraint /tmp/torch-cpu-constraints.txt" in DOCKERFILE
+    assert "python -m pip check" in DOCKERFILE
+
+    # The build fails closed if the resolved environment is not the pinned CPU
+    # wheel or if CUDA runtime distributions enter through a transitive update.
+    assert "metadata.version('torch') == expected" in DOCKERFILE
+    assert "torch.version.cuda is None" in DOCKERFILE
+    assert "n.startswith(('nvidia-', 'cuda-'))" in DOCKERFILE
+    assert "n == 'triton'" in DOCKERFILE
+
+
+def test_runtime_artifacts_are_owned_during_copy() -> None:
+    """Large layers get their final UID/GID without a recursive copy-up layer."""
+
+    expected_copies = {
+        "COPY --from=builder --chown=10001:10001 /opt/venv /opt/venv",
+        (
+            "COPY --from=builder --chown=10001:10001 "
+            "/app/.model_cache /app/.model_cache"
+        ),
+        "COPY --chown=10001:10001 agentmem/ /app/agentmem/",
+    }
+    lines = {line.strip() for line in DOCKERFILE.splitlines()}
+
+    assert expected_copies <= lines
+    assert "chown -R" not in DOCKERFILE
+    assert "USER 10001:10001" in DOCKERFILE
+    assert "WORKDIR /app/agentmem" in DOCKERFILE
+
+
+def test_offline_model_and_deployment_identity_contracts_are_preserved() -> None:
+    assert "ARG EXTRAS=local" in DOCKERFILE
+    assert "ARG PREDOWNLOAD_MODEL=BAAI/bge-large-en-v1.5" in DOCKERFILE
+    assert "SENTENCE_TRANSFORMERS_HOME=/app/.model_cache" in DOCKERFILE
+    assert "TRANSFORMERS_OFFLINE=1" in DOCKERFILE
+    assert "HF_DATASETS_OFFLINE=1" in DOCKERFILE
+    assert "SentenceTransformer('$PREDOWNLOAD_MODEL')" in DOCKERFILE
+
+    # The runtime build identity must remain late enough that changing a commit
+    # SHA does not invalidate the expensive venv and offline-model layers.
+    copy_index = DOCKERFILE.index(
+        "COPY --from=builder --chown=10001:10001 /app/.model_cache"
+    )
+    build_arg_index = DOCKERFILE.index("ARG LIANS_BUILD_SHA=unknown")
+    build_env_index = DOCKERFILE.index('ENV LIANS_BUILD_SHA="${LIANS_BUILD_SHA}"')
+    workdir_index = DOCKERFILE.index("WORKDIR /app/agentmem")
+    user_index = DOCKERFILE.index("USER 10001:10001")
+    assert copy_index < build_arg_index < build_env_index < workdir_index < user_index
+
+    # Production post-deploy verification must keep targeting the isolated
+    # venv and exact GitHub commit embedded in both the image environment and
+    # Fly image metadata.
+    assert "/opt/venv/bin/alembic" in DEPLOY_WORKFLOW
+    assert '--build-arg "LIANS_BUILD_SHA=$GITHUB_SHA"' in DEPLOY_WORKFLOW
+    assert '--expected-sha "$GITHUB_SHA"' in DEPLOY_WORKFLOW
+    assert '--expected-build-sha "$GITHUB_SHA"' in DEPLOY_WORKFLOW
+    assert 'labels.get("GH_SHA") != expected_sha' in MACHINE_SELECTOR


### PR DESCRIPTION
﻿## Summary

- resolve the Docker `local` extra against the official PyTorch CPU index with an exact `torch==2.13.0+cpu` constraint
- fail the build if Torch reports CUDA support or if NVIDIA, CUDA, or Triton distributions enter transitively
- set UID/GID 10001 ownership during `COPY` and remove the recursive runtime `chown`
- add static contracts for the CPU dependency, ownership, offline model, non-root runtime, Alembic path, and exact `GH_SHA` deployment selection

The public Python dependency contract is unchanged; this only narrows the production Docker resolution used on the CPU-only Fly machine.

## Resolution evidence

At base `ee64c34ff7e53e030947ac08d68c8474ac2d0577`, the unconstrained Docker build resolved `sentence-transformers 5.6.1` and PyPI `torch 2.13.0`. The [official sentence-transformers metadata](https://pypi.org/pypi/sentence-transformers/5.6.1/json) requires `torch>=1.11.0`. The [official PyTorch CPU index](https://download.pytorch.org/whl/cpu/torch/) publishes the matching CPython 3.12 Linux `torch 2.13.0+cpu` wheel. The CPU image passed `pip check`, loaded the baked BAAI model offline, and completed an inference smoke.

## Measured locally

Same Docker Desktop engine, full no-cache dependency stages:

| Metric | Baseline | Candidate | Change |
|---|---:|---:|---:|
| pip artifacts downloaded | 2,866.1 MB | 335.7 MB | -2,530.4 MB (-88.3%) |
| dependency stage | 351.0 s | 154.6 s | -196.4 s (-56.0%) |
| runtime venv copy | 88.2 s | 66.1 s | -22.1 s |
| recursive ownership pass | present | removed | no copy-up layer |

The current production registry manifest has 6,963,838,408 compressed layer bytes. The locally built candidate reports 1,259,763,588 content bytes and approximately 3.1 GB of unpacked runtime layers (`/opt/venv` 1.5 GiB, model cache 1.3 GiB). The implied 81.9% transfer-size reduction is indicative, not a Fly measurement: this draft deliberately does not push or deploy the candidate image.

The baseline full build was cancelled after its recursive ownership pass remained active for more than 13 minutes on the local containerd snapshotter, so this PR does not claim a comparable end-to-end baseline build time. The candidate full no-cache build completed in 9m30s, including a 138.8s unauthenticated model download and 149.0s local export/unpack.

## Validation

- `docker build --no-cache --tag lians-production:cpu .`
- network-disabled BAAI load and inference: Torch `2.13.0+cpu`, CUDA `None`, device `cpu`, dimension `1024`, banned packages `[]`
- runtime UID/GID `10001:10001`; `/opt/venv/bin/alembic --version` and application import pass
- `docker build --build-arg EXTRAS= --build-arg PREDOWNLOAD_MODEL= --tag lians-production:lean-test .`
- lean image application import and `pip check`
- `python -m pytest agentmem/tests/test_production_image_contract.py agentmem/tests/test_packaging.py agentmem/tests/test_airgap.py -q` (19 passed)
- Ruff, compileall, Docker BuildKit check, release contract, and OpenAPI contract (71 paths / 84 operations)

## Preserved contracts

- baked `BAAI/bge-large-en-v1.5` cache and offline runtime settings
- non-root UID/GID 10001
- `/opt/venv/bin/alembic` post-deploy schema check
- exact `GH_SHA` Fly image/machine selection
- existing image command, workdir, port, release workflows, and public package extras

Draft only: no merge, deployment, package publication, or production change is included.



## Rebase verification

Rebased onto exact master `2678f148a5ee6c1e934fc014fd701ea7ca09fadb` (PR #71); exact candidate head is `5ec08541083a5bfbc95727eb69ef2fb304b8d18b`.

- preserves the late runtime `ARG LIANS_BUILD_SHA=unknown` / `ENV LIANS_BUILD_SHA="${LIANS_BUILD_SHA}"` after the expensive owned COPY layers
- preserves Fly's `--build-arg "LIANS_BUILD_SHA=$GITHUB_SHA"`, machine-label `--expected-sha "$GITHUB_SHA"`, and public `--expected-build-sha "$GITHUB_SHA"` verification
- release contract remains synchronized at `0.5.0`; OpenAPI remains 71 paths / 84 operations
- exact-head full image: 1,259,761,521 local content bytes, network-disabled BAAI inference shape `(1, 1024)`, Torch `2.13.0+cpu`, CUDA `None`, banned accelerator distributions `[]`
- exact-head lean image: 137,166,408 local content bytes, `lians` import passes, Torch and sentence-transformers absent

Both variants embed the exact candidate SHA, run as UID/GID 10001, preserve `/opt/venv/bin/alembic`, and pass `pip check`. GitHub exact-head checks are reported separately below by the PR check rollup.

