### PR TITLE
Avoid SQLite post-commit refresh race

### DIFF
--- a/agentmem/src/lians/memory_service.py
+++ b/agentmem/src/lians/memory_service.py
@@ -812,9 +812,12 @@ async def add_memory(
                     identifier=f"w:{mem.id}",
                 )
 
+            # Materialize the response while the instance is live. Supported
+            # session factories use expire_on_commit=False, but avoiding a
+            # post-commit SELECT also prevents SQLite local-mode writers from
+            # racing another transaction for an unnecessary refresh lock.
+            memory_out = _memory_to_out(mem, req.content)
             await db.commit()
-
-        await db.refresh(mem)
 
         # Change 7: invalidate in-process session cache on write
         invalidate_working_set(namespace, req.agent_id)
@@ -827,7 +830,7 @@ async def add_memory(
         record_write(namespace, supersession.relation)
         observe_add(namespace, _time.perf_counter() - _add_t0)
 
-        return _memory_to_out(mem, req.content)
+        return memory_out
 
 
 async def add_memory_idempotent(

--- a/agentmem/tests/test_concurrency.py
+++ b/agentmem/tests/test_concurrency.py
@@ -303,7 +303,8 @@ class TestConcurrentAsyncioWrites:
                     metadata=meta,
                 ))
 
-        await asyncio.gather(*[_add(i) for i in range(5)])
+        results = await asyncio.gather(*[_add(i) for i in range(5)])
+        assert len({result.id for result in results}) == 5
 
         async with session_factory() as db:
             open_mems = (await db.execute(


### PR DESCRIPTION
## Root cause

Concurrent local-mode SQLite writers committed correctly, but `add_memory` immediately issued an unnecessary post-commit `refresh`. That read could race the next writer and fail with `database table is locked: memories`. Production and supported test session factories already use `expire_on_commit=False`.

## Fix

Materialize `MemoryOut` before commit, return it after commit, and remove the post-commit SELECT. Also assert all five concurrent writes return distinct memory IDs.

## Validation

- full concurrency module: 11/11 passed
- five-writer regression: 25/25 isolated stress iterations passed
- full exact-head GitHub matrix: 21/21 passed
- `git diff --check` passed

This is isolated from PR #71; after merge, #71 will be rebased and rerun on the exact new master.