### PR TITLE
Document Lians Personal for individual users

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://www.lians.ai/">Website</a> ·
   <a href="docs/install.md">Install</a> ·
   <a href="https://github.com/Lians-ai/Lians/tree/master/docs">Docs</a> ·
+  <a href="https://www.lians.ai/pricing">Pricing</a> ·
   <a href="https://github.com/Lians-ai/Lians/issues">Issues</a> ·
   <a href="https://github.com/Lians-ai/Lians/stargazers"><strong>Star Lians</strong></a> ·
   <a href="https://github.com/Lians-ai"><strong>Follow @Lians-ai</strong></a>
@@ -33,6 +34,21 @@ Your agent can remember a useful fact now and recall it when it matters later.
 
 Lians is a memory layer, not another assistant. Your agent and model stay the
 same; Lians gives them a place to remember.
+
+## Start free. Upgrade only when it saves you time.
+
+- **Community is free:** run Lians locally or self-host it with no account,
+  API key, or software license fee.
+- **Lians Personal is $10/month:** get a managed account, a private hosted
+  memory workspace, 100,000 writes and 50,000 recalls each month, export and
+  deletion controls, and email setup support. Cancel anytime.
+
+[Install the free local version](docs/easy-install.md) or
+[get Lians Personal](https://www.lians.ai/upgrade?plan=starter).
+
+Lians does not change the underlying model or promise fewer tokens on every
+task. It can avoid resending old conversation when a small relevant recall is
+enough; verify the result on your own workflow.
 
 <p align="center">
   <a href="https://github.com/Lians-ai/Lians/releases/download/lians-memory-openai-demo-v1.0.0/Lians-Memory-OpenAI-submission-demo-v1.0.0.mp4"><strong>▶ Watch the 33-second demo: remember, recall, and confirmed deletion</strong></a>
@@ -179,6 +195,7 @@ Java, C, framework adapters, and self-hosting.
 | Add memory without a terminal | [Lians Easy](docs/easy-install.md) |
 | Give an existing AI client memory from a terminal | [MCP setup](#developer-setup-add-memory-through-mcp) |
 | Add local memory inside Python | [`LocalLiansClient`](agentmem/sdk/python) |
+| Use managed private memory without running a server | [Lians Personal — $10/month](https://www.lians.ai/upgrade?plan=starter) |
 | Connect Python or TypeScript to a Lians server | [Language SDKs](docs/install.md#language-sdks) |
 | Use Pydantic AI, LangChain, LangGraph, CrewAI, OpenAI Agents, or AutoGen | [Framework integrations](docs/install.md#framework-integrations) |
 | Run the full service yourself | [Self-host Lians](docs/install.md#self-host-lians) |

--- a/docs/community-cloud-boundary.md
+++ b/docs/community-cloud-boundary.md
@@ -20,10 +20,13 @@ practical. For example, the Cursor and Gemini starter profiles expose only
 `remember` and `recall`, and the Codex plugin injects a score-gated, bounded
 slice of memory.
 
-## Lians Cloud and enterprise packages
+## Lians Personal and organization packages
 
 Commercial value sits at the managed service and organizational boundary:
 
+- Lians Personal at $10 per month for one managed account, a private memory
+  workspace, 100,000 writes and 50,000 recalls per month, memory controls, and
+  email setup support;
 - hosted continuity across supported clients and devices;
 - shared/team memory and organization administration;
 - higher managed storage, write, recall, and operational limits;
@@ -33,9 +36,11 @@ Commercial value sits at the managed service and organizational boundary:
 - private networking, residency, customer-managed keys, dedicated deployment,
   or air-gap assistance where contracted.
 
-Availability and limits are contract- and environment-specific. A capability
-must not be presented as generally available until it is operating in the
-customer's environment and covered by the applicable order form or plan.
+The public Lians Personal allowance is enforced through the production
+subscription entitlement. Organization capabilities and limits are contract-
+and environment-specific. A capability must not be presented as generally
+available until it is operating in the customer's environment and covered by
+the applicable order form or plan.
 
 ## Licensing boundary
 

--- a/docs/pricing-tiers.md
+++ b/docs/pricing-tiers.md
@@ -5,8 +5,9 @@ published under Apache 2.0 stays under Apache 2.0; commercial packages sell
 managed capacity, organizational operation, evidence services, deployment
 assurance, and contractual commitments.
 
-This is a packaging guide, not a public price list. Confirm availability,
-limits, pricing, and contractual terms before quoting a customer.
+Community and Lians Personal below are public self-serve offers. Confirm the
+current checkout before quoting a price or allowance. Organization packages
+remain scoped to the deployment, workflow, evidence, and support boundary.
 
 ## Community
 
@@ -27,19 +28,25 @@ Community does not include a Lians-hosted production tenant, cross-device
 account, team administration, higher hosted limits, an SLA, or managed evidence
 review.
 
-## Managed Developer
+## Lians Personal — $10/month
 
-*For developers who want hosted continuity without operating the memory layer.*
+*For one person who wants hosted continuity without operating the memory layer.*
 
-**Deployment:** Lians-managed service, where available
+**Deployment:** Lians-managed service through a monthly self-serve subscription
 
-**Commercial value:**
+**Includes:**
 
-- Hosted continuity across supported clients and devices
-- Managed identity and storage
-- Defined hosted usage allowance
-- Upgrade path to higher managed limits
-- Standard service support
+- One managed Lians account and private memory workspace
+- Hosted continuity across supported API and MCP connections
+- 100,000 memory writes and 50,000 recalls per month
+- Memory inspection, correction, deletion, and export controls
+- Email setup support
+- Monthly billing with cancellation at any time
+
+Personal does not change the underlying model, increase a provider quota, or
+promise lower token use on every task. It can reduce repeated context when a
+small relevant recall replaces conversation history that would otherwise be
+resent, and results should be verified on the user's workflow.
 
 ## Team
 
@@ -93,10 +100,10 @@ strict residency, isolation, or procurement requirements.*
 
 ## Pricing principle
 
-Developer service may be usage-based. Institutional pricing should be tied to
-the deployment boundary, managed limits, support obligation, evidence scope,
-and contractual risk. Do not quote a hosted tier or limit until enforcement and
-entitlements are active for that environment.
+Lians Personal is the simple public on-ramp. Institutional pricing should be
+tied to the deployment boundary, managed limits, support obligation, evidence
+scope, and contractual risk. Do not quote an organization tier or limit until
+enforcement and entitlements are active for that environment.
 
 See the [Community and commercial boundary](community-cloud-boundary.md) and
 the [managed billing design](billing.md).


### PR DESCRIPTION
## What changed

- adds a clear free-versus-managed choice near the top of the product README
- links GitHub visitors directly to the free installer or the $10/month Personal checkout
- documents Personal limits, memory controls, cancellation, and the honest token-efficiency boundary
- aligns the repository packaging and Community/commercial boundary docs with the live offer

## Why

The repository already explains Lians well technically, but it did not give an everyday developer or student a simple paid path. This change keeps local and self-hosted use free while making the optional managed plan visible without replacing the existing setup documentation.

## Validation

- `python -m pytest agentmem/tests/test_distribution_contract.py -q` — 6 passed
- `git diff --check` — clean