### PR TITLE
Simplify Lians into one product with two delivery modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
   <a href="docs/install.md">Install</a> ·
   <a href="https://github.com/Lians-ai/Lians/tree/master/docs">Docs</a> ·
   <a href="https://www.lians.ai/pricing">Pricing</a> ·
-  <a href="https://github.com/Lians-ai/Lians/issues">Issues</a> ·
-  <a href="https://github.com/Lians-ai/Lians/stargazers"><strong>Star Lians</strong></a> ·
-  <a href="https://github.com/Lians-ai"><strong>Follow @Lians-ai</strong></a>
+  <a href="https://github.com/Lians-ai/Lians/issues">Issues</a>
 </p>
 
 <p align="center">
@@ -22,36 +20,40 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 license"></a>
 </p>
 
-# Memory for any AI agent.
+# Portable memory for the AI tools you already use.
 
-Lians gives AI agents durable memory across chats, sessions, tools, and models.
-Your agent can remember a useful fact now and recall it when it matters later.
+Lians keeps useful project facts, decisions, research constraints, and
+preferences available when you start a new chat or switch tools. It is a
+memory layer, not another assistant: your model stays the same.
 
-- **Works with the AI you already use** through MCP, plugins, or an SDK.
-- **Runs locally by default** with SQLite and no Lians account or API key.
-- **Keeps memory focused** by returning a small, relevant set of current facts.
-- **Stays provider-neutral** so memory is not trapped inside one model vendor.
+The product loop is deliberately small:
 
-Lians is a memory layer, not another assistant. Your agent and model stay the
-same; Lians gives them a place to remember.
+1. **Remember** something worth keeping.
+2. **Recall** a few relevant current facts in a later session.
+3. **Inspect, correct, or forget** the memory when it changes.
 
-## Start free. Upgrade only when it saves you time.
+Lians works through MCP, plugins, and SDKs. Local mode stores memory in SQLite,
+needs no Lians account or API key, and does not lock memory to one model vendor.
 
-- **Community is free:** run Lians locally or self-host it with no account,
-  API key, or software license fee.
-- **Lians Personal is $10/month:** get a managed account, a private hosted
-  memory workspace, 100,000 writes and 50,000 recalls each month, export and
-  deletion controls, and email setup support. Cancel anytime.
+## One product, two ways to run it
 
-**First-customer setup:** the first Personal customer gets a 30-minute
-founder-led setup session at no extra cost. We will connect one supported AI
-tool and run the two-chat memory test together. Purchase only when managed
-memory solves a real problem for you.
+| | **Lians Local** | **Lians Personal** |
+|---|---|---|
+| Best for | Developers, students, and self-managed projects | One person who wants Lians operated for them |
+| Runs | On your device or infrastructure | In a private Lians-managed workspace |
+| Includes | The complete local memory loop through MCP or Python | 100,000 writes, 50,000 recalls, export and deletion controls, and email setup support |
+| Price | **Free** under Apache 2.0 | **$10/month**, cancel anytime |
+| Start | [Install local Lians](#free-local-setup-add-memory-through-mcp) | [Choose Lians Personal](https://www.lians.ai/upgrade?plan=starter&utm_source=github&utm_medium=readme&utm_campaign=product_modes) |
 
-[Get Lians Personal for $10/month](https://www.lians.ai/upgrade?plan=starter&utm_source=github&utm_medium=readme&utm_campaign=first_customer_setup) or
-[install the free local version through MCP](#free-local-setup-add-memory-through-mcp).
+Both modes provide the same basic experience: remember, recall, inspect,
+correct, and forget. Choose Local when you are comfortable running a package;
+choose Personal when setup and operation are the part you want handled.
 
-## Pick the AI you already use
+The first genuine Personal customer also gets a 30-minute founder-led setup
+session at no extra cost. Purchase only when managed memory solves a real
+problem for you.
+
+## Connect the AI tool you already use
 
 - **Cursor:** use the [one-click MCP installer](integrations/cursor).
 - **Claude Code:** paste the [two plugin commands](integrations/lians-plugin).
@@ -71,21 +73,6 @@ enough; verify the result on your own workflow.
 <p align="center">
   <a href="https://github.com/Lians-ai/Lians/releases/download/lians-memory-openai-demo-v1.0.0/Lians-Memory-OpenAI-submission-demo-v1.0.0.mp4"><strong>▶ Watch the 33-second demo: remember, recall, and confirmed deletion</strong></a>
 </p>
-
-## Simplest setup: Lians Personal
-
-Choose Personal when you want Lians managed for you instead of maintaining a
-local memory service. It includes a private hosted workspace, 100,000 writes
-and 50,000 recalls each month, export and deletion controls, and email setup
-support for **$10/month**. Cancel anytime.
-
-[Start Lians Personal with founder-led setup](https://www.lians.ai/upgrade?plan=starter&utm_source=github&utm_medium=readme&utm_campaign=first_customer_setup)
-
-The standalone desktop installer is still a technical preview. Signed Windows
-and notarized macOS downloads are not in the current GitHub releases, so the
-project does not present a nonexistent or unsigned download as the normal-user
-path. Developers evaluating the preview can use the
-[Lians Easy source guide](docs/easy-install.md).
 
 ## Free local setup: add memory through MCP
 

--- a/docs/pricing-tiers.md
+++ b/docs/pricing-tiers.md
@@ -1,109 +1,78 @@
 # Lians Packaging and Pricing
 
-Lians is packaged around the service and deployment boundary. Code already
-published under Apache 2.0 stays under Apache 2.0; commercial packages sell
-managed capacity, organizational operation, evidence services, deployment
-assurance, and contractual commitments.
+Lians is one memory product with two default delivery modes. Users should not
+have to choose among separate “developer,” “research,” “team,” or “regulated”
+products before they understand the core memory loop.
 
-Community and Lians Personal below are public self-serve offers. Confirm the
-current checkout before quoting a price or allowance. Organization packages
-remain scoped to the deployment, workflow, evidence, and support boundary.
+## The product
 
-## Community
+Lians gives an AI tool five user-visible memory controls:
 
-*For individual developers, local evaluation, and self-managed integration.*
+1. remember a useful fact, preference, constraint, or decision;
+2. recall a bounded set of relevant current memories;
+3. inspect what is stored;
+4. correct a stale memory without losing its history; and
+5. forget a memory with explicit confirmation.
 
-**Deployment:** local library, GitHub connector, or customer-operated server
+The model and assistant remain the user's choice. Lians supplies the portable
+memory layer beside them.
 
-**Includes:**
+## The two default modes
 
-- Provider-neutral memory for Codex, Claude, Gemini, and MCP-compatible clients
-- Durable writes and bounded recall
-- Local SQLite mode
-- Existing public temporal, provenance, and technical-evidence primitives
-- Community documentation and public benchmark receipts
-- Community support
+| | **Lians Local** | **Lians Personal** |
+|---|---|---|
+| Customer | Developers, students, local evaluation, and self-managed projects | One person who wants hosted continuity without operating the memory layer |
+| Deployment | Local library, MCP server, or customer-operated service | Lians-managed private workspace |
+| Price | Free under Apache 2.0 | $10/month, cancel anytime |
+| Capacity | Limited by the user's environment | 100,000 writes and 50,000 recalls per month |
+| Support | Community documentation and public issues | Email setup support |
 
-Community does not include a Lians-hosted production tenant, cross-device
-account, team administration, higher hosted limits, an SLA, or managed evidence
-review.
+Local is a useful product, not a crippled trial. It includes provider-neutral
+memory, SQLite mode, the basic five-control lifecycle, existing temporal and
+provenance capabilities, public documentation, and reproducible benchmarks.
+It does not include a Lians-hosted tenant, an SLA, or managed operation.
 
-## Lians Personal — $10/month
-
-*For one person who wants hosted continuity without operating the memory layer.*
-
-**Deployment:** Lians-managed service through a monthly self-serve subscription
-
-**Includes:**
-
-- One managed Lians account and private memory workspace
-- Hosted continuity across supported API and MCP connections
-- 100,000 memory writes and 50,000 recalls per month
-- Memory inspection, correction, deletion, and export controls
-- Email setup support
-- Monthly billing with cancellation at any time
+Personal includes one managed account and private workspace, hosted continuity
+through supported connections, the published monthly allowance, memory export
+and deletion controls, and email setup support.
 
 Personal does not change the underlying model, increase a provider quota, or
 promise lower token use on every task. It can reduce repeated context when a
-small relevant recall replaces conversation history that would otherwise be
-resent, and results should be verified on the user's workflow.
+small relevant recall replaces history that would otherwise be resent; verify
+that result on the user's workflow.
 
-## Team
+## Organizations use the same product
 
-*For shared production workflows and internal AI programs.*
+An organization does not buy a different memory engine. It scopes how Lians is
+deployed and operated for a shared workflow. A proposal may include only the
+capabilities the target environment actually needs, such as:
 
-**Deployment:** Lians-managed, customer cloud, or private deployment
+- shared memory and organization administration;
+- contracted storage, write, and recall limits;
+- identity, policy, retention, and information-barrier operation;
+- managed evidence exports, monitoring, and evaluation gates;
+- private networking, regional residency, customer-managed keys, or a
+  dedicated environment;
+- customer-cloud, private-VPC, on-premises, or air-gapped deployment support;
+- architecture review, named support, an SLA, or data-processing terms where
+  separately agreed; and
+- custom connector work when it is part of the signed scope.
 
-**Commercial value:**
-
-- Shared/team memory and organization administration
-- Higher contracted storage, write, and recall limits
-- Central policy and retention operation
-- Managed evidence exports, monitoring, and evaluation gates
-- Deployment review and named support options
-
-## Regulated Production
-
-*For sensitive, audited, or time-dependent AI workflows.*
-
-**Deployment:** customer cloud, private VPC, on-premises, or approved managed
-environment
-
-**Commercial value:**
-
-- Production architecture and hardening review
-- Identity, retention, information-barrier, and key-management design
-- Managed evidence operations and review-ready exports
-- Private networking, regional residency, or dedicated environments where sold
-- Contracted support and service levels
-- BAA or other required data-processing terms where agreed
-
+These are deployment and service options, not four more public product tiers.
 Technical primitives do not by themselves establish legal or regulatory
-compliance. Claims depend on the deployed configuration and customer controls.
+compliance; claims depend on the deployed configuration and customer controls.
 
-## Enterprise / Air-Gap
+## Packaging rule
 
-*For banks, hospitals, law firms, insurers, and government environments with
-strict residency, isolation, or procurement requirements.*
+The public choice is **Local or Personal**. Organization pricing is then tied
+to the workflow, deployment boundary, managed capacity, support obligation,
+evidence scope, and contractual risk. Do not quote an organization tier or
+limit until its enforcement and entitlements operate in that environment.
 
-**Deployment:** private cloud, on-premises, or air-gapped
-
-**Commercial value:**
-
-- Dedicated onboarding and security architecture review
-- Air-gap and local embedding deployment assistance
-- Customer-managed key and identity integration
-- Procurement evidence packet
-- Named support channel and negotiated SLA
-- Optional custom connector development
-- Annual contract pricing
-
-## Pricing principle
-
-Lians Personal is the simple public on-ramp. Institutional pricing should be
-tied to the deployment boundary, managed limits, support obligation, evidence
-scope, and contractual risk. Do not quote an organization tier or limit until
-enforcement and entitlements are active for that environment.
+Code already published under Apache 2.0 remains under that license. Commercial
+value comes from hosted operation, managed capacity, organizational controls,
+deployment assurance, support, and contractual commitments—not from pretending
+the public code requires a new license.
 
 See the [Community and commercial boundary](community-cloud-boundary.md) and
 the [managed billing design](billing.md).


### PR DESCRIPTION
## What changed

- reframe the README around one Lians memory product with two delivery modes: free Local and $10/month managed Personal
- remove the star/follow request from the pre-value navigation
- replace duplicated Personal sales sections with one comparison and one honest decision rule
- consolidate Team, Regulated, Enterprise, and Air-Gap into organization deployment options around the same product
- keep the local-first, Apache-2.0, provider-neutral, and nontechnical-user boundaries explicit

## Why

The repository currently gives a new visitor too many simultaneous product decisions before they understand the basic memory loop. This change makes the first mental model concrete:

1. remember;
2. recall;
3. inspect, correct, or forget;
4. choose whether to run it locally or have Lians operate it.

Advanced organizational capabilities remain available, but they no longer look like separate public products.

## User impact

A developer, student, researcher, or individual AI-tool user can understand the product and choose a working path from the top of the README. Organization buyers see deployment and service scope without being asked to pick from multiple premature SKUs.

No website, pricing amount, allowance, product behavior, license, installer, or API surface changed.

## Validation

- `git diff --check`
- `python -m pytest agentmem/tests/test_distribution_contract.py agentmem/tests/test_product_manifest.py -q` — 10 passed
