### PR TITLE
docs: record verified v0.5.0 release surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
     id: version
     attributes:
       label: Lians version
-      placeholder: v0.4.1, container digest, or commit SHA
+      placeholder: vX.Y.Z, container digest, or commit SHA
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ independently and may differ when a publisher fails. See
 [`docs/published-release-status.json`](docs/published-release-status.json) for the
 current distribution truth.
 
-## Unreleased — source manifests at 0.5.0
-
-The `0.5.0` source version is not a published-release claim. Do not advertise or
-install `0.5.0` until the release checklist verifies PyPI, npm, Go, Maven, the C
-asset, GitHub Releases, GHCR, and the MCP Registry from clean environments.
+## 0.5.0 — 2026-08-02
 
 ### Added
 - Decision Envelopes, completeness grades, signed Evidence Packs, and offline
@@ -27,25 +23,6 @@ asset, GitHub Releases, GHCR, and the MCP Registry from clean environments.
 - Runtime, webhook, artifact, and workflow security hardening.
 - Runtime Docker contexts now exclude nested dependency/build trees; the test
   harness accepts an explicit `TEST_REDIS_URL` for isolated local and CI runs.
-
-## 0.4.2 — 2026-07-18 (Python SDK only)
-
-- Published `lians-sdk` with real local semantic embeddings included in the
-  `[local]` and `[mcp]` installation paths. Other ecosystems remained on their
-  previously published versions.
-
-## 0.4.1 — 2026-07-17
-
-- Corrected the Java group to `ai.lians` and published Java 0.4.1 to Maven
-  Central, Go 0.4.1 to the module proxy, C 0.4.1 as a GitHub release asset, and
-  MCP manifest/container 0.4.1.
-- Shipped lifecycle, recall-quality, local-MCP, packaging, and benchmark fixes.
-- npm remained at 0.4.0 after the 0.4.1 publisher authorization failure.
-
-## Unreleased
-
-### Changed
-
 - Recall policy `lians-recall-policy-v3` caps each query facet at 400 candidates
   (at most four facets) and publishes both the per-facet and request-wide upper
   bounds alongside per-memory work limits in its evidence.
@@ -64,6 +41,20 @@ asset, GitHub Releases, GHCR, and the MCP Registry from clean environments.
 - Idempotent writes now commit their retry key and durable recall-invalidation
   barrier atomically with the memory. A retry repairs a post-commit cache outage
   and returns the original memory instead of inserting a duplicate.
+
+## 0.4.2 — 2026-07-18 (Python SDK only)
+
+- Published `lians-sdk` with real local semantic embeddings included in the
+  `[local]` and `[mcp]` installation paths. Other ecosystems remained on their
+  previously published versions.
+
+## 0.4.1 — 2026-07-17
+
+- Corrected the Java group to `ai.lians` and published Java 0.4.1 to Maven
+  Central, Go 0.4.1 to the module proxy, C 0.4.1 as a GitHub release asset, and
+  MCP manifest/container 0.4.1.
+- Shipped lifecycle, recall-quality, local-MCP, packaging, and benchmark fixes.
+- npm remained at 0.4.0 after the 0.4.1 publisher authorization failure.
 
 ## 0.4.0 — 2026-07-06
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 repository-code: "https://github.com/Lians-ai/Lians"
 url: "https://www.lians.ai"
 license: Apache-2.0
-version: 0.4.0
-date-released: 2026-07-06
+version: 0.5.0
+date-released: 2026-08-02
 keywords:
   - agent memory
   - bitemporal data

--- a/Dockerfile.glama
+++ b/Dockerfile.glama
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 # Hosted builders such as Glama may not support build arguments, so this
 # fallback tracks the verified public image. The publisher always overrides
 # and verifies this value before creating a versioned GHCR tag.
-ARG LIANS_VERSION=0.4.1
+ARG LIANS_VERSION=0.5.0
 
 RUN groupadd --system lians \
     && useradd --system --gid lians --create-home lians \

--- a/README.md
+++ b/README.md
@@ -404,11 +404,11 @@ verify the machine-readable [published release status](docs/published-release-st
 
 | Language | Install | Client | Docs |
 |----------|---------|--------|------|
-| **Python 0.4.2** | `pip install lians-sdk==0.4.2` | `from lians import LiansClient` | [sdk/python](agentmem/sdk/python) |
+| **Python 0.5.0** | `pip install lians-sdk==0.5.0` | `from lians import LiansClient` | [sdk/python](agentmem/sdk/python) |
 | **TypeScript / Node 0.4.0** | `npm install @lians-ai/lians@0.4.0` | `import { LiansClient } from "@lians-ai/lians"` | [sdk/typescript](agentmem/sdk/typescript) |
-| **Go 0.4.1** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.4.1` | `lians.NewClient(url, key)` | [sdk/go](agentmem/sdk/go) |
-| **Java 0.4.1** (JVM 11+) | `ai.lians:lians-sdk:0.4.1` (Maven Central) | `new LiansClient(opts)` | [sdk/java](agentmem/sdk/java) |
-| **C 0.4.1** (C99 + libcurl) | build from the `v0.4.1` source tag | `lians_client_new(...)` | [sdk/c](agentmem/sdk/c) |
+| **Go 0.5.0** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.5.0` | `lians.NewClient(url, key)` | [sdk/go](agentmem/sdk/go) |
+| **Java 0.5.0** (JVM 11+) | `ai.lians:lians-sdk:0.5.0` (Maven Central) | `new LiansClient(opts)` | [sdk/java](agentmem/sdk/java) |
+| **C 0.5.0** (C99 + libcurl) | build from the `v0.5.0` release asset | `lians_client_new(...)` | [sdk/c](agentmem/sdk/c) |
 
 → **One-page install + 30-second quickstart for every language: [docs/install.md](docs/install.md)**
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ python scripts/check_openapi_contract.py
 # 3. Run the full test/build/package matrix and inspect the release diff.
 # 4. Confirm PyPI trusted publishing, npm scope authorization, Maven secrets,
 #    and the Maven opt-in variable before creating the tag.
-git tag vX.Y.Z
+git tag -a vX.Y.Z -m "release: vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
@@ -55,15 +55,18 @@ does not prove that any registry accepted the release.
 
 ## After a release
 
-1. Wait for every tag-triggered workflow and inspect each publisher log.
+1. Wait for `publish-lian.yml`, `publish-lian-npm.yml`, `release.yml`, and
+   `publish-mcp-container.yml`, then inspect each publisher log.
 2. Verify clean external installs for Python, TypeScript, Go, Java, and the C
    release asset. Run the installed Python wheel outside this monorepo.
    Then run `uv lock --directory integrations/mcpb` and rerun
    `python scripts/check_release_contract.py` before packaging the MCPB.
-3. Publish and verify the MCP Registry manifest, then verify the GHCR version and
-   `latest` tags resolve to the intended digest. The container workflow strips
-   the Git tag's leading `v`, validates the result against `VERSION`, and uses
-   that same value for the installed Python distribution and runtime image tag.
+3. Publish `server.json` to the MCP Registry, then verify the Registry entry and
+   the GHCR version and `latest` tags. Both GHCR tags must resolve to the intended
+   OCI index, including `linux/amd64`, `linux/arm64`, SBOM, and provenance
+   manifests. The container workflow strips the Git tag's leading `v`, validates
+   the result against `VERSION`, and uses that same value for the installed
+   Python distribution and runtime image tag.
 4. Update `docs/published-release-status.json` only from observed registry state,
    then run:
 
@@ -74,11 +77,13 @@ does not prove that any registry accepted the release.
    ```
 
    The script checks registries with stable unauthenticated metadata endpoints.
-   The C release asset and GHCR container remain explicit manual checks; both are
-   still required before `--require-source-sync` may be treated as a release gate.
+   The C release asset and GHCR container remain explicit manual checks. The
+   source-sync command is the final all-surfaces gate and is expected to fail if
+   any publisher remains on an older version.
 
-5. Update public install instructions only after both commands pass. If any
-   publisher fails, leave the matrix split and record the failure explicitly.
+5. Update each public install instruction to the version actually observed for
+   that ecosystem. If a publisher fails, leave the matrix split and record the
+   older public version explicitly; never advertise the source version as live.
 
 - **Publish to the MCP registry — manual, easy to forget** (0.3.3 and the
   first day of 0.3.4 were missing because this step lives outside the
@@ -87,7 +92,7 @@ does not prove that any registry accepted the release.
   ```bash
   # from the repo root (reads server.json, which the version bump updated)
   mcp-publisher login github     # interactive device flow; token expires
-  mcp-publisher publish
+  mcp-publisher publish server.json
   # verify:
   curl -fsS "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ebeirne%2Flians&version=latest"
   ```

--- a/agentmem/sdk/java/README.md
+++ b/agentmem/sdk/java/README.md
@@ -18,14 +18,14 @@ Maven:
 <dependency>
   <groupId>ai.lians</groupId>
   <artifactId>lians-sdk</artifactId>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-implementation "ai.lians:lians-sdk:0.4.1"
+implementation "ai.lians:lians-sdk:0.5.0"
 ```
 
 Published releases are available from [Maven Central](https://central.sonatype.com/artifact/ai.lians/lians-sdk). Release JARs are also attached to [GitHub Releases](https://github.com/Lians-ai/Lians/releases). The source checkout may contain a newer unreleased version; use the published coordinate above for external builds.

--- a/agentmem/tests/test_published_release_status.py
+++ b/agentmem/tests/test_published_release_status.py
@@ -18,34 +18,27 @@ def test_checked_in_release_status_is_valid_and_explicit_about_drift():
     errors = validate_status(status, (ROOT / "VERSION").read_text().strip())
     assert errors == []
     assert source_sync_drift(status) == {
-        "pypi": "0.4.2",
         "npm": "0.4.0",
-        "go": "0.4.1",
-        "maven": "0.4.1",
-        "c": "0.4.1",
-        "ghcr_mcp": "0.4.1",
-        "mcp_registry": "0.4.1",
-        "github_release": "0.4.1",
     }
 
 
 def test_registry_parsers_select_authoritative_release_versions():
-    assert parse_go_versions(b"v0.4.0\nv0.3.4\nv0.4.1\n") == "0.4.1"
+    assert parse_go_versions(b"v0.4.1\nv0.3.4\nv0.5.0\n") == "0.5.0"
     assert (
         parse_maven_metadata(
-            b"<metadata><versioning><release>0.4.1</release></versioning></metadata>"
+            b"<metadata><versioning><release>0.5.0</release></versioning></metadata>"
         )
-        == "0.4.1"
+        == "0.5.0"
     )
 
     assert (
         parse_mcp_registry(
             b'{"servers":[{"server":{"name":"io.github.ebeirne/lians",'
-            b'"version":"0.4.1"},"_meta":{'
+            b'"version":"0.5.0"},"_meta":{'
             b'"io.modelcontextprotocol.registry/official":{'
             b'"status":"active","isLatest":true}}}]}'
         )
-        == "0.4.1"
+        == "0.5.0"
     )
 
 
@@ -53,10 +46,10 @@ def test_live_comparison_reports_expected_and_actual_versions():
     status = load_status(ROOT / "docs" / "published-release-status.json")
     live = {
         "production_api": "0.5.0",
-        "pypi": "0.4.2",
-        "npm": "0.4.1",
+        "pypi": "0.5.0",
+        "npm": "0.5.0",
     }
-    assert compare_live(status, live) == {"npm": ("0.4.0", "0.4.1")}
+    assert compare_live(status, live) == {"npm": ("0.4.0", "0.5.0")}
 
 
 def test_production_verification_uses_version_endpoint() -> None:
@@ -92,11 +85,11 @@ def test_glama_default_tracks_verified_public_image():
 
 def test_release_status_rejects_prefixed_ghcr_runtime_tag():
     status = load_status(ROOT / "docs" / "published-release-status.json")
-    status["artifacts"]["ghcr_mcp"]["runtime"] = "ghcr.io/lians-ai/lians-mcp:v0.4.1"
+    status["artifacts"]["ghcr_mcp"]["runtime"] = "ghcr.io/lians-ai/lians-mcp:v0.5.0"
     errors = validate_status(status, (ROOT / "VERSION").read_text().strip())
     assert errors == [
         (
             "artifacts.ghcr_mcp.runtime must use the normalized, unprefixed "
-            "version tag ghcr.io/lians-ai/lians-mcp:0.4.1"
+            "version tag ghcr.io/lians-ai/lians-mcp:0.5.0"
         )
     ]

--- a/docs/glama-deployment.md
+++ b/docs/glama-deployment.md
@@ -13,7 +13,7 @@ introspection pipeline.
 - Persistent volume: `/data`
 - API key: not required for local SQLite mode
 
-The default image runs `lians-sdk[mcp]==0.4.1` as a non-root user. Release
+The default image runs `lians-sdk[mcp]==0.5.0` as a non-root user. Release
 automation overrides the default with the validated release version and checks
 the installed distribution before publishing. The database path is
 `/data/mcp.db`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,12 +14,12 @@ webhook coverage currently varies by client.
 
 | Language | Install | Import / entry point |
 |----------|---------|----------------------|
-| **Python 0.4.2** | `pip install lians-sdk==0.4.2` | `from lians import LiansClient` |
-| **Python 0.4.2 (local, no server)** | `pip install "lians-sdk[local]==0.4.2"` | `from lians import LocalLiansClient` |
+| **Python 0.5.0** | `pip install lians-sdk==0.5.0` | `from lians import LiansClient` |
+| **Python 0.5.0 (local, no server)** | `pip install "lians-sdk[local]==0.5.0"` | `from lians import LocalLiansClient` |
 | **TypeScript / Node 0.4.0** | `npm install @lians-ai/lians@0.4.0` | `import { LiansClient } from "@lians-ai/lians"` |
-| **Go 0.4.1** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.4.1` | `lians.NewClient(url, key)` |
-| **Java 0.4.1** (JVM 11+) | Maven `ai.lians:lians-sdk:0.4.1` | `new LiansClient(opts)` |
-| **C 0.4.1** (C99 + libcurl) | check out `v0.4.1`, then `cmake -S agentmem/sdk/c -B build` | `lians_client_new(...)` |
+| **Go 0.5.0** | `go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.5.0` | `lians.NewClient(url, key)` |
+| **Java 0.5.0** (JVM 11+) | Maven `ai.lians:lians-sdk:0.5.0` | `new LiansClient(opts)` |
+| **C 0.5.0** (C99 + libcurl) | download the `v0.5.0` source asset, then run CMake | `lians_client_new(...)` |
 
 Published versions currently differ by ecosystem. The exact registry state is
 tracked in [`published-release-status.json`](published-release-status.json) and
@@ -84,7 +84,7 @@ _, _ = c.AddMemory(ctx, lians.AddMemoryRequest{
 <dependency>
   <groupId>ai.lians</groupId>
   <artifactId>lians-sdk</artifactId>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
 </dependency>
 ```
 ```java
@@ -118,9 +118,9 @@ pip install lians-sdk[all]          # everything
 ## Verify a release
 
 ```bash
-pip install lians-sdk==0.4.2
+pip install lians-sdk==0.5.0
 npm view @lians-ai/lians version
-go list -m github.com/Lians-ai/Lians/agentmem/sdk/go@v0.4.1
+go list -m github.com/Lians-ai/Lians/agentmem/sdk/go@v0.5.0
 curl -fsSL https://repo1.maven.org/maven2/ai/lians/lians-sdk/maven-metadata.xml
 python scripts/check_published_artifacts.py
 ```

--- a/docs/published-release-status.json
+++ b/docs/published-release-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "lians.published-release-status.v1",
-  "verified_at": "2026-08-01T06:00:00Z",
+  "verified_at": "2026-08-02T05:19:36Z",
   "source_version": "0.5.0",
   "production_api": {
     "version": "0.5.0",
@@ -9,7 +9,7 @@
   },
   "artifacts": {
     "pypi": {
-      "version": "0.4.2",
+      "version": "0.5.0",
       "url": "https://pypi.org/project/lians-sdk/"
     },
     "npm": {
@@ -17,29 +17,29 @@
       "url": "https://www.npmjs.com/package/@lians-ai/lians"
     },
     "go": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "url": "https://pkg.go.dev/github.com/Lians-ai/Lians/agentmem/sdk/go"
     },
     "maven": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "url": "https://central.sonatype.com/artifact/ai.lians/lians-sdk"
     },
     "c": {
-      "version": "0.4.1",
-      "url": "https://github.com/Lians-ai/Lians/releases/tag/v0.4.1"
+      "version": "0.5.0",
+      "url": "https://github.com/Lians-ai/Lians/releases/tag/v0.5.0"
     },
     "ghcr_mcp": {
-      "version": "0.4.1",
-      "runtime": "ghcr.io/lians-ai/lians-mcp:0.4.1",
+      "version": "0.5.0",
+      "runtime": "ghcr.io/lians-ai/lians-mcp:0.5.0",
       "url": "https://github.com/Lians-ai/Lians/pkgs/container/lians-mcp"
     },
     "mcp_registry": {
-      "version": "0.4.1",
+      "version": "0.5.0",
       "url": "https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians"
     },
     "github_release": {
-      "version": "0.4.1",
-      "url": "https://github.com/Lians-ai/Lians/releases/tag/v0.4.1"
+      "version": "0.5.0",
+      "url": "https://github.com/Lians-ai/Lians/releases/tag/v0.5.0"
     }
   }
 }

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,29 +1,46 @@
 # Publishing the SDKs
 
-Lians ships Python, TypeScript, Go, Java, and C SDKs. A unified `vX.Y.Z` tag runs the language-specific publication workflows and creates GitHub Release artifacts.
+Lians ships Python, TypeScript, Go, Java, and C SDKs plus an MCP container and
+Registry manifest. A unified annotated `vX.Y.Z` tag starts four GitHub Actions
+workflows; the MCP Registry manifest is published separately after the matching
+Python package is live.
 
 ## Release checklist
 
-1. Set the same version in:
+1. Set the same version in `VERSION` and every release manifest, including:
    - `agentmem/sdk/python/pyproject.toml`
    - `agentmem/sdk/typescript/package.json`
    - `agentmem/sdk/typescript/package-lock.json`
    - `agentmem/sdk/java/pom.xml`
+   - `agentmem/sdk/go/version.go`
+   - `agentmem/sdk/c/CMakeLists.txt`
+   - `server.json`
 2. Update package README installation examples.
-3. Merge the release PR only after the full CI matrix passes.
-4. Confirm PyPI trusted publishing, npm trusted publishing, and Maven Central credentials are configured.
+3. Run `python scripts/check_release_contract.py`, then merge the release PR only
+   after the full CI matrix passes.
+4. Confirm PyPI and npm trusted publishing, Maven Central credentials and opt-in,
+   GHCR package permissions, and GitHub Release permissions are configured.
 5. Create and push one annotated tag:
 
 ```bash
-git tag -a v0.4.2 -m "release: v0.4.2"
-git push origin v0.4.2
+git tag -a vX.Y.Z -m "release: vX.Y.Z"
+git push origin vX.Y.Z
 ```
 
-6. Monitor all three workflows until completion:
+6. Monitor all four tag-triggered workflows until completion:
    - `publish-lian.yml`
    - `publish-lian-npm.yml`
    - `release.yml`
-7. Verify the published version from each public registry. A successful workflow is not proof that a registry search index has propagated.
+   - `publish-mcp-container.yml`
+7. After PyPI exposes the exact release, publish `server.json` to the MCP Registry:
+
+   ```bash
+   mcp-publisher login github
+   mcp-publisher publish server.json
+   ```
+
+8. Verify the published version from every public registry. A successful
+   workflow is not proof that a registry or search index has propagated.
 
 ## Registry matrix
 
@@ -34,6 +51,8 @@ git push origin v0.4.2
 | Go | proxy.golang.org and pkg.go.dev | `release.yml` creates a module-path tag | GitHub token supplied to the workflow |
 | Java | Maven Central and GitHub Release JAR | `release.yml` signs and deploys with the `release` Maven profile | Sonatype credentials and GPG signing secrets |
 | C | GitHub Release source archive | `release.yml` creates `lians-c-<version>.tar.gz` | GitHub token supplied to the workflow |
+| MCP container | GitHub Container Registry | `publish-mcp-container.yml` waits for the exact PyPI release, smoke-tests the server, and publishes multi-architecture `X.Y.Z` and `latest` tags with SBOM and provenance | GitHub package permissions plus OIDC attestation permission |
+| MCP manifest | Official MCP Registry | `mcp-publisher publish server.json` after the referenced PyPI package is live | Short-lived GitHub login for the `io.github.ebeirne/lians` namespace |
 
 ## npm trusted publishing
 
@@ -56,7 +75,7 @@ The workflow also supports manual dispatch. This is useful when registry authori
 The Go module lives in a subdirectory. `release.yml` mirrors `vX.Y.Z` to `agentmem/sdk/go/vX.Y.Z` automatically so consumers can run:
 
 ```bash
-go get github.com/Lians-ai/Lians/agentmem/sdk/go@v0.4.1
+go get github.com/Lians-ai/Lians/agentmem/sdk/go@vX.Y.Z
 ```
 
 ## Maven Central
@@ -73,3 +92,17 @@ It also requires the repository variable `PUBLISH_MAVEN_CENTRAL=true`. The Maven
 ## C source archive
 
 The C SDK is distributed as source. `release.yml` packages `agentmem/sdk/c` into `lians-c-<version>.tar.gz` for consumers to vendor into their own build.
+
+## Container and MCP Registry
+
+`publish-mcp-container.yml` validates the unprefixed `X.Y.Z` tag against
+`VERSION`, waits for that exact `lians-sdk` version on PyPI, smoke-tests the
+stdio MCP server, and publishes `ghcr.io/lians-ai/lians-mcp:X.Y.Z` plus
+`latest`. Verify both tags resolve to the same OCI index and that it contains
+`linux/amd64` and `linux/arm64` images.
+
+The public Registry identity remains `io.github.ebeirne/lians`; the GitHub
+organization hosting the repository does not change that established package
+name. Publish the checked-in manifest explicitly with
+`mcp-publisher publish server.json`, then verify exactly one active `isLatest`
+entry for that identity.

--- a/llms-install.md
+++ b/llms-install.md
@@ -20,7 +20,7 @@ Add this server entry to the MCP configuration used by your client:
   "mcpServers": {
     "lians": {
       "command": "uvx",
-      "args": ["--from", "lians-sdk[mcp]==0.4.1", "lians-mcp"]
+      "args": ["--from", "lians-sdk[mcp]==0.5.0", "lians-mcp"]
     }
   }
 }
@@ -34,7 +34,7 @@ eight memory tools. No environment variables are required for local mode.
 To start the stdio server directly:
 
 ```bash
-uvx --from 'lians-sdk[mcp]==0.4.1' lians-mcp
+uvx --from 'lians-sdk[mcp]==0.5.0' lians-mcp
 ```
 
 The process waits for MCP messages on standard input. This is expected. Stop it
@@ -50,7 +50,7 @@ Set `LIANS_LOCAL_DB` only when a specific database path is needed:
   "mcpServers": {
     "lians": {
       "command": "uvx",
-      "args": ["--from", "lians-sdk[mcp]==0.4.1", "lians-mcp"],
+      "args": ["--from", "lians-sdk[mcp]==0.5.0", "lians-mcp"],
       "env": {
         "LIANS_LOCAL_DB": "/absolute/path/to/lians-mcp.db"
       }


### PR DESCRIPTION
## What changed

- Records the publicly verified v0.5.0 release across PyPI, Go, Maven Central, GitHub Releases, GHCR, and the MCP Registry.
- Updates install instructions, release docs, changelog, citation metadata, Glama/MCP pins, and release-status tests.
- Keeps npm at its observed public version, 0.4.0, until trusted publishing is configured and v0.5.0 is independently verified.

## Why

The source tree is v0.5.0, but release truth must come from public registry state rather than successful workflow logs. This draft prevents Lians from advertising artifacts that consumers cannot actually install.

## User impact

Consumers receive accurate, ecosystem-specific installation commands now. Once npm v0.5.0 is live, this branch will be amended so every SDK surface is synchronized.

## Validation

- `python scripts/check_release_contract.py`
- `python -m pytest agentmem/tests/test_published_release_status.py -q` (8 passed)
- `python -m ruff check agentmem/tests/test_published_release_status.py scripts/check_published_artifacts.py`
- `python scripts/check_published_artifacts.py`
- JSON/YAML parsing and `git diff --check`

`python scripts/check_published_artifacts.py --require-source-sync` currently has one intentional blocker: npm is publicly 0.4.0.
