### PR TITLE
docs: route setup to live Personal plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ same; Lians gives them a place to remember.
   memory workspace, 100,000 writes and 50,000 recalls each month, export and
   deletion controls, and email setup support. Cancel anytime.
 
-[Install the free local version](docs/easy-install.md) or
-[get Lians Personal](https://www.lians.ai/upgrade?plan=starter).
+[Get Lians Personal for $10/month](https://www.lians.ai/upgrade?plan=starter) or
+[install the free local version through MCP](#free-local-setup-add-memory-through-mcp).
 
 Lians does not change the underlying model or promise fewer tokens on every
 task. It can avoid resending old conversation when a small relevant recall is
@@ -54,31 +54,22 @@ enough; verify the result on your own workflow.
   <a href="https://github.com/Lians-ai/Lians/releases/download/lians-memory-openai-demo-v1.0.0/Lians-Memory-OpenAI-submission-demo-v1.0.0.mp4"><strong>▶ Watch the 33-second demo: remember, recall, and confirmed deletion</strong></a>
 </p>
 
-## Install Lians without a terminal
+## Simplest setup: Lians Personal
 
-Download **LiansMemory** for Windows, macOS, or Linux from
-[GitHub Releases](https://github.com/Lians-ai/Lians/releases), open it, choose
-the AI clients found on your computer, and select **Install Lians**.
+Choose Personal when you want Lians managed for you instead of maintaining a
+local memory service. It includes a private hosted workspace, 100,000 writes
+and 50,000 recalls each month, export and deletion controls, and email setup
+support for **$10/month**. Cancel anytime.
 
-The desktop setup:
+[Start Lians Personal](https://www.lians.ai/upgrade?plan=starter)
 
-- needs no Lians account, API key, Python installation, or model download;
-- safely backs up existing client settings before changing them;
-- gives supported clients one shared local memory profile; and
-- includes a diagnostic command and silent install mode for managed devices.
+The standalone desktop installer is still a technical preview. Signed Windows
+and notarized macOS downloads are not in the current GitHub releases, so the
+project does not present a nonexistent or unsigned download as the normal-user
+path. Developers evaluating the preview can use the
+[Lians Easy source guide](docs/easy-install.md).
 
-Restart the selected AI client, then try:
-
-```text
-Remember that I am researching sustainable packaging for independent retailers.
-```
-
-The first standalone builds support Claude Desktop, Cursor, Windsurf, Gemini
-CLI, and Codex. ChatGPT does not load local stdio MCP servers, so the installer
-does not modify ChatGPT; it requires a hosted connector. See the
-[guided install and IT deployment guide](docs/easy-install.md).
-
-## Developer setup: add memory through MCP
+## Free local setup: add memory through MCP
 
 Use this path when you prefer a package-managed MCP server or want the full
 temporal and governance engine.
@@ -199,10 +190,10 @@ Java, C, framework adapters, and self-hosting.
 
 | You want to... | Start with |
 |---|---|
-| Add memory without a terminal | [Lians Easy](docs/easy-install.md) |
-| Give an existing AI client memory from a terminal | [MCP setup](#developer-setup-add-memory-through-mcp) |
-| Add local memory inside Python | [`LocalLiansClient`](agentmem/sdk/python) |
 | Use managed private memory without running a server | [Lians Personal — $10/month](https://www.lians.ai/upgrade?plan=starter) |
+| Give an existing AI client free local memory | [MCP setup](#free-local-setup-add-memory-through-mcp) |
+| Add local memory inside Python | [`LocalLiansClient`](agentmem/sdk/python) |
+| Evaluate the desktop installer preview from source | [Lians Easy](docs/easy-install.md) |
 | Connect Python or TypeScript to a Lians server | [Language SDKs](docs/install.md#language-sdks) |
 | Use Pydantic AI, LangChain, LangGraph, CrewAI, OpenAI Agents, or AutoGen | [Framework integrations](docs/install.md#framework-integrations) |
 | Run the full service yourself | [Self-host Lians](docs/install.md#self-host-lians) |

--- a/docs/easy-install.md
+++ b/docs/easy-install.md
@@ -1,18 +1,26 @@
-# Install Lians without a terminal
+# Lians Easy desktop preview
 
-Lians Easy is the normal-user path for adding private, local memory to a
-supported AI client. It is deliberately smaller than the full Lians engine:
-there is no account, API key, Python setup, database server, or embedding model
-download.
+Lians Easy is a technical preview for adding private, local memory to a
+supported AI client. It is deliberately smaller than the full Lians engine.
+There is no account, API key, database server, or embedding-model download.
+
+There are currently no signed Windows, notarized macOS, or Linux
+`LiansMemory` assets in [GitHub Releases](https://github.com/Lians-ai/Lians/releases).
+Do not send normal users to that page expecting a desktop download. For a live,
+managed setup, use [Lians Personal for $10/month](https://www.lians.ai/upgrade?plan=starter).
+For free local memory today, use the [published MCP setup](install.md#mcp--use-lians-as-a-native-tool).
 
 ## Personal setup
 
-1. Download **LiansMemory** for your operating system from
-   [GitHub Releases](https://github.com/Lians-ai/Lians/releases).
-2. Open the downloaded app.
-3. Leave the AI clients you use selected and choose **Install Lians**.
-4. Restart those clients.
-5. Ask the client to remember one useful fact, then recall it in another chat.
+Developers evaluating the preview can run it from a source checkout:
+
+```bash
+python -m pip install -e packages/lians-easy
+python -m lians_easy
+```
+
+Choose the clients to configure, select **Install Lians**, restart those
+clients, then ask one to remember a useful fact and recall it in another chat.
 
 Existing client configuration files are backed up before every change. Memory
 is stored in a local SQLite file under the operating system's per-user Lians


### PR DESCRIPTION
## What changed

- make the live $10/month Personal plan the simplest setup path for nontechnical visitors
- route free local users to the published MCP setup
- label Lians Easy accurately as a source-only technical preview
- remove instructions that sent users to GitHub Releases for desktop assets that do not exist

## Why

The README promoted a no-terminal desktop download, but the current releases contain no Windows, macOS, or Linux `LiansMemory` assets. The linked guide also says unsigned builds should not be promoted broadly. That created a dead end at the highest-intent onboarding point.

This change keeps the free local path intact while sending normal users to a checkout that is live today.

## User impact

- nontechnical users see a working managed option instead of a missing download
- developers retain the verified free MCP path
- desktop preview evaluators receive honest source instructions and trust-gate context

## Validation

- `python -m lians_easy --help`
- `python -m pytest packages/lians-easy/tests -q` — 7 passed
- `git diff --check`
- live releases audited: no `LiansMemory` desktop assets are currently published
