### PR TITLE
Bound first-run MCP model warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Remember that this project uses Python 3.12 and pytest.
 What Python version and test runner does this project use?
 ```
 
+On a clean machine, the first memory tool may download and initialize the local
+semantic model. Lians reports that warmup to MCP clients that support progress.
+If it is still running after 90 seconds, the tool returns a retryable error and
+does not queue the write; keep the MCP server running and retry shortly. Model
+files use the Hugging Face cache controlled by `HF_HOME`.
+
 Local MCP memory is stored in `~/.lians/mcp.db`. The starter configuration
 exposes the basic loop plus the controls needed to trust it:
 

--- a/agentmem/sdk/python/README.md
+++ b/agentmem/sdk/python/README.md
@@ -62,6 +62,13 @@ environment:
 }
 ```
 
+The first memory tool on a clean machine may download the local semantic model.
+Progress-aware MCP clients receive a warmup message. After 90 seconds Lians
+returns a retryable error without queuing the write; keep the server running and
+retry shortly. Set `LIANS_MCP_LOCAL_READY_TIMEOUT` to 5-600 seconds when a host
+needs a different bound. Model files use the Hugging Face cache controlled by
+`HF_HOME`.
+
 ## Connect to a Lians server
 
 ```bash

--- a/agentmem/sdk/python/lians/mcp_server.py
+++ b/agentmem/sdk/python/lians/mcp_server.py
@@ -22,6 +22,7 @@ Environment variables:
     LIANS_MCP_CODEX_DYNAMIC_SCOPE Bind scope from Codex sandbox metadata when true
     LIANS_MCP_DATA_HOME Fixed private data root required by Codex dynamic scope
     LIANS_MCP_PREWARM Runtime warmup: background (default), true/sync, or false/off
+    LIANS_MCP_LOCAL_READY_TIMEOUT Seconds a tool waits for local model warmup (default: 90)
     LIANS_MCP_ENABLED_TOOLS Optional comma-separated tool allowlist
     LIANS_MCP_SCHEMA_PROFILE Tool schema shape: standard (default) or compact
     LIANS_MCP_RECALL_K Number of candidates considered for recall (default: 50)
@@ -278,6 +279,12 @@ def _bounded_int_env(name: str, default: int, minimum: int, maximum: int) -> int
 # own representative quality run and implies no universal usage or latency gain.
 LIANS_MCP_RECALL_K = _bounded_int_env("LIANS_MCP_RECALL_K", 50, 1, 100)
 LIANS_MCP_CONTEXT_MAX_TOKENS = _bounded_int_env("LIANS_MCP_CONTEXT_MAX_TOKENS", 2650, 64, 32000)
+LIANS_MCP_LOCAL_READY_TIMEOUT = _bounded_int_env(
+    "LIANS_MCP_LOCAL_READY_TIMEOUT",
+    90,
+    5,
+    600,
+)
 
 _TOOL_NAMES = frozenset(
     {
@@ -331,6 +338,68 @@ LIANS_MCP_SCHEMA_PROFILE = _parse_schema_profile(
 _LOCAL_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="lians-mcp-local")
 _LOCAL_CLIENT: Any = None
 _LOCAL_PREWARM_FUTURE: Future[Any] | None = None
+
+
+class LocalRuntimeNotReady(RuntimeError):
+    """A safe, retryable local-model readiness failure for MCP clients."""
+
+
+async def _wait_for_local_runtime(server: Any) -> None:
+    """Wait boundedly for background warmup before queuing an embedding call.
+
+    Local requests and prewarm deliberately share a single executor because the
+    synchronous local client owns one asyncio loop.  Waiting here keeps a timed
+    out write out of that executor: the caller can safely retry without the
+    original write completing invisibly later.
+    """
+
+    future = _LOCAL_PREWARM_FUTURE
+    if LIANS_URL or future is None or future.done():
+        return
+
+    try:
+        request_context = server.request_context
+    except LookupError:
+        request_context = None
+    progress_token = (
+        getattr(request_context.meta, "progressToken", None)
+        if request_context is not None and request_context.meta is not None
+        else None
+    )
+    if progress_token is not None:
+        await request_context.session.send_progress_notification(
+            progress_token,
+            0,
+            total=1,
+            message="Lians is preparing its local semantic model for the first use.",
+        )
+
+    try:
+        await asyncio.wait_for(
+            asyncio.shield(asyncio.wrap_future(future)),
+            timeout=LIANS_MCP_LOCAL_READY_TIMEOUT,
+        )
+    except TimeoutError as exc:
+        if progress_token is not None:
+            await request_context.session.send_progress_notification(
+                progress_token,
+                0.9,
+                total=1,
+                message="The first-run model download is still in progress; retry shortly.",
+            )
+        raise LocalRuntimeNotReady(
+            "Lians is still preparing the local semantic model. No memory was written; "
+            "keep the MCP server running and retry this tool shortly. The first run may "
+            "download the model into the Hugging Face cache controlled by HF_HOME."
+        ) from exc
+
+    if progress_token is not None:
+        await request_context.session.send_progress_notification(
+            progress_token,
+            1,
+            total=1,
+            message="Lians local semantic memory is ready.",
+        )
 
 
 def _bind_codex_dynamic_scope(meta: object) -> _CodexScopeBinding | None:
@@ -954,6 +1023,8 @@ def _build_server() -> Any:
         try:
             if LIANS_MCP_ENABLED_TOOLS is not None and name not in LIANS_MCP_ENABLED_TOOLS:
                 return [TextContent(type="text", text=f"Lians tool disabled: {name}")]
+            if name in {"remember", "recall", "correct_memory", "recall_at"}:
+                await _wait_for_local_runtime(server)
             if name == "remember":
                 body = {
                     "agent_id": LIANS_AGENT_ID,
@@ -1197,6 +1268,10 @@ def _build_server() -> Any:
 
             return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
+        except LocalRuntimeNotReady as exc:
+            # This message is fixed, contains no provider details, and tells the
+            # caller whether retrying can duplicate a write (it cannot).
+            raise RuntimeError(str(exc)) from exc
         except Exception as exc:
             # Let the MCP server mark operational failures as errors. Returning
             # an ordinary text block here makes hosts treat a failed remember as

--- a/agentmem/sdk/python/tests/test_mcp_local.py
+++ b/agentmem/sdk/python/tests/test_mcp_local.py
@@ -1,14 +1,14 @@
 """Unit coverage for zero-config MCP routing into LocalLiansClient."""
 
 import asyncio
+from concurrent.futures import Future
 from datetime import datetime
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
+from lians import local_client, mcp_server
 from mcp.shared.memory import create_connected_server_and_client_session
 from mcp.types import CallToolRequest, CallToolRequestParams, RequestParams
-
-from lians import local_client, mcp_server
 
 
 def _codex_meta(project: Path) -> dict[str, object]:
@@ -488,6 +488,84 @@ def test_mcp_prewarm_mode_is_explicit_and_validated():
     assert mcp_server._parse_prewarm_mode("off") == "off"
     with pytest.raises(ValueError, match="LIANS_MCP_PREWARM"):
         mcp_server._parse_prewarm_mode("sometimes")
+
+
+def test_embedding_tool_times_out_before_queuing_a_hidden_write(monkeypatch):
+    prewarm = Future()
+    called = False
+    progress_messages = []
+
+    async def fake_api(method, path, body=None):
+        nonlocal called
+        called = True
+        return {"id": "must-not-be-written"}
+
+    monkeypatch.setattr(mcp_server, "LIANS_URL", "")
+    monkeypatch.setattr(mcp_server, "LIANS_MCP_LOCAL_READY_TIMEOUT", 0.01)
+    monkeypatch.setattr(mcp_server, "_LOCAL_PREWARM_FUTURE", prewarm)
+    monkeypatch.setattr(mcp_server, "_api", fake_api)
+    server = mcp_server._build_server()
+
+    async def call_through_mcp_session():
+        async def record_progress(progress, total, message):
+            progress_messages.append((progress, total, message))
+
+        async with create_connected_server_and_client_session(server) as session:
+            return await session.call_tool(
+                "remember",
+                {
+                    "content": "Do not store this after the caller times out",
+                    "event_time_iso": "2026-08-13T12:00:00Z",
+                },
+                progress_callback=record_progress,
+            )
+
+    result = asyncio.run(call_through_mcp_session())
+
+    assert result.isError is True
+    assert "still preparing the local semantic model" in result.content[0].text
+    assert "No memory was written" in result.content[0].text
+    assert [message for _, _, message in progress_messages] == [
+        "Lians is preparing its local semantic model for the first use.",
+        "The first-run model download is still in progress; retry shortly.",
+    ]
+    assert called is False
+
+
+def test_embedding_tool_runs_after_background_prewarm_completes(monkeypatch):
+    prewarm = Future()
+    prewarm.set_result({"memories": []})
+    calls = []
+
+    async def fake_api(method, path, body=None):
+        calls.append((method, path, body))
+        return {"id": "memory-1"}
+
+    monkeypatch.setattr(mcp_server, "LIANS_URL", "")
+    monkeypatch.setattr(mcp_server, "_LOCAL_PREWARM_FUTURE", prewarm)
+    monkeypatch.setattr(mcp_server, "_api", fake_api)
+    server = mcp_server._build_server()
+    handler = next(
+        callback
+        for request_type, callback in server.request_handlers.items()
+        if request_type.__name__ == "CallToolRequest"
+    )
+    request = CallToolRequest(
+        params=CallToolRequestParams(
+            name="remember",
+            arguments={
+                "content": "Store this once semantic memory is ready",
+                "event_time_iso": "2026-08-13T12:00:00Z",
+            },
+        )
+    )
+
+    result = asyncio.run(handler(request))
+
+    assert result.root.isError is False
+    assert [(method, path) for method, path, _ in calls] == [
+        ("POST", "/v1/memories")
+    ]
 
 
 def test_mcp_schema_profile_is_explicit_and_validated():

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,6 +29,13 @@ this server to your client's MCP configuration:
 Restart the client. Local mode needs no Lians account, API key, or Docker
 service and stores memory in `~/.lians/mcp.db`.
 
+On a clean machine, the first memory tool may download and initialize the local
+semantic model. Progress-aware MCP clients show a warmup message. If warmup is
+still running after 90 seconds, Lians returns a retryable error and guarantees
+that the attempted write was not queued; keep the MCP server running and retry
+shortly. Model files use the Hugging Face cache controlled by `HF_HOME`. Set
+`LIANS_MCP_LOCAL_READY_TIMEOUT` to 5-600 seconds to change the bound.
+
 The starter configuration exposes `remember`, `recall`, `list_memories`,
 `correct_memory`, and confirmed `forget_memory`. Remove the
 `LIANS_MCP_ENABLED_TOOLS` setting to also expose the advanced point-in-time,


### PR DESCRIPTION
## What changed

- report MCP progress while the first local semantic-model warmup is running
- stop waiting after a configurable 90-second bound
- guarantee a timed-out `remember` is not queued and cannot complete invisibly later
- return a fixed, retryable error that explains the Hugging Face cache and safe retry path
- document the first-run behavior in the main, SDK, and install guides

## Why

A clean `lians-sdk[mcp]` install can initialize successfully while its first tool call waits behind a large local model download. The previous behavior looked like a hang and could leave callers unsure whether retrying would duplicate a write. This addresses the concrete failure mode reported in #147 without falling back to test-grade embeddings.

## Validation

- `ruff check agentmem/sdk/python/lians/mcp_server.py agentmem/sdk/python/tests/test_mcp_local.py`
- `python -m pytest agentmem/sdk/python/tests/test_mcp_local.py -q -k 'not test_mcp_tools_advertise_safe_approval_hints'` (45 passed, 1 pre-existing unrelated test deselected)
- focused readiness/error regressions: 3 passed
- `git diff --check`

## Follow-up

#147 should remain open until the clean-cache wheel smoke test is measured on Windows and Unix and the model acquisition itself is made faster.