### PR TITLE
docs: clarify supported, preview, and legacy paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ Java, C, framework adapters, and self-hosting.
 | Use Pydantic AI, LangChain, LangGraph, CrewAI, OpenAI Agents, or AutoGen | [Framework integrations](docs/install.md#framework-integrations) |
 | Run the full service yourself | [Self-host Lians](docs/install.md#self-host-lians) |
 
+Cloned the repository and unsure which package or folder is current? Read
+[Supported paths and repository status](docs/supported-paths.md) before choosing
+an SDK, plugin, preview, or legacy tree.
+
 ## Why Lians
 
 Most memory demos store text and run vector search. Lians also handles the

--- a/agentmem/tests/test_distribution_contract.py
+++ b/agentmem/tests/test_distribution_contract.py
@@ -88,3 +88,20 @@ def test_student_community_kit_uses_working_repository_asset_paths():
     assert 'src="assets/logo-blue.png"' in kit
     assert "[blue lotus logo](assets/logo-blue.png)" in kit
     assert (ROOT / "docs/assets/logo-blue.png").is_file()
+
+
+def test_supported_path_map_separates_current_preview_and_legacy_routes():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    guide = (ROOT / "docs/supported-paths.md").read_text(encoding="utf-8")
+    legacy = (ROOT / "sdk/python/README.md").read_text(encoding="utf-8")
+
+    assert "[Supported paths and repository status](docs/supported-paths.md)" in readme
+    assert '`uvx --from "lians-sdk[mcp]" lians-mcp`' in guide
+    assert '`pip install "lians-sdk[local]"`' in guide
+    assert "`agentmem/sdk/python/` | **Current and published**" in guide
+    assert "`packages/lians-easy/` | **Technical preview**" in guide
+    assert "`sdk/python/` | **Legacy**" in guide
+    assert "not a signed desktop download" in guide
+    assert "not the general local installation path" in guide
+    assert "not the supported starting point" in legacy
+    assert "[`agentmem/sdk/python`](../../agentmem/sdk/python)" in legacy

--- a/docs/supported-paths.md
+++ b/docs/supported-paths.md
@@ -1,0 +1,61 @@
+# Supported paths and repository status
+
+Use this page when you have cloned Lians and need to know which installation,
+package, or directory is the supported starting point. It is deliberately
+shorter than the architecture and deployment documentation.
+
+Last reviewed: August 14, 2026. The current public release line is `0.5.0`; the
+machine-readable registry record is
+[`published-release-status.json`](published-release-status.json).
+
+## I just want Lians to work
+
+| What you need | Start here | Status |
+|---|---|---|
+| Memory in Cursor, Claude, Codex, Gemini, or another MCP client | `uvx --from "lians-sdk[mcp]" lians-mcp` in the [MCP install guide](install.md#existing-ai-client-use-mcp) | **Recommended** |
+| A managed private workspace without running a service | [Lians Personal](https://www.lians.ai/upgrade?plan=starter) | **Current managed** |
+| Local memory inside a Python app or notebook | `pip install "lians-sdk[local]"` and [`LocalLiansClient`](../agentmem/sdk/python) | **Recommended** |
+| A shared self-hosted HTTP service | [`agentmem/src/lians/`](../agentmem/src/lians) through the [self-hosting guide](install.md#self-host-lians) | **Current, operator-managed** |
+| A language client for an existing HTTP service | [`agentmem/sdk/`](../agentmem/sdk) | **Current release line** |
+| A source-only desktop installer experiment | [`packages/lians-easy/`](../packages/lians-easy) | **Technical preview** |
+
+The current Python distribution is named **`lians-sdk`**, while its import
+namespace is **`lians`**. For new work, install `lians-sdk`; do not select a
+folder merely because it is named `sdk/python`.
+
+## What each top-level path means
+
+| Path | Status | Use it for |
+|---|---|---|
+| `agentmem/src/lians/` | **Current** | The memory engine and FastAPI service. |
+| `agentmem/sdk/python/` | **Current and published** | `lians-sdk` 0.5.x, `LocalLiansClient`, the HTTP client, and `lians-mcp`. |
+| `agentmem/sdk/typescript/` | **Current and published** | The `@lians-ai/lians` package. |
+| `agentmem/sdk/go/`, `java/`, `c/` | **Current and versioned** | HTTP clients released with the repository. |
+| `integrations/` | **Current, integration-specific** | Tested client and framework setup. Begin with the integration's README. |
+| `plugins/lians-memory/` | **Current Codex plugin source** | The repository marketplace plugin and its local runtime. |
+| `plugins/lians-memory-universal/` | **Submission/evaluation bundle** | Hosted OpenAI review material; it is not the general local installation path. |
+| `packages/lians-easy/` | **Technical preview** | Source evaluation of the lightweight desktop runtime. It is not a signed desktop download. |
+| `sdk/python/` | **Legacy** | The older `lians` 0.2.0 thin-client tree. Do not use it for new installs, examples, or integrations. |
+| `demo/`, `benchmarks/`, `paper/` | **Evidence and examples** | Reproducible demonstrations, evaluation fixtures, and research—not product installation entry points. |
+
+## Release and trust boundaries
+
+- The verified published versions are the ones in
+  [`published-release-status.json`](published-release-status.json), not every
+  version string that remains in a historical or compatibility directory.
+- The normal free local path is the published `lians-sdk[mcp]` package. It needs
+  no Lians account or API key and stores memory in `~/.lians/mcp.db`.
+- Lians Easy remains source-only for normal users. The current GitHub release
+  does not contain signed Windows, notarized macOS, or Linux desktop installer
+  assets. See the [preview trust gate](easy-install.md#release-trust-gate).
+- The full service and remote SDKs are for a hosted or self-hosted HTTP
+  deployment. They are not required for one person using local MCP memory.
+- A plugin or integration README may provide a shorter client-specific setup,
+  but it should resolve to one of the current paths above.
+
+## Maintainer rule
+
+New user-facing documentation must link to a **Recommended** or **Current** path.
+Preview paths must say what is missing. Legacy paths must not appear in new
+installation examples. When release status changes, update this page and
+`published-release-status.json` together.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,14 @@
+# Legacy Python client tree
+
+This directory contains the older `lians` 0.2.0 thin-client package metadata.
+It remains in the repository for compatibility and migration work, but it is
+not the supported starting point for a new Lians integration.
+
+For new work:
+
+- install the current **`lians-sdk`** package;
+- use the [`agentmem/sdk/python`](../../agentmem/sdk/python) source tree; and
+- follow the [current install guide](../../docs/install.md).
+
+The published package name is `lians-sdk`; its Python import namespace is still
+`lians`. Do not use this legacy tree in new examples or installation commands.


### PR DESCRIPTION
## What changed
- adds one short supported-path map for newcomers choosing between MCP, Personal, local Python, the self-hosted service, SDKs, plugins, and Lians Easy
- makes the `lians-sdk` distribution name versus `lians` import namespace explicit
- labels `sdk/python/` as the older 0.2.0 legacy tree and points new work to `agentmem/sdk/python/`
- distinguishes the desktop technical preview and hosted OpenAI submission bundle from normal installation paths
- links the map from the main interface chooser and protects the status contract with a focused test

## Why
A genuine public peer review identified repository complexity and the two Python SDK trees as the main adoption weakness. This makes the working path obvious without removing compatibility code or overstating preview distribution.

## Verification
- `python -m ruff check agentmem/tests/test_distribution_contract.py`
- `python -m pytest agentmem/tests/test_distribution_contract.py agentmem/tests/test_published_release_status.py -q` - 17 passed
- `git diff --check`

No runtime behavior, package publication, price, or allowance changes.