### PR TITLE
feat: enable universal Lians memory

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -90,7 +90,7 @@ jobs:
     timeout-minutes: 45
     environment:
       name: production
-      url: https://agentmem-lotus.fly.dev
+      url: https://mcp.lians.ai
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
@@ -409,8 +409,13 @@ jobs:
       - name: Run public production smoke checks
         run: |
           python scripts/check_production_deployment.py \
-            --base-url https://agentmem-lotus.fly.dev \
+            --base-url https://mcp.lians.ai \
             --expected-build-sha "$GITHUB_SHA"
+
+      - name: Verify the public OpenAI MCP boundary
+        run: |
+          python scripts/check_openai_plugin_endpoint.py \
+            --resource-url https://mcp.lians.ai/mcp
 
       - name: Publish rollback command
         if: always()

--- a/agentmem/tests/test_fly_deploy_workflow_contract.py
+++ b/agentmem/tests/test_fly_deploy_workflow_contract.py
@@ -85,3 +85,16 @@ def test_post_deploy_release_identity_and_smoke_gates_remain() -> None:
     assert "FLY_MACHINE_EXEC_TOKEN" not in workflow
     assert "scripts/check_production_deployment.py" in workflow
     assert '--expected-build-sha "$GITHUB_SHA"' in workflow
+    assert "--base-url https://mcp.lians.ai" in workflow
+    assert "scripts/check_openai_plugin_endpoint.py" in workflow
+    assert "--resource-url https://mcp.lians.ai/mcp" in workflow
+
+
+def test_production_config_enables_hosted_mcp_with_personal_tenancy() -> None:
+    with FLY_CONFIG_PATH.open("rb") as handle:
+        config = tomllib.load(handle)
+
+    environment = config["env"]
+    assert environment["HOSTED_MCP_ENABLED"] == "true"
+    assert environment["HOSTED_MCP_RESOURCE_URL"] == "https://mcp.lians.ai"
+    assert environment["HOSTED_MCP_TENANT_CLAIM"] == "sub"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -35,11 +35,11 @@ alembic upgrade head
 
 # Verify schema version
 alembic current
-# Expected: 0028_decision_envelopes (head)
+# Expected: 0030_force_hosted_mcp_rls (head)
 ```
 
-Before deploying migration 0028, complete the disposable staging-data
-rehearsal in `docs/migration-0028-staging-rehearsal.md`.
+Before deploying a new migration head, complete the guarded staging database
+workflow and verify the exact revision required by the production workflow.
 
 For the exact Fly.io production gate, release sequence, abort criteria, and
 application rollback procedure, use `docs/production-release.md`.

--- a/docs/production-release.md
+++ b/docs/production-release.md
@@ -9,15 +9,14 @@ production application `agentmem-lotus`.
 |---|---|
 | Application | Fly app `agentmem-lotus` |
 | Database | Fly Postgres app `agentmem-lotus-db` |
-| Public health endpoint | `https://agentmem-lotus.fly.dev/readyz` |
+| Public health endpoint | `https://mcp.lians.ai/readyz` |
 | Deployment branch | `master` only |
 | Deployment workflow | **Production deploy** |
 | Rollback workflow | **Production rollback** |
-| Expected schema after release | `0028_decision_envelopes` |
+| Expected schema after release | `0030_force_hosted_mcp_rls` |
 
-The production database is currently at `0020_decision_records`. The release
-command advances it through migrations 0021 to 0028 before the application
-image is promoted.
+The production workflow migrates the database to the reviewed Alembic head
+`0030_force_hosted_mcp_rls` before the application image is promoted.
 
 ## Controls already enforced
 
@@ -32,8 +31,8 @@ image is promoted.
   database-volume snapshot before deploying. If Fly coalesces that request,
   it accepts only an existing `created` snapshot no older than two hours.
 - Fly gates promotion on `/readyz`.
-- The workflow verifies revision `0028_decision_envelopes` and the public API
-  surface after deployment.
+- The workflow verifies revision `0030_force_hosted_mcp_rls`, the public API
+  surface, and the unauthenticated OpenAI MCP boundary after deployment.
 
 ## Go/no-go checklist
 
@@ -43,10 +42,10 @@ All items must be true before starting the workflow:
 - [ ] The production workflow files on `master` match the reviewed release
       candidate.
 - [ ] The staging database check passes at revision
-      `0028_decision_envelopes`.
+      `0030_force_hosted_mcp_rls`.
 - [ ] A sanitized staging-data migration rehearsal has passed.
 - [ ] The release-candidate container build succeeds.
-- [ ] `https://agentmem-lotus.fly.dev/readyz` is healthy before the release.
+- [ ] `https://mcp.lians.ai/readyz` is healthy before the release.
 - [ ] Fly reports exactly one attached, encrypted production database volume.
 - [ ] A recent automatic database snapshot exists.
 - [ ] The on-call operator has the prior complete Fly image reference.
@@ -63,7 +62,7 @@ Do not proceed if any item is unknown.
 5. Let the protected production job complete its five-minute wait.
 6. Confirm the workflow records a prior image and selects a `created`
    database snapshot no older than two hours.
-7. Confirm the Fly release migration reaches `0028_decision_envelopes`.
+7. Confirm the Fly release migration reaches `0030_force_hosted_mcp_rls`.
 8. Confirm the deployment and public smoke checks pass.
 9. Inspect `/health`, `/readyz`, error rate, and request latency for at least
    15 minutes.
@@ -75,7 +74,7 @@ Abort or stop promotion if:
 - the staging database check fails;
 - no production snapshot is both `created` and less than two hours old;
 - the release command fails or reports any revision other than
-  `0028_decision_envelopes`;
+  `0030_force_hosted_mcp_rls`;
 - `/readyz` does not become healthy within the workflow timeout;
 - the public OpenAPI surface is incomplete;
 - authenticated traffic shows a material increase in errors or latency.
@@ -86,9 +85,9 @@ Use the **Production rollback** workflow with the prior image reference
 published by the deploy job. Run it from `master` and type `ROLLBACK`.
 
 Application rollback intentionally uses `--skip-release-command`. Do not run
-an Alembic downgrade during incident response. Migrations 0021 through 0028
-are additive, so the prior application image can run against the advanced
-schema while the incident is investigated. A database restore is a separate,
+an Alembic downgrade during incident response. Migrations through 0030 are
+additive, so the prior application image can run against the advanced schema
+while the incident is investigated. A database restore is a separate,
 last-resort recovery procedure.
 
 After rollback, verify `/livez`, `/health`, and `/readyz`, then preserve the
@@ -96,12 +95,10 @@ failed release logs and snapshot identifiers.
 
 ## Known nonblocking follow-ups
 
-- Redis is currently disabled in production, so the recall cache is not
-  active. The application remains healthy without it, but Redis should be
-  provisioned and load-tested before claiming cached recall latency.
+- Redis is required for hosted-MCP rate limits. Confirm its staged secret is
+  deployed and reachable before enabling the public MCP surface.
 - Fly automatic snapshots retain five days. Enable off-platform WAL/archive
   backups before treating the current setup as the final disaster-recovery
   posture.
-- Add a named required reviewer to the GitHub `production` environment when a
-  second release operator is available. The non-bypassable wait timer remains
-  the active protection until then.
+- Keep the named independent reviewer and self-review prevention on the GitHub
+  `production` environment; do not bypass either release control.

--- a/fly.toml
+++ b/fly.toml
@@ -47,9 +47,9 @@ primary_region = 'sjc'  # colocated with agentmem-lotus-db — cross-region DB c
   CORS_ORIGINS                  = "https://lians.ai,https://www.lians.ai"
   AIRGAP_MODE                   = "false"
   RETENTION_PRUNE_INTERVAL_HOURS = "24"
-  # Universal plugin stays fail-closed until OAuth issuer/JWKS secrets and the
-  # stable mcp.lians.ai DNS/TLS route are provisioned.
-  HOSTED_MCP_ENABLED            = "false"
+  # Public hosted MCP uses the stable mcp.lians.ai origin and per-user OAuth
+  # subjects; issuer and JWKS endpoints are supplied as protected Fly secrets.
+  HOSTED_MCP_ENABLED            = "true"
   HOSTED_MCP_RESOURCE_URL       = "https://mcp.lians.ai"
   HOSTED_MCP_SERVICE_DOCUMENTATION_URL = "https://www.lians.ai/privacy"
   HOSTED_MCP_RETENTION_DAYS     = "365"
@@ -63,7 +63,7 @@ primary_region = 'sjc'  # colocated with agentmem-lotus-db — cross-region DB c
   HOSTED_MCP_MAX_STORED_BYTES_PER_TENANT = "40000000"
   HOSTED_MCP_MAX_WRITE_BYTES_PER_DAY = "1000000"
   HOSTED_MCP_MAX_AUDIT_EVENTS_PER_DAY = "5000"
-  HOSTED_MCP_TENANT_CLAIM       = "tenant_id"
+  HOSTED_MCP_TENANT_CLAIM       = "sub"
   HOSTED_MCP_MAX_TOKEN_LIFETIME_SECONDS = "3600"
 
 [[vm]]


### PR DESCRIPTION
## What changed

- enable the hosted Lians Memory MCP on the canonical `mcp.lians.ai` origin
- bind personal-memory tenancy to the verified OAuth `sub` claim
- make production deployment smoke-test the public domain and unauthenticated MCP auth boundary
- update the production runbooks to Alembic head `0030_force_hosted_mcp_rls`

## Why

The universal OpenAI plugin implementation is merged and its database migration has passed staging. This follow-up is the reviewed, auditable switch that exposes the production MCP only after `auth.lians.ai` was verified and made Auth0's default domain.

## Validation

- 113 focused hosted MCP, OAuth, endpoint, submission-bundle, and Fly workflow tests passed
- universal plugin validator passed
- Ruff checks passed on the touched Python test
- `git diff --check` passed

## Release sequence

This PR must be reviewed and merged before the second protected production deployment. The deployment workflow now fails closed unless `https://mcp.lians.ai/mcp` publishes valid protected-resource metadata and the expected unauthenticated Bearer challenge.