### PR TITLE
docs: add GitHub follow call to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   <a href="docs/install.md">Install</a> ·
   <a href="https://github.com/Lians-ai/Lians/tree/master/docs">Docs</a> ·
   <a href="https://github.com/Lians-ai/Lians/issues">Issues</a> ·
-  <a href="https://github.com/Lians-ai/Lians/stargazers"><strong>Star Lians</strong></a>
+  <a href="https://github.com/Lians-ai/Lians/stargazers"><strong>Star Lians</strong></a> ·
+  <a href="https://github.com/Lians-ai"><strong>Follow @Lians-ai</strong></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- add a single `Follow @Lians-ai` link beside the existing `Star Lians` link
- keep the README's simple product positioning and all website content unchanged

## Verification
- `git diff --check`
- confirmed `https://github.com/Lians-ai` resolves to the public project profile

Disclosure: this change was prepared with AI assistance and reviewed against the live README.