### PR TITLE
Add canonical product manifest and remove legacy owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,17 @@
-* @Lians-ai @Ds6826 @ebeirne
+* @Lians-ai @ebeirne
 
-/.github/ @Lians-ai @Ds6826 @ebeirne
-/.gitleaksignore @Lians-ai @Ds6826 @ebeirne
-/Dockerfile @Lians-ai @Ds6826 @ebeirne
-/fly.toml @Lians-ai @Ds6826 @ebeirne
-/agentmem/alembic/ @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/api/deps.py @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/api/routes_admin.py @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/api/routes_provisioning.py @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/config.py @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/crypto.py @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/middleware.py @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/openai_oauth.py @Lians-ai @Ds6826 @ebeirne
-/agentmem/src/lians/webhook_service.py @Lians-ai @Ds6826 @ebeirne
-/Dockerfile.glama @Lians-ai @Ds6826 @ebeirne
-/k8s/ @Lians-ai @Ds6826 @ebeirne
+/.github/ @Lians-ai @ebeirne
+/.gitleaksignore @Lians-ai @ebeirne
+/Dockerfile @Lians-ai @ebeirne
+/fly.toml @Lians-ai @ebeirne
+/agentmem/alembic/ @Lians-ai @ebeirne
+/agentmem/src/lians/api/deps.py @Lians-ai @ebeirne
+/agentmem/src/lians/api/routes_admin.py @Lians-ai @ebeirne
+/agentmem/src/lians/api/routes_provisioning.py @Lians-ai @ebeirne
+/agentmem/src/lians/config.py @Lians-ai @ebeirne
+/agentmem/src/lians/crypto.py @Lians-ai @ebeirne
+/agentmem/src/lians/middleware.py @Lians-ai @ebeirne
+/agentmem/src/lians/openai_oauth.py @Lians-ai @ebeirne
+/agentmem/src/lians/webhook_service.py @Lians-ai @ebeirne
+/Dockerfile.glama @Lians-ai @ebeirne
+/k8s/ @Lians-ai @ebeirne

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What changed
+
+<!-- Summarize the change and its user or developer impact. -->
+
+## Validation
+
+<!-- List the checks you ran. -->
+
+## Product record
+
+- [ ] I updated `product-manifest.json` if this changes Lians capabilities, positioning, workflow, or availability, or this change does not affect the product record.

--- a/agentmem/tests/test_product_manifest.py
+++ b/agentmem/tests/test_product_manifest.py
@@ -1,0 +1,41 @@
+import json
+from datetime import date
+from pathlib import Path
+
+
+MANIFEST_PATH = Path(__file__).parents[2] / "product-manifest.json"
+
+
+def _bounded_string(value: object, *, maximum: int) -> bool:
+    return isinstance(value, str) and bool(value.strip()) and len(value) <= maximum
+
+
+def test_product_manifest_matches_console_contract() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert manifest["schemaVersion"] == 1
+    date.fromisoformat(manifest["updatedAt"])
+    assert manifest["source"] == {
+        "repository": "Lians-ai/Lians",
+        "branch": "master",
+    }
+
+    product = manifest["product"]
+    assert _bounded_string(product["name"], maximum=80)
+    assert _bounded_string(product["category"], maximum=160)
+    assert _bounded_string(product["summary"], maximum=600)
+
+    workflow = product["workflow"]
+    assert 1 <= len(workflow) <= 8
+    for step in workflow:
+        assert set(step) == {"label", "detail"}
+        assert _bounded_string(step["label"], maximum=80)
+        assert _bounded_string(step["detail"], maximum=400)
+
+    surfaces = product["surfaces"]
+    assert 1 <= len(surfaces) <= 8
+    for surface in surfaces:
+        assert set(surface) == {"label", "status", "detail"}
+        assert _bounded_string(surface["label"], maximum=80)
+        assert _bounded_string(surface["status"], maximum=80)
+        assert _bounded_string(surface["detail"], maximum=400)

--- a/product-manifest.json
+++ b/product-manifest.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "updatedAt": "2026-08-11",
+  "source": {
+    "repository": "Lians-ai/Lians",
+    "branch": "master"
+  },
+  "product": {
+    "name": "Lians",
+    "category": "Decision evidence and reconstruction for regulated AI",
+    "summary": "Lians keeps a portable, provider-neutral record of what an AI system knew, retrieved, did, and reviewed so consequential decisions can be reconstructed and verified later.",
+    "workflow": [
+      {
+        "label": "Capture",
+        "detail": "Record prompts, retrieved context, tool calls, outputs, policies, and review events as a decision is made."
+      },
+      {
+        "label": "Reconstruct",
+        "detail": "Replay the evidence trail to show what the system knew and why it produced a consequential result."
+      },
+      {
+        "label": "Verify",
+        "detail": "Check evidence integrity, policy application, reviewer actions, and the exact chain behind a decision."
+      },
+      {
+        "label": "Monitor",
+        "detail": "Track later changes to evidence, policies, models, and outcomes without losing the original record."
+      }
+    ],
+    "surfaces": [
+      {
+        "label": "Library",
+        "status": "Available",
+        "detail": "Local-first Python library backed by SQLite for embedding decision evidence directly in an application."
+      },
+      {
+        "label": "Self-hosted server",
+        "status": "Available",
+        "detail": "Team deployment backed by Postgres and pgvector for shared evidence, controls, and investigation workflows."
+      },
+      {
+        "label": "Cloud",
+        "status": "Early access",
+        "detail": "Managed Lians service for teams that want the evidence layer operated for them."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What changed

- adds a versioned `product-manifest.json` as the owner console's source of truth
- validates the manifest contract in the product test suite
- adds a pull-request reminder to keep the product record current when capabilities or availability change
- removes `Ds6826` from product repository code ownership so reviews no longer depend on that account

## Why

The owner console currently receives live repository activity but its product overview is embedded in the website. Moving the overview into the Lians product repository lets product changes flow to the console without a website code change. The ownership cleanup keeps the repository aligned with the canonical Lians organization and owner account.

## Validation

- `python -m pytest agentmem/tests/test_product_manifest.py -q`
- `python -m json.tool product-manifest.json`
- full repository CI matrix
- `git diff --check`
