### PR TITLE
Harden production schema verification token

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -353,10 +353,58 @@ jobs:
 
       - name: Verify schema revision inside the production app
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_MACHINE_EXEC_TOKEN }}
+          # Attenuate this existing app-scoped token locally. The verifier only
+          # receives the 10-minute, exact-command derivative below.
+          FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}
         run: |
-          python scripts/verify_production_schema.py \
+          set -euo pipefail
+          base_token="$FLY_API_TOKEN"
+          unset FLY_API_TOKEN FLY_ACCESS_TOKEN
+          schema_shell_command="cd /app/agentmem && /opt/venv/bin/alembic -c alembic.ini current"
+          now="$(date -u +%s)"
+          caveats="$(
+            jq -cn \
+              --arg shell "$schema_shell_command" \
+              --argjson nb "$((now - 30))" \
+              --argjson na "$((now + 600))" '
+                [
+                  {
+                    type: "IfPresent",
+                    body: {
+                      ifs: [
+                        {
+                          type: "Commands",
+                          body: [
+                            {
+                              args: ["/bin/sh", "-c", $shell],
+                              exact: true
+                            }
+                          ]
+                        }
+                      ],
+                      else: "r"
+                    }
+                  },
+                  {
+                    type: "ValidityWindow",
+                    body: {not_before: $nb, not_after: $na}
+                  }
+                ]
+              '
+          )"
+          schema_token="$(
+            FLY_API_TOKEN="$base_token" flyctl tokens attenuate <<<"$caveats"
+          )"
+          test -n "$schema_token"
+          test "$schema_token" != "$base_token"
+          [[ "$schema_token" != *$'\n'* && "$schema_token" != *$'\r'* ]]
+          echo "::add-mask::$schema_token"
+          base_token=""
+          caveats=""
+
+          FLY_API_TOKEN="$schema_token" python scripts/verify_production_schema.py \
             --machine-id "$PRODUCTION_MACHINE_ID"
+          schema_token=""
 
       - name: Run public production smoke checks
         run: |

--- a/agentmem/tests/test_fly_deploy_workflow_contract.py
+++ b/agentmem/tests/test_fly_deploy_workflow_contract.py
@@ -42,5 +42,31 @@ def test_post_deploy_release_identity_and_smoke_gates_remain() -> None:
     assert "Verify schema revision inside the production app" in workflow
     assert "python scripts/verify_production_schema.py" in workflow
     assert '--machine-id "$PRODUCTION_MACHINE_ID"' in workflow
+    schema_step = workflow.split(
+        "- name: Verify schema revision inside the production app", maxsplit=1
+    )[1].split("\n      - name:", maxsplit=1)[0]
+    assert "FLY_API_TOKEN: ${{ secrets.FLY_APP_TOKEN }}" in schema_step
+    assert "FLY_MACHINE_EXEC_TOKEN" not in schema_step
+    assert "flyctl tokens attenuate" in schema_step
+    assert "tokens create" not in schema_step
+    assert "tokens revoke" not in schema_step
+    assert 'schema_shell_command="cd /app/agentmem && /opt/venv/bin/alembic -c alembic.ini current"' in schema_step
+    assert 'args: ["/bin/sh", "-c", $shell]' in schema_step
+    assert "exact: true" in schema_step
+    assert 'else: "r"' in schema_step
+    assert 'body: {not_before: $nb, not_after: $na}' in schema_step
+    assert '"$((now - 30))"' in schema_step
+    assert '"$((now + 600))"' in schema_step
+    assert 'echo "::add-mask::$schema_token"' in schema_step
+    assert 'test "$schema_token" != "$base_token"' in schema_step
+    assert 'FLY_API_TOKEN="$schema_token" python scripts/verify_production_schema.py' in schema_step
+    assert "unset FLY_API_TOKEN FLY_ACCESS_TOKEN" in schema_step
+    assert schema_step.index("unset FLY_API_TOKEN FLY_ACCESS_TOKEN") < schema_step.index(
+        'FLY_API_TOKEN="$schema_token" python'
+    )
+    assert schema_step.index('base_token=""') < schema_step.index(
+        'FLY_API_TOKEN="$schema_token" python'
+    )
+    assert "FLY_MACHINE_EXEC_TOKEN" not in workflow
     assert "scripts/check_production_deployment.py" in workflow
     assert '--expected-build-sha "$GITHUB_SHA"' in workflow

--- a/agentmem/tests/test_verify_production_schema_script.py
+++ b/agentmem/tests/test_verify_production_schema_script.py
@@ -22,7 +22,7 @@ def result(returncode: int, *, stdout: str = "", stderr: str = "") -> subprocess
     return subprocess.CompletedProcess([], returncode, stdout, stderr)
 
 
-def test_retries_restricted_exec_and_preserves_exact_command(capsys: pytest.CaptureFixture[str]) -> None:
+def test_retries_machine_exec_and_preserves_exact_command(capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[tuple[list[str], dict[str, object]]] = []
     responses = iter(
         [

--- a/scripts/verify_production_schema.py
+++ b/scripts/verify_production_schema.py
@@ -1,4 +1,4 @@
-"""Verify the production schema through a restricted Fly Machine exec token."""
+"""Verify the production schema through Fly Machine exec."""
 
 from __future__ import annotations
 
@@ -17,9 +17,9 @@ ATTEMPTS = 3
 EXEC_TIMEOUT_SECONDS = 120
 RETRY_DELAY_SECONDS = 5
 
-# FLY_MACHINE_EXEC_TOKEN is caveated to this exact remote command. Changing
-# its spelling, quoting, paths, or arguments requires updating the token policy
-# and the protected GitHub environment secret before the next deployment.
+# The protected workflow locally attenuates its app-scoped deploy token to this
+# exact command and a 10-minute validity window before invoking this script.
+# Keep the remote command fixed and reviewable.
 SCHEMA_COMMAND = (
     "/bin/sh -c 'cd /app/agentmem && "
     "/opt/venv/bin/alembic -c alembic.ini current'"
@@ -30,7 +30,7 @@ Sleeper = Callable[[float], None]
 
 
 class SchemaVerificationError(RuntimeError):
-    """Raised when restricted schema verification cannot prove the expected head."""
+    """Raised when production schema verification cannot prove the expected head."""
 
 
 def _as_text(value: str | bytes | None) -> str:
@@ -96,7 +96,7 @@ def verify_schema(
                 print(f"Production schema revision: {EXPECTED_REVISION}")
                 return EXPECTED_REVISION
             raise SchemaVerificationError(
-                "restricted Machine exec succeeded but did not report the expected schema head"
+                "Machine exec succeeded but did not report the expected schema head"
             )
 
         if attempt < ATTEMPTS:
@@ -104,7 +104,7 @@ def verify_schema(
             sleeper(RETRY_DELAY_SECONDS)
 
     raise SchemaVerificationError(
-        f"restricted Machine exec failed after {ATTEMPTS} attempts"
+        f"Machine exec failed after {ATTEMPTS} attempts"
     )
 
 


### PR DESCRIPTION
## Summary\n- derive a 10-minute exact-command Fly token locally from the protected app token\n- prevent broad Fly credentials from reaching the schema verifier\n- preserve fail-closed schema verification and contract-test the caveats\n\n## Validation\n- 48 targeted deployment/release tests passed\n- Ruff clean\n- workflow YAML parsed\n- diff check clean\n- exact attenuation was live-proved against the production machine; unrelated commands were denied