### PR TITLE
docs: show verified Glama MCP quality score

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="https://pypi.org/project/lians-sdk"><img src="https://img.shields.io/pypi/v/lians-sdk?label=PyPI" alt="PyPI version"></a>
   <a href="https://www.npmjs.com/package/@lians-ai/lians"><img src="https://img.shields.io/npm/v/%40lians-ai%2Flians?label=npm" alt="npm version"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians"><img src="https://img.shields.io/badge/MCP-Official%20Registry-blueviolet" alt="MCP Official Registry"></a>
+  <a href="https://glama.ai/mcp/servers/Lians-ai/Lians"><img src="https://glama.ai/mcp/servers/Lians-ai/Lians/badges/score.svg" alt="Glama MCP quality score"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 license"></a>
 </p>
 


### PR DESCRIPTION
Adds the live Glama MCP score badge beside the official registry badge now that the server is claimed, released, tested, and all nine tools have A grades.\n\nValidation:\n- badge endpoint returns HTTP 200 (image/svg+xml)\n- git diff --check passes