### PR TITLE
Add Glama server ownership metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "maintainers": [
-    "Lians-ai"
-  ]
+  "maintainers": ["Lians-ai"]
 }

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "Lians-ai"
+  ]
+}


### PR DESCRIPTION
## What changed

- add the root glama.json metadata Glama uses to verify MCP server ownership
- identify the Lians-ai repository account as the listing maintainer

This unblocks claiming the Lians server listing so we can publish a release, configure the server, and generate Glama quality scores.

## Validation

- parsed glama.json successfully as JSON
- ran git diff --check

## Product record

- [x] This change does not affect the product record; it only adds directory ownership metadata.