### PR TITLE
docs: add a beginner setup chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ memory solves a real problem for you.
 [Get Lians Personal for $10/month](https://www.lians.ai/upgrade?plan=starter&utm_source=github&utm_medium=readme&utm_campaign=first_customer_setup) or
 [install the free local version through MCP](#free-local-setup-add-memory-through-mcp).
 
+## Pick the AI you already use
+
+- **Cursor:** use the [one-click MCP installer](integrations/cursor).
+- **Claude Code:** paste the [two plugin commands](integrations/lians-plugin).
+- **Codex app, CLI, or IDE:** run the [one-command MCP setup](integrations/codex).
+
+All three routes use the same free local memory by default. After setup, try the
+[three-minute, two-chat memory challenge](https://github.com/Lians-ai/Lians/discussions/122).
+
 Lians does not change the underlying model or promise fewer tokens on every
 task. It can avoid resending old conversation when a small relevant recall is
 enough; verify the result on your own workflow.
@@ -128,7 +137,7 @@ Use the exact setup guide for
 [Gemini CLI](integrations/gemini),
 [Claude Code](integrations/lians-plugin), or
 [OpenCode](integrations/opencode), or
-[Codex](plugins/lians-memory). Remove `LIANS_MCP_ENABLED_TOOLS` when you want
+[Codex](integrations/codex). Remove `LIANS_MCP_ENABLED_TOOLS` when you want
 the advanced temporal and audit tools too.
 
 ## How it works

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,52 +1,56 @@
-# Lians for Codex
+# Lians Memory for Codex
 
-Give Codex memory across tasks without changing the model or your workflow.
-The default setup runs locally, needs no Lians account or API key, and exposes
-only `remember` and `recall`.
+Give the Codex app, CLI, and IDE extension durable local memory. They share the
+same MCP configuration, so you only need to add Lians once.
 
-## Install
+## Install in one command
 
 1. Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/).
-2. Copy the block from [`config.example.toml`](config.example.toml) into
-   `~/.codex/config.toml`.
-3. Restart Codex.
+2. Run this command in a terminal:
 
-Try:
-
-```text
-Remember that this repository uses Python 3.12 and pytest.
+```bash
+codex mcp add lians --env LIANS_MCP_ENABLED_TOOLS=remember,recall,list_memories,correct_memory,forget_memory -- uvx --from "lians-sdk[mcp]" lians-mcp
 ```
 
-Then open another task and ask:
+3. Restart Codex. Run `codex mcp list` to confirm that `lians` is configured,
+   or type `/mcp` in the Codex terminal UI to see the connected server.
+
+This follows Codex's official
+[MCP CLI configuration](https://learn.chatgpt.com/docs/extend/mcp?surface=cli).
+Local mode needs no Lians account or API key. Memories persist in
+`~/.lians/mcp.db` by default.
+
+## Test it in two chats
+
+In one Codex chat, ask:
 
 ```text
-What Python version and test runner does this repository use?
+Remember that this project's release color is amber.
 ```
 
-Memory is stored in `~/.lians/mcp.db`. Set `LIANS_LOCAL_DB` if you want a
-different location.
-
-## Add project instructions
-
-Copy [`AGENTS.md`](AGENTS.md) to a project root, or merge its memory rules into
-an existing `AGENTS.md`. It tells Codex what is worth remembering and what
-should never be stored.
-
-## Install the Lians plugin
-
-The repository also includes the [`lians-memory`](../../plugins/lians-memory)
-plugin for a packaged Codex experience:
+Open a new chat in the same project and ask:
 
 ```text
-git clone https://github.com/Lians-ai/Lians.git
-codex plugin marketplace add /absolute/path/to/Lians
-codex plugin add lians-memory@lians
+What is this project's release color?
 ```
 
-## Advanced tools
+Approve the `remember` or `recall` tool if Codex asks. The starter profile also
+includes inspect, correction, and deletion controls so you can see and change
+what the agent remembers.
 
-Remove the `LIANS_MCP_ENABLED_TOOLS` line from the MCP configuration to expose
-point-in-time recall, reconstruction, conflicts, lineage, fact history, and
-backtest checks.
+## Optional managed connection
 
-For the complete product overview, see the [root README](../../README.md).
+The command defaults to a local SQLite store. If you prefer a managed private
+workspace and setup support, [Lians Personal](https://www.lians.ai/upgrade?plan=starter&utm_source=github&utm_medium=integration_guide&utm_campaign=codex_setup)
+is $10/month. The free local version remains available without an account.
+
+## Optional tuning
+
+- Set `LIANS_LOCAL_DB` if you want the local database somewhere other than
+  `~/.lians/mcp.db`.
+- Copy the example [`AGENTS.md`](AGENTS.md) into a project to tell Codex what is
+  worth remembering and what should never be stored.
+- Remove `LIANS_MCP_ENABLED_TOOLS` from the MCP configuration to expose the
+  advanced temporal, lineage, audit, and backtest tools.
+- See the packaged [`lians-memory`](../../plugins/lians-memory) plugin for the
+  full Codex workflow.


### PR DESCRIPTION
﻿## What changed

- adds an above-the-fold chooser for Cursor, Claude Code, and Codex
- routes each user to the shortest supported setup path
- replaces the expert-first Codex guide with a verified one-command MCP setup
- keeps free local memory first and the optional $10 managed plan explicit

## Why

Students, indie developers, and other individual users should not need to understand the whole architecture before trying Lians. The README now answers the first question immediately: "How do I install this in the AI tool I already use?"

## Checks

- `git diff --check`
- verified all local README targets exist
- verified Codex MCP CLI syntax against the official OpenAI MCP documentation
