### PR TITLE
docs: add OpenCode memory setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Use the exact setup guide for
 [Cursor](integrations/cursor),
 [Gemini CLI](integrations/gemini),
 [Claude Code](integrations/lians-plugin), or
+[OpenCode](integrations/opencode), or
 [Codex](plugins/lians-memory). Remove `LIANS_MCP_ENABLED_TOOLS` when you want
 the advanced temporal and audit tools too.
 

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,50 @@
+# Lians Memory for OpenCode
+
+Give OpenCode durable local memory through its native MCP support. The same
+Lians store can support other compatible agents, so your memory is not tied to
+OpenCode or a model provider.
+
+## Install
+
+1. Install [`uv`](https://docs.astral.sh/uv/).
+2. Merge [`opencode.example.json`](opencode.example.json) into your OpenCode
+   configuration.
+3. Restart OpenCode and run:
+
+   ```bash
+   opencode mcp list
+   ```
+
+   Confirm that `lians` is connected.
+
+4. Try these prompts in separate chats:
+
+   ```text
+   Remember that this project uses Python 3.12 and pytest.
+   ```
+
+   ```text
+   What Python version and test runner does this project use? Use Lians memory.
+   ```
+
+Local mode needs no Lians account or API key and stores memory in
+`~/.lians/mcp.db`.
+
+## What OpenCode can use
+
+The starter profile exposes five tools:
+
+- `remember` stores a durable fact, preference, constraint, or decision.
+- `recall` retrieves a small set of relevant, current memories.
+- `list_memories` lets you inspect what Lians currently knows.
+- `correct_memory` replaces stale information without hiding its history.
+- `forget_memory` permanently erases one memory after explicit confirmation.
+
+Remove `LIANS_MCP_ENABLED_TOOLS` from the configuration when you want the
+advanced temporal and audit tools too.
+
+OpenCode documents local MCP servers in its
+[MCP server guide](https://opencode.ai/docs/mcp-servers/). Lians follows that
+documented `type`, `command`, `enabled`, and `environment` format.
+
+Repository: https://github.com/Lians-ai/Lians

--- a/integrations/opencode/opencode.example.json
+++ b/integrations/opencode/opencode.example.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "lians": {
+      "type": "local",
+      "command": [
+        "uvx",
+        "--from",
+        "lians-sdk[mcp]",
+        "lians-mcp"
+      ],
+      "enabled": true,
+      "environment": {
+        "LIANS_MCP_ENABLED_TOOLS": "remember,recall,list_memories,correct_memory,forget_memory"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a ready-to-copy OpenCode MCP configuration for Lians
- document install, connection verification, and a two-chat memory check
- link OpenCode from the main developer setup section

## Validation
- validated the configuration shape against OpenCode's current MCP documentation
- parsed `opencode.example.json` successfully
- `git diff --check`

AI-assisted: Codex helped draft and validate this documentation; Ethan Beirne remains responsible for the change.