### PR TITLE
docs: add one-click Cursor memory install

### DIFF
--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -6,6 +6,15 @@ slice in a later chat.
 
 ## Install for one project
 
+Use Cursor's official one-click MCP installer:
+
+[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install Lians in Cursor">](https://cursor.com/en/install-mcp?name=Lians&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyItLWZyb20iLCJsaWFucy1zZGtbbWNwXSIsImxpYW5zLW1jcCJdLCJlbnYiOnsiTElBTlNfTUNQX0VOQUJMRURfVE9PTFMiOiJyZW1lbWJlcixyZWNhbGwsbGlzdF9tZW1vcmllcyxjb3JyZWN0X21lbW9yeSxmb3JnZXRfbWVtb3J5In19)
+
+The button passes the same local server configuration shown below to Cursor.
+Review it in Cursor before approving the install.
+
+For manual setup:
+
 1. Install [`uv`](https://docs.astral.sh/uv/).
 2. Copy [`mcp.example.json`](mcp.example.json) to `.cursor/mcp.json` in your
    project. If that file already exists, merge the `lians` server into its


### PR DESCRIPTION
## Summary
- add Cursor's official HTTPS one-click MCP installer to the existing Cursor guide
- pass the same local `uvx` command and five-tool starter profile as `mcp.example.json`
- keep the manual setup path immediately below the button

## Validation
- decoded the embedded Base64 config and compared command, arguments, and tool scope with the checked-in example
- followed the installer URL through its redirect and received HTTP 200
- `git diff --check`

AI-assisted: Codex helped generate and validate the install link; Ethan Beirne remains responsible for the change.