### PR TITLE
feat: package Lians as a Gemini CLI extension

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,16 @@
+{
+  "name": "lians",
+  "version": "0.5.0",
+  "description": "Open-source, local-first memory for any AI agent.",
+  "mcpServers": {
+    "lians": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "lians-sdk[mcp]==0.5.0",
+        "lians-memory-mcp"
+      ],
+      "timeout": 120000
+    }
+  }
+}

--- a/integrations/gemini/README.md
+++ b/integrations/gemini/README.md
@@ -7,9 +7,16 @@ memory is not locked to Gemini or its model provider.
 ## Install
 
 1. Install [`uv`](https://docs.astral.sh/uv/).
-2. Merge [`settings.example.json`](settings.example.json) into
-   `~/.gemini/settings.json`.
+2. Install the extension:
+
+   ```bash
+   gemini extensions install https://github.com/Lians-ai/Lians
+   ```
+
 3. Restart Gemini CLI, then run `/mcp list` to confirm that `lians` is connected.
+
+For a manual setup, merge [`settings.example.json`](settings.example.json)
+into `~/.gemini/settings.json`.
 
 The Community starter profile exposes only two tools:
 


### PR DESCRIPTION
## Summary
- add a root `gemini-extension.json` for direct Gemini CLI installation
- launch the published, credential-free `lians-memory-mcp` wrapper through `uvx`
- document the one-command extension install path while retaining manual setup

## Verification
- `npx -y @google/gemini-cli@latest extensions validate .`
- Gemini CLI 0.55.1: `Extension . has been successfully validated.`
- live PyPI 0.5.0 MCP handshake exposes exactly `remember` and `recall` through `lians-memory-mcp`
- `git diff --check`

## After merge
Add the `gemini-cli-extension` GitHub topic so the official Gemini CLI gallery crawler can discover the repository. Google’s current docs say no issue or email submission is required.

Disclosure: this extension was prepared with AI assistance and validated with the official Gemini CLI.