### PR TITLE
Fix the Gemini extension's published MCP command

### DIFF
--- a/agentmem/tests/test_distribution_contract.py
+++ b/agentmem/tests/test_distribution_contract.py
@@ -19,6 +19,17 @@ def test_gemini_starter_profile_is_bounded_and_requires_confirmation():
     assert server["trust"] is False
 
 
+def test_gemini_extension_uses_the_published_bounded_server():
+    extension = _json("gemini-extension.json")
+    server = extension["mcpServers"]["lians"]
+
+    assert extension["version"] == "0.5.1"
+    assert server["command"] == "uvx"
+    assert server["args"] == ["--from", "lians-sdk[mcp]==0.5.0", "lians-mcp"]
+    assert server["includeTools"] == ["remember", "recall"]
+    assert server["timeout"] == 300000
+
+
 def test_cursor_starter_profile_is_local_bounded_stdio():
     server = _json("integrations/cursor/mcp.example.json")["mcpServers"]["lians"]
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "lians",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Open-source, local-first memory for any AI agent.",
   "mcpServers": {
     "lians": {
@@ -8,9 +8,13 @@
       "args": [
         "--from",
         "lians-sdk[mcp]==0.5.0",
-        "lians-memory-mcp"
+        "lians-mcp"
       ],
-      "timeout": 120000
+      "timeout": 300000,
+      "includeTools": [
+        "remember",
+        "recall"
+      ]
     }
   }
 }


### PR DESCRIPTION
## What changed

- use `lians-mcp`, the console command actually shipped by `lians-sdk[mcp]==0.5.0`
- keep Gemini's visible surface to `remember` and `recall` with the supported `includeTools` allowlist
- increase the clean-start MCP timeout from 120 to 300 seconds while first-run latency is tracked in #147
- bump the extension manifest to 0.5.1 so installed extensions can detect the correction
- add a distribution-contract regression test

## Why

The extension merged in #141 pins PyPI 0.5.0 but invokes `lians-memory-mcp`, an entry point present on the repository's current source but absent from the published 0.5.0 wheel. The published wheel exposes only `lians-mcp`, so a fresh Gemini install cannot start the extension as currently configured.

## Validation

- `python -m pytest agentmem/tests/test_distribution_contract.py -q` — 7 passed
- `python -m json.tool gemini-extension.json` — passed
- `python -m ruff check agentmem/tests/test_distribution_contract.py` — passed
- `npx -y @google/gemini-cli@latest extensions validate .` — passed
- installed entry-point inspection for `lians-sdk[mcp]==0.5.0` — only `lians-mcp = lians.mcp_server:main`