### PR TITLE
fix: tolerate Redis read latency in rate limiting

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -417,6 +417,12 @@ jobs:
           python scripts/check_openai_plugin_endpoint.py \
             --resource-url https://mcp.lians.ai/mcp
 
+      - name: Verify the MCP boundary preserved production health
+        run: |
+          python scripts/check_production_deployment.py \
+            --base-url https://mcp.lians.ai \
+            --health-only
+
       - name: Publish rollback command
         if: always()
         run: |

--- a/agentmem/src/lians/cache.py
+++ b/agentmem/src/lians/cache.py
@@ -36,6 +36,8 @@ from typing import Any, Iterator, Optional
 _redis_client: Any = None
 logger = logging.getLogger("agentmem.cache")
 _CACHE_SCHEMA_VERSION = "scoring-v2"
+_REDIS_CONNECT_TIMEOUT_SECONDS = 1
+_REDIS_SOCKET_TIMEOUT_SECONDS = 3
 _FIXED_WINDOW_INCREMENT_LUA = """
 local count = redis.call('INCRBY', KEYS[1], ARGV[1])
 local ttl = redis.call('TTL', KEYS[1])
@@ -87,8 +89,12 @@ def _get_redis() -> Any:
         _redis_client = aioredis.from_url(
             get_settings().redis_url,
             decode_responses=True,
-            socket_connect_timeout=1,
-            socket_timeout=1,
+            socket_connect_timeout=_REDIS_CONNECT_TIMEOUT_SECONDS,
+            socket_timeout=_REDIS_SOCKET_TIMEOUT_SECONDS,
+            # The fixed-window script mutates state atomically. A timed-out
+            # reply may still mean Redis committed the increment, so retrying
+            # could double-count one request.
+            retry_on_timeout=False,
         )
     return _redis_client
 

--- a/agentmem/tests/test_fly_deploy_workflow_contract.py
+++ b/agentmem/tests/test_fly_deploy_workflow_contract.py
@@ -108,6 +108,20 @@ def test_post_deploy_release_identity_and_smoke_gates_remain() -> None:
     assert "--resource-url https://mcp.lians.ai/mcp" in workflow
 
 
+def test_mcp_boundary_is_followed_by_a_fresh_health_gate() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    boundary = "python scripts/check_openai_plugin_endpoint.py"
+    post_boundary_gate = (
+        "python scripts/check_production_deployment.py \\\n"
+        "            --base-url https://mcp.lians.ai \\\n"
+        "            --health-only"
+    )
+
+    assert workflow.count(boundary) == 1
+    assert workflow.count(post_boundary_gate) == 1
+    assert workflow.index(boundary) < workflow.index(post_boundary_gate)
+
+
 def test_production_config_enables_hosted_mcp_with_personal_tenancy() -> None:
     with FLY_CONFIG_PATH.open("rb") as handle:
         config = tomllib.load(handle)

--- a/agentmem/tests/test_middleware.py
+++ b/agentmem/tests/test_middleware.py
@@ -336,6 +336,42 @@ class TestRateLimitMiddleware:
         assert second.status_code == 429
         assert second.headers["Retry-After"] == "60"
 
+    async def test_redis_timeout_is_not_retried_and_records_one_fallback(self):
+        """A timed-out mutating script may have committed, so never retry it."""
+        from fastapi import FastAPI
+        from src.lians.middleware import RateLimitMiddleware
+
+        limited_app = FastAPI()
+
+        @limited_app.get("/limited")
+        async def limited():
+            return {"ok": True}
+
+        limited_app.add_middleware(
+            RateLimitMiddleware,
+            requests_per_minute=1,
+            fingerprint_secret="test-rate-limit-fingerprint-secret",
+        )
+        with (
+            patch("src.lians.cache._get_redis") as mock_redis,
+            patch("src.lians.degradation.record_degradation") as degradation,
+        ):
+            redis = AsyncMock()
+            redis.eval = AsyncMock(side_effect=TimeoutError("slow Redis reply"))
+            mock_redis.return_value = redis
+            async with AsyncClient(
+                transport=ASGITransport(app=limited_app),
+                base_url="http://test",
+            ) as local_client:
+                response = await local_client.get(
+                    "/limited", headers={"X-API-Key": "fallback-key"}
+                )
+
+        assert response.status_code == 200
+        assert response.headers["X-RateLimit-Remaining"] == "0"
+        assert redis.eval.await_count == 1
+        degradation.assert_called_once_with("rate_limit", "redis_unavailable")
+
     def test_api_key_discriminator_is_keyed_and_stable(self):
         """Bucket IDs must not expose a reusable digest of the API key."""
         from src.lians.middleware import RateLimitMiddleware

--- a/agentmem/tests/test_recall_cache.py
+++ b/agentmem/tests/test_recall_cache.py
@@ -1,9 +1,25 @@
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from src.lians import cache
+
+
+def test_redis_client_allows_bounded_read_jitter_without_command_retry(monkeypatch):
+    from redis import asyncio as aioredis
+
+    client = object()
+    from_url = Mock(return_value=client)
+    monkeypatch.setattr(aioredis, "from_url", from_url)
+    monkeypatch.setattr(cache, "_redis_client", None)
+
+    assert cache._get_redis() is client
+    assert from_url.call_count == 1
+    _, kwargs = from_url.call_args
+    assert kwargs["socket_connect_timeout"] == 1
+    assert kwargs["socket_timeout"] == 3
+    assert kwargs["retry_on_timeout"] is False
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- increase only the shared Redis read timeout from 1s to 3s while retaining the 1s connect timeout
- explicitly disable command retry because the mutating rate-limit Lua script may commit before a reply timeout
- add regression coverage for client configuration and the single-attempt bounded fallback
- re-check production health after the public MCP boundary probe during deployment

## Production evidence

After the hosted MCP deployment, an unauthenticated `POST /mcp` reproducibly completed with the expected 401 but timed out waiting for the Redis rate-limit response at roughly 1.0-1.1s. The atomic script still appeared to commit its short-lived key, so replaying it would risk double-counting. Readiness then reported `degraded` for the five-minute degradation window.

This patch preserves the existing atomic script and fallback behavior, adds bounded read-latency headroom, and makes the deployment workflow fail if the MCP probe causes a health degradation.

## Validation

- `1183 passed, 23 skipped` full server suite
- `88 passed` focused cache, middleware, hosted MCP, deployment workflow, and smoke-check suite
- CI-fatal Ruff selection passed
- workflow YAML parsed successfully
- `git diff --check` passed
- two independent read-only reviews found no blocker