### PR TITLE
Make v0.5.0 release recovery policy-safe

### DIFF
--- a/.github/workflows/publish-lian-npm.yml
+++ b/.github/workflows/publish-lian-npm.yml
@@ -2,6 +2,11 @@ name: Publish lians to npm
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing TypeScript or unified release tag to publish (for example, v0.5.0)
+        required: true
+        type: string
   push:
     tags:
       - "v*"            # unified release tag; one `vX.Y.Z` ships every language
@@ -16,6 +21,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+
+      - name: Verify release version
+        shell: bash
+        working-directory: agentmem/sdk/typescript
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            expected_version="${RELEASE_TAG#v}"
+          elif [[ "${RELEASE_TAG}" =~ ^lians-ts-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            expected_version="${RELEASE_TAG#lians-ts-v}"
+          else
+            echo "release_tag must be vX.Y.Z or lians-ts-vX.Y.Z" >&2
+            exit 1
+          fi
+          package_version="$(node -p "require('./package.json').version")"
+          if [[ "${package_version}" != "${expected_version}" ]]; then
+            echo "package.json=${package_version} does not match ${RELEASE_TAG}" >&2
+            exit 1
+          fi
 
       - name: Set up Node
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
@@ -23,6 +51,22 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false
+
+      - name: Verify npm supports trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm_version="$(npm --version)"
+          echo "npm ${npm_version}"
+          node -e '
+            const actual = process.argv[1].split(".").map(Number);
+            const minimum = [11, 5, 1];
+            const supported = actual.some((part, index) => part > minimum[index] && actual.slice(0, index).every((value, prior) => value === minimum[prior]))
+              || actual.every((part, index) => part === minimum[index]);
+            if (!supported) {
+              throw new Error(`npm ${process.argv[1]} does not support trusted publishing; expected >=11.5.1`);
+            }
+          ' "${npm_version}"
 
       - name: Install dependencies
         working-directory: agentmem/sdk/typescript
@@ -39,8 +83,3 @@ jobs:
       - name: Publish to npm
         working-directory: agentmem/sdk/typescript
         run: npm publish --access public
-        # npm CLI 11.5.1+ prefers the short-lived GitHub OIDC credential. Keep
-        # the existing token as a migration fallback until trusted publishing
-        # is verified, then remove the secret from the repository.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ name: Release SDK artifacts
 # own publish workflows; this covers Java (jar) and C (source tarball), and
 # sanity-builds Go. See docs/publishing.md.
 on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing unified release tag to recover or republish (for example, v0.5.0)
+        required: true
+        type: string
   push:
     tags:
       - "v*"
@@ -12,12 +18,65 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: sdk-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+
 jobs:
-  java-jar:
-    name: Build Java jar
+  release-context:
+    name: Validate release context
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
+      - name: Verify tag and source version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release_tag must be an existing stable semver tag (vX.Y.Z)" >&2
+            exit 1
+          fi
+          version="${RELEASE_TAG#v}"
+          source_version="$(tr -d '[:space:]' < VERSION)"
+          if [[ "${source_version}" != "${version}" ]]; then
+            echo "VERSION=${source_version} does not match ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          tag_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          head_sha="$(git rev-parse HEAD)"
+          if [[ "${tag_sha}" != "${head_sha}" ]]; then
+            echo "checked-out SHA ${head_sha} does not match ${RELEASE_TAG} (${tag_sha})" >&2
+            exit 1
+          fi
+      - name: Create GitHub release if absent
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "GitHub Release ${RELEASE_TAG} already exists"
+          else
+            gh release create "${RELEASE_TAG}" \
+              --verify-tag \
+              --title "Lians ${RELEASE_TAG}" \
+              --generate-notes
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  java-jar:
+    name: Build Java jar
+    needs: release-context
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
@@ -27,31 +86,38 @@ jobs:
         run: mvn -B --no-transfer-progress package
         working-directory: agentmem/sdk/java
       - name: Attach jar to release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
-        with:
-          files: agentmem/sdk/java/target/*.jar
+        shell: bash
+        run: gh release upload "${RELEASE_TAG}" agentmem/sdk/java/target/*.jar --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   c-tarball:
     name: Package C source
+    needs: release-context
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - name: Create tarball
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          version="${RELEASE_TAG#v}"
           tar -czf "lians-c-${version}.tar.gz" -C agentmem/sdk c
       - name: Attach tarball to release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
-        with:
-          files: lians-c-*.tar.gz
+        shell: bash
+        run: gh release upload "${RELEASE_TAG}" lians-c-*.tar.gz --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   go-tag:
     name: Tag Go module for go get
+    needs: release-context
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.22"
@@ -63,18 +129,27 @@ jobs:
       # tag to agentmem/sdk/go/vX.Y.Z so consumers can pin a version.
       - name: Push module-path tag
         run: |
-          gotag="agentmem/sdk/go/${GITHUB_REF_NAME}"
-          if git rev-parse "$gotag" >/dev/null 2>&1; then
-            echo "$gotag already exists; skipping"
+          set -euo pipefail
+          gotag="agentmem/sdk/go/${RELEASE_TAG}"
+          target_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          if git ls-remote --exit-code origin "refs/tags/${gotag}" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/${gotag}:refs/tags/${gotag}"
+            existing_sha="$(git rev-list -n 1 "${gotag}")"
+            if [[ "${existing_sha}" != "${target_sha}" ]]; then
+              echo "${gotag} already points to ${existing_sha}, expected ${target_sha}" >&2
+              exit 1
+            fi
+            echo "${gotag} already exists at the verified release commit"
           else
-            git tag "$gotag" "${GITHUB_REF_NAME}"
-            git push origin "$gotag"
+            git tag "${gotag}" "${target_sha}"
+            git push origin "refs/tags/${gotag}"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   maven-central:
     name: Publish to Maven Central
+    needs: release-context
     runs-on: ubuntu-latest
     # Opt-in: set repository variable PUBLISH_MAVEN_CENTRAL=true and configure the
     # OSSRH_* / MAVEN_GPG_* secrets first (see docs/publishing.md). Until then the
@@ -82,6 +157,8 @@ jobs:
     if: ${{ vars.PUBLISH_MAVEN_CENTRAL == 'true' }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,7 @@ Pushing a `vX.Y.Z` tag triggers:
 | Workflow | Does |
 |----------|------|
 | `publish-lian.yml` | Builds + publishes **Python** `lians-sdk` to PyPI (OIDC trusted publishing) |
-| `publish-lian-npm.yml` | `npm publish` **TypeScript** `@lians-ai/lians` (needs `NPM_TOKEN`) |
+| `publish-lian-npm.yml` | `npm publish` **TypeScript** `@lians-ai/lians` through npm trusted publishing (GitHub OIDC) |
 | `release.yml` → `java-jar` | Attaches the **Java** jar to the GitHub Release |
 | `release.yml` → `c-tarball` | Attaches `lians-c-<version>.tar.gz` (the **C** source) to the Release |
 | `release.yml` → `go-tag` | Mirrors the tag to `agentmem/sdk/go/vX.Y.Z` so `go get …@vX.Y.Z` resolves |
@@ -49,7 +49,7 @@ does not prove that any registry accepted the release.
 | Registry | Setup |
 |----------|-------|
 | **PyPI** | Configure a *Trusted Publisher* for `lians-sdk` pointing at `publish-lian.yml` (no token needed). |
-| **npm** | Create the `@lians-ai` org (or your chosen scope), add repo secret `NPM_TOKEN` with publish rights. |
+| **npm** | Configure `@lians-ai/lians` trusted publishing for `Lians-ai/Lians`, workflow `publish-lian-npm.yml`, with `npm publish` allowed. |
 | **Maven Central** | Create a [Central Portal](https://central.sonatype.com) account for `ai.lians` (verified via a TXT record on lians.ai); add secrets `OSSRH_USERNAME`, `OSSRH_PASSWORD`, `MAVEN_GPG_KEY` (ASCII-armored private key), `MAVEN_GPG_PASSPHRASE`; set repo **variable** `PUBLISH_MAVEN_CENTRAL=true`. Until then, the jar is attached to the GitHub Release. |
 | **Go / pkg.go.dev** | Nothing — `go-tag` creates the resolvable tag automatically. |
 

--- a/agentmem/sdk/typescript/package.json
+++ b/agentmem/sdk/typescript/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://www.lians.ai",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Lians-ai/Lians.git"
+    "url": "git+https://github.com/Lians-ai/Lians.git"
   },
   "bugs": {
     "url": "https://github.com/Lians-ai/Lians/issues"

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -30,7 +30,7 @@ git push origin v0.4.2
 | SDK | Registry | Publication path | Authentication |
 |---|---|---|---|
 | Python | [PyPI](https://pypi.org/project/lians-sdk/) | `publish-lian.yml` builds the sdist and wheel, then publishes them | PyPI trusted publisher through GitHub OIDC |
-| TypeScript | [npm](https://www.npmjs.com/package/@lians-ai/lians) | `publish-lian-npm.yml` builds, tests, and runs `npm publish` | npm trusted publisher through GitHub OIDC, with `NPM_TOKEN` retained temporarily as a migration fallback |
+| TypeScript | [npm](https://www.npmjs.com/package/@lians-ai/lians) | `publish-lian-npm.yml` builds, tests, and runs `npm publish` | npm trusted publisher through GitHub OIDC; no long-lived publish token |
 | Go | proxy.golang.org and pkg.go.dev | `release.yml` creates a module-path tag | GitHub token supplied to the workflow |
 | Java | Maven Central and GitHub Release JAR | `release.yml` signs and deploys with the `release` Maven profile | Sonatype credentials and GPG signing secrets |
 | C | GitHub Release source archive | `release.yml` creates `lians-c-<version>.tar.gz` | GitHub token supplied to the workflow |
@@ -47,9 +47,9 @@ Configure the existing `@lians-ai/lians` package on npmjs.com with this trusted 
 | Workflow filename | `publish-lian-npm.yml` |
 | Allowed action | `npm publish` |
 
-The workflow uses a GitHub-hosted runner, Node 24, npm 11.5.1 or later, and `id-token: write`. After one OIDC publication succeeds, remove the `NPM_TOKEN` repository secret and the fallback environment variable from the workflow.
+The workflow uses a GitHub-hosted runner, Node 24, npm 11.5.1 or later, and `id-token: write`. Publishing is OIDC-only: configure the trusted publisher before dispatching the workflow, and do not add a long-lived `NPM_TOKEN` fallback.
 
-The workflow also supports manual dispatch. This is useful when registry authorization fails after a tag has already published successfully to the other registries. A manual rerun publishes the version currently present on the selected branch, so verify that the npm version is still unpublished first.
+The workflow also supports manual dispatch. This is useful when registry authorization fails after a tag has already published successfully to the other registries. Supply the existing release tag; the workflow checks out that immutable tag and verifies its package version before publishing. Verify that the npm version is still unpublished first.
 
 ## Go module tags
 


### PR DESCRIPTION
## What changed

- add a manual, immutable-tag recovery path to the SDK release workflow
- validate the selected tag, source version, and exact checked-out commit
- replace the policy-blocked `softprops/action-gh-release` steps with built-in `gh release` commands
- make Go module-tag recovery idempotent and fail closed on a SHA mismatch
- make npm manual recovery check out and validate the immutable release tag
- remove the failing long-lived npm token fallback in favor of OIDC-only trusted publishing
- normalize the npm package repository URL and align publishing documentation

## Root cause

The `v0.5.0` SDK workflow was rejected before startup because the repository Actions allowlist used `softprops/action-gh-release/*`, which does not match a root action ref. The npm publisher fell back to an unauthorized `NPM_TOKEN` and received an npm registry `E404` permission response.

## Impact

After merge, the SDK workflow can be manually dispatched with `v0.5.0` without moving the already-published tag. It will recover the GitHub Release, Java/C assets, Go module tag, and Maven publication from the exact tagged commit. npm recovery becomes short-lived OIDC-only once the package trusted publisher is configured.

## Validation

- actionlint 1.7.12 on both modified workflows
- TypeScript build and 18 tests
- `npm pack --dry-run` for `@lians-ai/lians@0.5.0`
- release contract checker
- published release-status tests: 8 passed
- Ruff and `git diff --check`
