### PR TITLE
docs: add a root contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to Lians
+
+Thank you for helping make memory easier to add to any AI agent. Contributions
+that simplify installation, improve recall quality, strengthen tests, or add a
+real agent integration are especially welcome.
+
+## Find a task
+
+- Start with an open [`good first issue`](https://github.com/Lians-ai/Lians/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
+- Search existing issues before proposing new work.
+- Comment on the issue before starting so another contributor does not duplicate
+  the same work.
+- Open an issue first for a new feature or any change that affects public
+  behavior, storage, security, or compatibility.
+
+## Set up the repository
+
+```bash
+git clone https://github.com/Lians-ai/Lians.git
+cd Lians
+python -m venv .venv
+python -m pip install -e ".[dev]"
+python scripts/test_all.py
+```
+
+The full [development guide](docs/CONTRIBUTING.md) explains the repository
+layout, focused Python and TypeScript test commands, integration conventions,
+and commit style.
+
+## Submit a pull request
+
+Keep each pull request focused on one problem. Before submitting it:
+
+- run the most relevant tests locally;
+- add or update tests when behavior changes;
+- update user-facing documentation when setup or behavior changes;
+- update `product-manifest.json` when capabilities, positioning, workflow, or
+  availability changes; and
+- confirm that no secrets, credentials, personal data, or real API keys are in
+  the diff.
+
+Describe what changed, why it matters to a user or developer, and the exact
+validation you ran. Link the issue when one exists.
+
+## Report a security issue
+
+Do not open a public issue for a vulnerability. Follow the private reporting
+instructions in the [security policy](docs/SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ python scripts/test_all.py
 ```
 
 Focused test runs and development conventions are in
-[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md). Published package and registry
+[CONTRIBUTING.md](CONTRIBUTING.md). Published package and registry
 versions are tracked in
 [docs/published-release-status.json](docs/published-release-status.json).
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -26,4 +26,4 @@ where the memory loop becomes confusing, slow, or unreliable.
 - Never post credentials, personal data, or confidential records.
 - No purchased stars, reciprocal-star campaigns, or manufactured engagement.
 
-See the [product roadmap](../ROADMAP.md) and [contribution guide](CONTRIBUTING.md).
+See the [product roadmap](../ROADMAP.md) and [contribution guide](../CONTRIBUTING.md).


### PR DESCRIPTION
## What changed

- add a root contributor guide with a direct good-first-issue path
- document the claim-before-work, setup, pull-request, validation, and private security-reporting flow
- route the README and community page to the canonical root guide

This makes the next action obvious for developers arriving through the current GitHub discovery campaign while keeping the detailed development commands in `docs/CONTRIBUTING.md`.

## Validation

- `git diff --check`
- verified every new relative link resolves in the repository
- confirmed this is documentation-only and does not change product behavior

## Product record

- [x] This change does not affect the product record.