### PR TITLE
ci: align npm trusted publisher environment

### DIFF
--- a/.github/workflows/publish-lian-npm.yml
+++ b/.github/workflows/publish-lian-npm.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:


### PR DESCRIPTION
Adds the protected npm environment to the publish job so the GitHub trusted-publisher claim matches the npm package configuration.\n\nVerification: YAML parses successfully and git diff --check passes.