### PR TITLE
docs: add coordinated marketing launch campaign

### DIFF
--- a/docs/gtm/amplification-campaign-2026-08-09.md
+++ b/docs/gtm/amplification-campaign-2026-08-09.md
@@ -1,0 +1,84 @@
+# Lians proof amplification campaign
+
+Date: 2026-08-09
+
+## Campaign rule
+
+Every announcement points to one verifiable artifact, one useful takeaway, and one action. Avoid combining all wins into a generic company update.
+
+## LangChain documentation merge
+
+Primary post:
+
+> Lians is now documented in LangChain's memory integrations. The important part is not another connector. It is the ability to ask what an agent could know at a prior moment, with provenance for the retrieved facts. If your evaluation replays old decisions, point-in-time memory prevents today's corrections from leaking into yesterday's answer.
+>
+> Docs merge: https://github.com/langchain-ai/docs/pull/4949
+> Quickstart: https://www.lians.ai/docs
+
+Tutorial: `Point-in-time agent memory with LangChain and Lians`
+
+Outline:
+
+1. Record an original policy fact.
+2. Record a later correction.
+3. Run present-time recall.
+4. Run `recall_at` before the correction.
+5. Export the decision evidence and compare the source versions.
+
+Partner ask: invite LangChain to reshare the tutorial after it is published, with the merged documentation link as the factual basis.
+
+## MCP Registry and Glama
+
+Primary post:
+
+> Lians can now be discovered through the official MCP Registry and Glama. The default tool surface stays deliberately small: remember, recall, and point-in-time recall. That gives coding agents durable memory without exposing a sprawling tool schema on every prompt.
+>
+> MCP setup: https://www.lians.ai/docs
+
+Tutorial: `Give an MCP host governed memory in three tools`
+
+Partner ask: request a listing refresh that uses `Lians-ai/Lians`, v0.5.0, and the current description. Do not claim any directory endorsement beyond the verified listing state.
+
+## v0.5.0 release
+
+Primary post:
+
+> Lians v0.5.0 is live on GitHub and PyPI. This release adds the decision-evidence work behind reproducible AI decisions and the newest memory controls. Python users can install `lians-sdk==0.5.0`. The npm package is still 0.4.0 while publisher authorization is repaired.
+>
+> Release: https://github.com/Lians-ai/Lians/releases/tag/v0.5.0
+
+Release tutorial: `From an agent action to a decision receipt`
+
+The tutorial should end with a receipt that shows the query time, fact versions, source references, and verifier result.
+
+## Codex memory usage-extension work
+
+Primary post:
+
+> We tested whether durable retrieval can extend practical model usage on the same billing plan. On one frozen Codex Ultra memory task, a pre-model Lians recall reduced estimated per-task credits from 3.249 to 1.5965 while preserving the exact answer, equal to 2.04x same-budget usage for that task.
+>
+> The broader 120-turn matrix passed pooled economics at 2.22x but failed the every-prompt protected gate. That means the honest result is workload-specific: memory can extend usage when retrieval preserves answer quality, not that Lians universally increases account quota.
+>
+> Evidence and reproduction steps: https://github.com/Lians-ai/Lians/blob/master/docs/benchmarks/provider-usage-extension-2026-08-08.md
+
+Tutorial: `Measure memory economics without inventing a quota claim`
+
+Outline:
+
+1. Freeze the prompts and expected answers.
+2. Compare full-context and bounded-retrieval conditions.
+3. Gate economics on quality first.
+4. Report provider-returned cost separately from estimated cost.
+5. Publish both the pooled result and failed cells.
+
+## Seven-day coordinated cadence
+
+| Day | Main artifact | Secondary action |
+| --- | --- | --- |
+| 1 | Lookahead Show HN launch | Answer comments and record recurring objections |
+| 2 | LinkedIn launch | Ask LangChain for a reshare of the integration tutorial |
+| 3 | v0.5.0 decision-receipt tutorial | Refresh MCP Registry and Glama descriptions |
+| 4 | Codex usage-extension methodology post | Share the exact claim boundary in developer communities |
+| 5 | Product Hunt launch | Send roundup wave one |
+| 6 | Decision Evidence Brief issue 1 | Invite replies with benchmark requests |
+| 7 | Launch evidence recap | Publish traffic, completion, and conversion counts without visitor identifiers |

--- a/docs/gtm/decision-evidence-brief-001.md
+++ b/docs/gtm/decision-evidence-brief-001.md
@@ -1,0 +1,37 @@
+# Decision Evidence Brief, issue 1
+
+Subject: `The hidden future in agent memory`
+
+Preview: `A reproducible lookahead-bias demo, Lians v0.5.0, and an honest test of same-budget model usage.`
+
+## What changed
+
+Lians v0.5.0 is public on GitHub and PyPI. The release advances the evidence layer for teams that need to reconstruct an AI decision after facts, policies, permissions, or memory have changed.
+
+The fastest way to understand the problem is our lookahead-bias demo. It runs the same simple agent strategy twice on seeded synthetic data. Present-time memory can retrieve facts from the future of the simulated decision. Point-in-time memory cannot. The attractive backtest result disappears when the information boundary is enforced.
+
+Read and reproduce it: https://www.lians.ai/blog/backtest-lookahead
+
+## Integration note
+
+LangChain merged Lians into its memory documentation, and Lians is discoverable through the official MCP Registry. The default MCP profile exposes only three tools for ordinary use: remember, recall, and point-in-time recall.
+
+Start here: https://www.lians.ai/docs
+
+## Benchmark note
+
+We also tested a narrower economic question: can bounded durable recall complete more comparable memory tasks under the same model budget?
+
+On one frozen Codex Ultra task, both conditions returned the exact answer. The Lians pre-model hook reduced estimated per-task credits from 3.249 to 1.5965, equal to 2.04x same-budget usage for that task.
+
+The broader 120-turn matrix reached 2.22x pooled economics but failed the every-prompt quality and economics gate. We are publishing the failure because averages should not become universal quota claims.
+
+Methods and artifacts: https://github.com/Lians-ai/Lians/blob/master/docs/benchmarks/provider-usage-extension-2026-08-08.md
+
+## One question for readers
+
+Which historical AI decision would be hardest for your team to reproduce today?
+
+Reply with the workflow, the facts that change, and the evidence you would need. We will choose one anonymized pattern for the next brief.
+
+You are receiving the monthly Decision Evidence Brief because you explicitly subscribed on lians.ai. You can unsubscribe by emailing privacy@lians.ai until the self-service preference endpoint is available.

--- a/docs/gtm/distribution-maintenance-2026-08-09.md
+++ b/docs/gtm/distribution-maintenance-2026-08-09.md
@@ -1,0 +1,59 @@
+# Distribution maintenance ledger
+
+Date: 2026-08-09
+
+## Verified package state
+
+| Surface | Verified state | Required action |
+| --- | --- | --- |
+| GitHub | v0.5.0 public, 2 stars, 2 forks | Improve the release notes and route launch traffic to the repository |
+| PyPI | `lians-sdk` 0.5.0 | Keep install examples pinned to 0.5.0 |
+| npm | `@lians-ai/lians` 0.4.0, with 31 downloads from August 2 through August 8 | Authorize GitHub trusted publishing for `Lians-ai/Lians` and the workflow file, then rerun the existing v0.5.0 package workflow |
+| LangChain | Documentation pull request 4949 merged | Publish the point-in-time memory tutorial and request a reshare |
+| MCP Registry | Listing verified | Refresh version and repository metadata after the public SDK contains the bounded profile |
+| Glama | Listing reported approved | Verify the displayed version and repository before using an approval claim in public copy |
+| RoninForge | Current August 3 census is healthy, 7 of 7 checks passed | No correction request is needed; preserve the current `Lians-ai/Lians` evidence |
+
+## npm authorization evidence
+
+GitHub Actions run `31287160248` checked out v0.5.0, verified the release version, installed dependencies, built, and passed tests. The publish step returned npm `E404` for `@lians-ai/lians@0.5.0`, which npm also uses when the current identity lacks package permission.
+
+Repair checklist:
+
+1. Sign in to npm as an owner of the `@lians-ai/lians` package.
+2. Open package settings and configure a trusted publisher for GitHub Actions.
+3. Match organization `Lians-ai`, repository `Lians`, and workflow `publish-lian-npm.yml` exactly.
+4. Add an environment name only if the npm publisher configuration and GitHub job both use the same environment.
+5. Rerun the workflow with release tag `v0.5.0`.
+6. Verify `npm view @lians-ai/lians version` returns `0.5.0` before announcing TypeScript parity.
+
+## RoninForge verification
+
+The current public page for `io.github.ebeirne/lians` reports Lians healthy in the August 3 census with 7 of 7 checks passed. It resolves the repository to `https://github.com/Lians-ai/Lians`, detects PyPI 0.5.0, and identifies the Apache 2.0 license. The earlier degraded state is no longer current, so no correction request should be sent.
+
+## Open directory queue
+
+Current verification and next actions:
+
+- TeleAI-UAGI Awesome Agent Memory pull request 61 merged on July 18. Treat this as an independent directory win and link it in launch amplification.
+- TensorBlock Awesome MCP Servers pull request 1261 merged on July 17. Treat this as an independent directory win and link it in launch amplification.
+- IAAR-Shanghai Awesome AI Memory pull request 124 remains open and mergeable.
+- cxxz Awesome Agent Memory pull request 17 remains open and mergeable.
+- kyrolabs Awesome Agents pull request 649 was closed without merging. Do not resubmit unless the maintainer invites a revised entry.
+- Docker MCP Catalog pull request 4464 is open and still requires review.
+- Cline marketplace issue 2050 is open with no maintainer comment.
+- The recorded mcp.so listing URL returns 404. Its current submission form requires a $39 one-time payment, so do not resubmit while keeping this campaign on the current billing plan.
+- MCPServers.org has a public Lians listing.
+- MCP.Directory
+- MCP Server Hub
+- AgentNDX
+- DeepYard
+- MCP Market
+- Smithery has a public Lians server record. The upstream CLI issue 797 remains the deployment follow-up.
+- PulseMCP manual ingestion request
+
+Use one canonical description:
+
+`Lians is an Apache 2.0 bitemporal memory and decision-evidence layer for AI agents, with point-in-time recall, provenance, governed memory lifecycle controls, and a small MCP tool surface.`
+
+Do not purchase expedited placement. Record a public listing URL or review identifier before marking any submission complete.

--- a/docs/gtm/editorial-outreach-wave-2026-08-09.csv
+++ b/docs/gtm/editorial-outreach-wave-2026-08-09.csv
@@ -1,0 +1,12 @@
+priority,target,article_url,contact_route,angle,status,follow_up_days
+1,Particula,https://particula.tech/blog/agent-memory-frameworks-tested-mem0-zep-letta-cognee-2026,sebastian@particula.tech,"Offer the executable adapter, point-in-time test, and lookahead receipts for independent rerun",followed_up_once_2026-08-09,none
+2,Vectorize,https://vectorize.io/articles/best-ai-agent-memory-systems,contact@vectorize.io,"Lead with the bitemporal model, public methods, and exact limitations",followed_up_once_2026-08-09,none
+3,Atlan,https://atlan.com/know/best-ai-agent-memory-frameworks-2026/,article author or editorial contact,"Add historical reconstruction and audit evidence as comparison axes for enterprise readers",ready_after_launch,7
+4,Developers Digest,https://developersdigest.tech/blog/best-ai-agent-memory-providers-2026,developer.digest.ai@gmail.com,"Offer a self-hosted regulated-memory lane and a reproducible benchmark artifact",pitched_2026-08-09,7
+5,Powerdrill,https://powerdrill.ai/blog/best-ai-agent-memory-solutions,article author or editorial contact,"Offer the keys-free lookahead demo and the comparison harness for retesting",ready_after_launch,7
+6,MCP.Directory,https://mcp.directory/blog/mem0-vs-letta-vs-zep-2026,directory contact,"Connect the official MCP Registry listing with point-in-time recall and a three-tool profile",ready_after_launch,7
+7,Rohit Raj,https://rohitraj.tech/en/notes/open-source-ai-agent-memory-mem0-vs-zep-letta-2026,author contact,"Lead with Apache 2.0, self-hosted operation, and public evidence artifacts",ready_after_launch,7
+8,XLR8,https://tryxlr8.ai/blogs/best-open-source-ai-memory-frameworks-2026,site contact,"Offer Lians as a bitemporal open-source system with explicit claim boundaries",ready_after_launch,7
+9,TECHSY,https://techsy.io/en/blog/best-ai-agent-memory-tools,site editorial contact,"Offer a distinct historical-reconstruction category and a reproducible demo",ready_after_launch,7
+10,dev.to agdex_ai,https://dev.to/agdex_ai/ai-agent-memory-in-2026-mem0-vs-zep-vs-letta-vs-cognee-a-practical-guide-cfa,DEV Community profile,"Provide a runnable code section showing a late revision and recall_at",ready_after_launch,7
+11,dev.to thedailyagent,https://dev.to/thedailyagent/top-6-ai-agent-memory-frameworks-for-devs-2026-1fef,DEV Community profile,"Provide a compact install, one test, and limitations rather than requesting placement",ready_after_launch,7

--- a/docs/gtm/public-launch-command-center-2026-08-09.md
+++ b/docs/gtm/public-launch-command-center-2026-08-09.md
@@ -1,0 +1,118 @@
+# Lians public launch command center
+
+Date: 2026-08-09
+
+## Launch position
+
+Lians is the open-source evidence and memory layer for reconstructing what an AI system could know when it acted. The launch proof is the reproducible lookahead-bias demo because it turns an abstract temporal-memory failure into a falsifiable result.
+
+Public claims must remain inside these boundaries:
+
+- The Lians v0.5.0 GitHub release and `lians-sdk` 0.5.0 on PyPI are public.
+- The TypeScript package remains on npm 0.4.0 until npm authorizes the GitHub publisher.
+- The LangChain documentation pull request was merged.
+- Lians is present in the official MCP Registry and has a public Glama listing.
+- A protected Codex Ultra repeat measured 2.04x same-budget usage with exact answers on that frozen task.
+- The broader 120-turn Codex matrix measured 2.22x pooled economics, but failed the every-prompt protected gate. Never present that result as a universal quota increase.
+- The lookahead demo uses seeded synthetic data. Its reported return and Sharpe values illustrate contamination, not investment performance.
+
+## Show HN submission
+
+Title:
+
+`Show HN: Your agent's memory can leak the future into backtests`
+
+URL:
+
+`https://www.lians.ai/blog/backtest-lookahead`
+
+Text:
+
+> We built a reproducible demo of a quiet failure in AI-agent evaluation: semantic memory retrieval can return facts that did not exist at the simulated decision time.
+>
+> The harness runs the same simple strategy on the same seeded synthetic market twice. Present-time retrieval produces the attractive result. Point-in-time retrieval exposes it as fiction. The run logs each contaminated retrieval with the decision timestamp and the fact's knowledge timestamp.
+>
+> This is not only a trading problem. Any historical replay can be contaminated, including support agents on old tickets, coding agents on old issues, and regulated decision systems on prior cases.
+>
+> The implementation is Apache 2.0, runs locally, and supports `recall_at` for point-in-time reconstruction. We would especially value criticism of the method and receipt format.
+
+First comment:
+
+> A useful distinction is event time versus knowledge time. Filtering on when an event happened does not catch a correction that arrived later. The demo models both axes so a late revision cannot appear in an earlier reconstruction. The full project and SDK are linked from the article.
+
+## Product Hunt launch page
+
+Name: `Lians`
+
+Tagline: `Reconstruct what your AI knew when it acted`
+
+Short description:
+
+`Open-source, bitemporal memory and decision evidence for AI agents. Recall facts as they were knowable at a prior time, preserve provenance, and export verifiable decision receipts.`
+
+Maker comment:
+
+> AI systems often make consequential decisions using facts, permissions, policies, and memory that later change. Ordinary logs show outputs. Lians reconstructs the state that was actually available when the decision happened.
+>
+> We built Lians around two primitives: bitemporal memory and verifiable evidence. You can record when a fact was true and when the system learned it, query with `recall_at`, and preserve the sources behind the result.
+>
+> The project is Apache 2.0 and available for Python, TypeScript, MCP, and local deployment. Our favorite demo shows how an agent memory layer can leak future information into a historical backtest, then fixes the contamination with point-in-time retrieval.
+>
+> We are looking for direct product criticism, integration feedback, and teams with one consequential workflow that must remain reconstructable.
+
+Topics: `Artificial Intelligence`, `Developer Tools`, `Open Source`, `Data Infrastructure`, `Compliance`
+
+Media order:
+
+1. Existing Lians Open Graph card.
+2. Lookahead-bias result chart.
+3. Decision receipt screenshot.
+4. Compatibility test screenshot.
+5. Installation and `recall_at` code sample.
+
+## LinkedIn launch post
+
+> Most AI audit trails answer: what did the system output?
+>
+> The harder question is: what could it actually know when it acted?
+>
+> Facts get corrected. Policies change. Permissions move. Agent memory keeps accumulating. If you replay an old decision against today's state, you can produce a confident explanation for a decision the system never made.
+>
+> We built Lians to reconstruct the historical state behind consequential AI decisions.
+>
+> The strongest example is a reproducible lookahead-bias demo. The same agent backtest, on the same seeded synthetic data, looks excellent when its memory can retrieve future facts. Pin retrieval to decision time and the apparent edge disappears. Every contaminated retrieval has a timestamped receipt.
+>
+> Lians is Apache 2.0, supports point-in-time recall, ships through Python and MCP, and now has merged LangChain documentation plus an official MCP Registry listing.
+>
+> Try the demo: https://www.lians.ai/blog/backtest-lookahead
+>
+> Explore the project: https://github.com/Lians-ai/Lians
+
+## arXiv readiness and publication gate
+
+The regulated-memory preprint is still a draft in pull request 26. It must not be described as an indexed arXiv paper.
+
+Before submission:
+
+- Merge the paper source and freeze its comparison artifact.
+- Re-run every table against the named public versions.
+- Add a limitations section that distinguishes executable tests from documentation checks.
+- Confirm all author names, affiliations, ORCID identifiers, and the corresponding-author email.
+- Select the most defensible arXiv category and confirm whether endorsement is required.
+- Build the source through arXiv's TeX environment and inspect the generated PDF.
+- Submit, retain the submission identifier, and wait for moderation before announcing an arXiv URL.
+
+Announcement after indexing:
+
+> We published the methods behind Lians' regulated-memory evaluation. The paper focuses on five properties that ordinary relevance benchmarks miss: point-in-time recall, stale-revision suppression, erasure evidence, audit reconstruction, and lookahead guards. Code, adapters, and evidence artifacts are public so every result can be challenged.
+
+## Launch sequence
+
+1. Deploy the measurement, sitemap, schemas, contact form, and newsletter capture.
+2. Confirm all launch URLs return 200 and the funnel report receives aggregate events.
+3. Submit the expanded sitemap and request indexing for the homepage, Product, Pricing, Docs, and comparison pages.
+4. Publish Show HN first and respond to substantive comments.
+5. Publish the LinkedIn post once the HN discussion has a stable URL.
+6. Schedule Product Hunt for the next eligible launch day with all media attached.
+7. Send roundup wave one with the live launch and benchmark links.
+8. Publish the first Decision Evidence Brief to the owned list.


### PR DESCRIPTION
## Summary

- add the public launch command center for Hacker News, Product Hunt, LinkedIn, and arXiv readiness
- add coordinated amplification copy for existing integration and release wins
- add the first Decision Evidence Brief and editorial outreach wave
- record verified package and directory maintenance state, including same-plan limits

## Verification

- confirmed all five artifacts match the prepared campaign sources
- ran git diff --check
- scanned every artifact for em dash characters and found none