### PR TITLE
Prevent single-Machine deploy downtime

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -87,7 +87,7 @@ jobs:
     name: Snapshot and deploy production
     needs: staging-gate
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment:
       name: production
       url: https://agentmem-lotus.fly.dev
@@ -258,20 +258,23 @@ jobs:
 
           python scripts/migrate_via_fly_proxy.py --host 127.0.0.1 --port 15433
 
-      - name: Deploy with canary health checks
+      - name: Deploy with blue-green health-gated cutover
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}
         run: |
           set -euo pipefail
           image_label="deployment-github-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           deployed_image="registry.fly.io/agentmem-lotus:${image_label}"
+          # Canary destroys its temporary check Machine before replacing the
+          # only serving Machine. Blue-green keeps the old Machine routed until
+          # its replacement passes the configured /readyz health check.
           flyctl deploy \
             --app agentmem-lotus \
             --config fly.toml \
             --image-label "$image_label" \
             --build-arg "LIANS_BUILD_SHA=$GITHUB_SHA" \
             --remote-only \
-            --strategy canary \
+            --strategy bluegreen \
             --wait-timeout 10m
           echo "DEPLOYED_IMAGE=$deployed_image" >> "$GITHUB_ENV"
 
@@ -352,19 +355,8 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_MACHINE_EXEC_TOKEN }}
         run: |
-          set -euo pipefail
-          output="$(
-            flyctl machine exec \
-              "$PRODUCTION_MACHINE_ID" \
-              "/bin/sh -c 'cd /app/agentmem && /opt/venv/bin/alembic -c alembic.ini current'" \
-              --app agentmem-lotus \
-              --timeout 60 \
-              2>&1
-          )"
-          printf '%s\n' "$output"
-          revision="$(grep -oE '^0028_decision_envelopes' <<<"$output" | head -n 1)"
-          test "$revision" = "0028_decision_envelopes"
-          echo "Production schema revision: $revision"
+          python scripts/verify_production_schema.py \
+            --machine-id "$PRODUCTION_MACHINE_ID"
 
       - name: Run public production smoke checks
         run: |

--- a/agentmem/tests/test_fly_deploy_workflow_contract.py
+++ b/agentmem/tests/test_fly_deploy_workflow_contract.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "fly-deploy.yml"
+FLY_CONFIG_PATH = REPOSITORY_ROOT / "fly.toml"
+
+
+def test_production_deploy_uses_bluegreen_cutover() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "- name: Deploy with blue-green health-gated cutover" in workflow
+    assert "--strategy bluegreen \\" in workflow
+    assert "--strategy canary" not in workflow
+    assert "--strategy rolling" not in workflow
+    assert "--strategy immediate" not in workflow
+
+
+def test_bluegreen_prerequisites_remain_configured() -> None:
+    with FLY_CONFIG_PATH.open("rb") as handle:
+        config = tomllib.load(handle)
+
+    service = config["http_service"]
+    assert service["min_machines_running"] >= 1
+    assert any(
+        check.get("method") == "GET" and check.get("path") == "/readyz"
+        for check in service["checks"]
+    )
+    assert "mounts" not in config
+
+
+def test_post_deploy_release_identity_and_smoke_gates_remain() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert 'image_label="deployment-github-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in workflow
+    assert '--image-label "$image_label"' in workflow
+    assert '--build-arg "LIANS_BUILD_SHA=$GITHUB_SHA"' in workflow
+    assert '--expected-image "$DEPLOYED_IMAGE"' in workflow
+    assert '--expected-sha "$GITHUB_SHA"' in workflow
+    assert "Verify schema revision inside the production app" in workflow
+    assert "python scripts/verify_production_schema.py" in workflow
+    assert '--machine-id "$PRODUCTION_MACHINE_ID"' in workflow
+    assert "scripts/check_production_deployment.py" in workflow
+    assert '--expected-build-sha "$GITHUB_SHA"' in workflow

--- a/agentmem/tests/test_production_image_contract.py
+++ b/agentmem/tests/test_production_image_contract.py
@@ -8,6 +8,9 @@ DEPLOY_WORKFLOW = (ROOT / ".github" / "workflows" / "fly-deploy.yml").read_text(
 MACHINE_SELECTOR = (ROOT / "scripts" / "select_fly_production_machine.py").read_text(
     encoding="utf-8"
 )
+SCHEMA_VERIFIER = (ROOT / "scripts" / "verify_production_schema.py").read_text(
+    encoding="utf-8"
+)
 
 
 def test_local_embedding_image_is_cpu_only_by_contract() -> None:
@@ -71,7 +74,8 @@ def test_offline_model_and_deployment_identity_contracts_are_preserved() -> None
     # Production post-deploy verification must keep targeting the isolated
     # venv and exact GitHub commit embedded in both the image environment and
     # Fly image metadata.
-    assert "/opt/venv/bin/alembic" in DEPLOY_WORKFLOW
+    assert "scripts/verify_production_schema.py" in DEPLOY_WORKFLOW
+    assert "/opt/venv/bin/alembic" in SCHEMA_VERIFIER
     assert '--build-arg "LIANS_BUILD_SHA=$GITHUB_SHA"' in DEPLOY_WORKFLOW
     assert '--expected-sha "$GITHUB_SHA"' in DEPLOY_WORKFLOW
     assert '--expected-build-sha "$GITHUB_SHA"' in DEPLOY_WORKFLOW

--- a/agentmem/tests/test_verify_production_schema_script.py
+++ b/agentmem/tests/test_verify_production_schema_script.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "verify_production_schema.py"
+SPEC = importlib.util.spec_from_file_location("verify_production_schema", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+MACHINE_ID = "78451d0fe5d158"
+
+
+def result(returncode: int, *, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+def test_retries_restricted_exec_and_preserves_exact_command(capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    responses = iter(
+        [
+            result(1, stderr="temporary Fly SSH error\n"),
+            result(0, stdout="0028_decision_envelopes (head)\n"),
+        ]
+    )
+    delays: list[float] = []
+
+    def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((command, kwargs))
+        return next(responses)
+
+    assert MODULE.verify_schema(MACHINE_ID, runner=runner, sleeper=delays.append) == MODULE.EXPECTED_REVISION
+
+    assert len(calls) == 2
+    assert calls[0][0] == calls[1][0]
+    assert calls[0][0] == [
+        "flyctl",
+        "machine",
+        "exec",
+        MACHINE_ID,
+        MODULE.SCHEMA_COMMAND,
+        "--app",
+        MODULE.APP_NAME,
+        "--timeout",
+        "120",
+    ]
+    assert calls[0][1] == {
+        "capture_output": True,
+        "check": False,
+        "text": True,
+        "timeout": 135,
+    }
+    assert delays == [5]
+
+    captured = capsys.readouterr()
+    assert "attempt 1/3; status=1" in captured.out
+    assert "temporary Fly SSH error" in captured.out
+    assert "attempt 2/3; status=0" in captured.out
+    assert "Production schema revision: 0028_decision_envelopes" in captured.out
+
+
+def test_reports_every_failed_attempt_before_exiting(capsys: pytest.CaptureFixture[str]) -> None:
+    attempts = 0
+
+    def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal attempts
+        attempts += 1
+        return result(1, stdout=f"attempt-{attempts}-stdout\n", stderr=f"attempt-{attempts}-stderr\n")
+
+    with pytest.raises(MODULE.SchemaVerificationError, match="after 3 attempts"):
+        MODULE.verify_schema(MACHINE_ID, runner=runner, sleeper=lambda _: None)
+
+    captured = capsys.readouterr()
+    for attempt in range(1, 4):
+        assert f"attempt {attempt}/3; status=1" in captured.out
+        assert f"attempt-{attempt}-stdout" in captured.out
+        assert f"attempt-{attempt}-stderr" in captured.out
+
+
+def test_reports_local_timeout_capture_and_retries(capsys: pytest.CaptureFixture[str]) -> None:
+    attempts = 0
+
+    def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise subprocess.TimeoutExpired(
+                command,
+                timeout=135,
+                output=b"partial stdout\n",
+                stderr=b"partial stderr\n",
+            )
+        return result(0, stdout="0028_decision_envelopes (head)\n")
+
+    assert MODULE.verify_schema(MACHINE_ID, runner=runner, sleeper=lambda _: None) == MODULE.EXPECTED_REVISION
+
+    captured = capsys.readouterr()
+    assert "attempt 1/3; status=local-timeout" in captured.out
+    assert "partial stdout" in captured.out
+    assert "partial stderr" in captured.out
+
+
+def test_success_without_expected_revision_fails_closed() -> None:
+    def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return result(0, stdout="0027_previous_revision\n")
+
+    with pytest.raises(MODULE.SchemaVerificationError, match="expected schema head"):
+        MODULE.verify_schema(MACHINE_ID, runner=runner, sleeper=lambda _: None)
+
+
+@pytest.mark.parametrize("machine_id", ["", "master", "A" * 14, "a" * 13, "a" * 15])
+def test_rejects_untrusted_machine_ids(machine_id: str) -> None:
+    with pytest.raises(ValueError, match="Machine ID"):
+        MODULE.verify_schema(machine_id)

--- a/scripts/verify_production_schema.py
+++ b/scripts/verify_production_schema.py
@@ -1,0 +1,128 @@
+"""Verify the production schema through a restricted Fly Machine exec token."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+
+APP_NAME = "agentmem-lotus"
+EXPECTED_REVISION = "0028_decision_envelopes"
+MACHINE_ID_PATTERN = re.compile(r"^[0-9a-f]{14}$")
+REVISION_PATTERN = re.compile(rf"(?m)^{EXPECTED_REVISION}(?: \(head\))?$")
+ATTEMPTS = 3
+EXEC_TIMEOUT_SECONDS = 120
+RETRY_DELAY_SECONDS = 5
+
+# FLY_MACHINE_EXEC_TOKEN is caveated to this exact remote command. Changing
+# its spelling, quoting, paths, or arguments requires updating the token policy
+# and the protected GitHub environment secret before the next deployment.
+SCHEMA_COMMAND = (
+    "/bin/sh -c 'cd /app/agentmem && "
+    "/opt/venv/bin/alembic -c alembic.ini current'"
+)
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+Sleeper = Callable[[float], None]
+
+
+class SchemaVerificationError(RuntimeError):
+    """Raised when restricted schema verification cannot prove the expected head."""
+
+
+def _as_text(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""
+
+
+def _write_capture(label: str, value: str) -> None:
+    print(f"--- {label} ---")
+    if value:
+        print(value, end="" if value.endswith("\n") else "\n")
+    else:
+        print("<empty>")
+
+
+def verify_schema(
+    machine_id: str,
+    *,
+    runner: Runner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+) -> str:
+    """Return the expected revision after a bounded, fully logged retry loop."""
+    if not MACHINE_ID_PATTERN.fullmatch(machine_id):
+        raise ValueError("production Machine ID must be 14 lowercase hexadecimal characters")
+
+    command = [
+        "flyctl",
+        "machine",
+        "exec",
+        machine_id,
+        SCHEMA_COMMAND,
+        "--app",
+        APP_NAME,
+        "--timeout",
+        str(EXEC_TIMEOUT_SECONDS),
+    ]
+
+    for attempt in range(1, ATTEMPTS + 1):
+        try:
+            completed = runner(
+                command,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=EXEC_TIMEOUT_SECONDS + 15,
+            )
+            status = completed.returncode
+            stdout = completed.stdout or ""
+            stderr = completed.stderr or ""
+        except subprocess.TimeoutExpired as exc:
+            status = "local-timeout"
+            stdout = _as_text(exc.stdout)
+            stderr = _as_text(exc.stderr)
+
+        print(f"Schema verification attempt {attempt}/{ATTEMPTS}; status={status}")
+        _write_capture("stdout", stdout)
+        _write_capture("stderr", stderr)
+
+        if status == 0:
+            output = f"{stdout}\n{stderr}"
+            if REVISION_PATTERN.search(output):
+                print(f"Production schema revision: {EXPECTED_REVISION}")
+                return EXPECTED_REVISION
+            raise SchemaVerificationError(
+                "restricted Machine exec succeeded but did not report the expected schema head"
+            )
+
+        if attempt < ATTEMPTS:
+            print(f"Retrying restricted Machine exec in {RETRY_DELAY_SECONDS} seconds.")
+            sleeper(RETRY_DELAY_SECONDS)
+
+    raise SchemaVerificationError(
+        f"restricted Machine exec failed after {ATTEMPTS} attempts"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--machine-id", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        verify_schema(args.machine_id)
+    except (SchemaVerificationError, ValueError) as exc:
+        print(f"Production schema verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Root cause

[Production run 30727434227](https://github.com/Lians-ai/Lians/actions/runs/30727434227) used Fly's `canary` strategy with one configured serving Machine. Fly created and health-checked temporary Machine `e826330b3272d8`, destroyed it, and then updated the sole serving Machine `78451d0fe5d158`. Public readiness was unavailable while that original Machine pulled and started the new image.

That matches Fly's documented behavior: canary validates a temporary Machine, destroys it, then continues as a rolling update. Blue-green instead boots a replacement beside every serving Machine and migrates traffic only after all replacements pass health checks.

- [Fly deploy strategy reference](https://fly.io/docs/reference/configuration/#picking-a-deployment-strategy)
- [Fly deploy canary lifecycle example](https://fly.io/docs/launch/deploy/#deployment-strategy)
- [Fly seamless deployment guidance](https://fly.io/docs/blueprints/seamless-deployments/)

## What changed

- Switch the protected production workflow from `canary` to `bluegreen`, keeping the old Machine routed until the new Machine passes the configured `/readyz` check.
- Preserve the unique run/attempt image label, exact release image and `GH_SHA` Machine selection, in-Machine Alembic revision gate, public boundary smoke checks, snapshot, migration, and rollback evidence.
- Replace the silent `set -e` command-substitution schema check with a tested helper that:
  - uses the exact remote command allowed by `FLY_MACHINE_EXEC_TOKEN`;
  - gives Fly exec 120 seconds and retries up to three times;
  - prints every attempt's status, stdout, and stderr;
  - fails closed unless `0028_decision_envelopes (head)` is proven.
- Increase the protected job budget from 30 to 45 minutes so bounded exec retries cannot race the job deadline after a slow image build.
- Add workflow contracts that reject canary, rolling, and immediate production semantics, require `/readyz` and no app volume mount, and preserve the release identity and public smoke gates.

## Operational prerequisites and cost

The current app topology satisfies blue-green's prerequisites: one `shared-cpu-2x` / 2 GB Machine in `sjc`, a service-level `/readyz` health check, and no attached app volume. The Fly organization must have capacity to start one additional same-size Machine in `sjc` during cutover.

Each deploy temporarily doubles app compute from one to two Machines; the replacement is billed only for the overlap and the old Machine is destroyed after cutover. There is no permanent second-Machine cost. Fly bills provisioned compute pro-rata; see [current Fly pricing](https://fly.io/docs/about/pricing/#compute).

## Validation

- 46 focused rollout, schema-helper, Machine-selection, public-smoke, release-evidence, and production-image tests passed.
- Ruff passed for the new files and the workflow's CI syntax/undefined-name scope.
- Runtime and scripts compiled successfully.
- Release contract: `0.5.0` synchronized.
- OpenAPI contract: 71 paths / 84 operations.
- Workflow YAML parsed and `flyctl config validate` passed with flyctl v0.4.76.

## Limitations

- Blue-green overlap requires old and new application versions to be compatible with the migrated schema. Future destructive migrations still require expand/contract sequencing.
- Adding an app volume makes Fly blue-green unsupported; the new contract intentionally fails if a mount appears.
- This removes deploy-induced single-Machine downtime, but it does not provide redundancy for a host failure outside deployment. Steady-state capacity remains one Machine.
- The CPU-only image can still take time to pull and requires temporary regional capacity; this change keeps traffic on the old Machine during that wait rather than changing image-build behavior.
- No production deploy is performed by this PR. The first protected rollout after merge remains the end-to-end availability proof.

## Integration baseline

Rebased onto exact master `4ab00357ee851baa2424c61acff4019da85756c1` after PR #71 and PR #80 landed. The resulting workflow retains `LIANS_BUILD_SHA`, public `/version` build-SHA verification, CPU-only PyTorch, and COPY `--chown` layer contracts alongside the blue-green rollout and retried schema gate.