### PR TITLE
docs: publish verified cross-agent memory proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The product loop is deliberately small:
 Lians works through MCP, plugins, and SDKs. Local mode stores memory in SQLite,
 needs no Lians account or API key, and does not lock memory to one model vendor.
 
+<p align="center">
+  <img src="docs/assets/cross-tool-memory-flow.svg" width="100%" alt="A project preference saved in Cursor flows through the encrypted Lians Bridge into a new Codex or Claude task with an inspectable receipt and controls to correct, pause, or forget it.">
+</p>
+
 ## Tested across real AI clients
 
 On August 14, 2026, a live hosted-MCP test stored one synthetic project memory

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians"><img src="https://img.shields.io/badge/MCP-Official%20Registry-blueviolet" alt="MCP Official Registry"></a>
   <a href="https://glama.ai/mcp/servers/Lians-ai/Lians"><img src="https://glama.ai/mcp/servers/Lians-ai/Lians/badges/score.svg" alt="Glama MCP quality score"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 license"></a>
+  <a href="https://github.com/Lians-ai/Lians/stargazers"><img src="https://img.shields.io/github/stars/Lians-ai/Lians?style=social" alt="Star Lians on GitHub"></a>
 </p>
 
 # Portable memory for the AI tools you already use.
@@ -34,6 +35,23 @@ The product loop is deliberately small:
 
 Lians works through MCP, plugins, and SDKs. Local mode stores memory in SQLite,
 needs no Lians account or API key, and does not lock memory to one model vendor.
+
+## Tested across real AI clients
+
+On August 14, 2026, a live hosted-MCP test stored one synthetic project memory
+through Cursor, recalled it in a separate Cursor chat, and then recalled the
+same exact codeword in a fresh Claude Code session. After confirmed deletion,
+Cursor returned no matching memory.
+
+In a separate balanced Cursor CLI stress test, bounded Lians-style context used
+**24.72% fewer provider-reported input tokens** than a 201-line always-applied
+Cursor rule while preserving all four exact answers. This is one synthetic
+large-rule workload, not a promise of universal token savings.
+
+[Read the methodology, raw aggregate evidence, and current platform blockers](docs/benchmarks/cross-agent-memory-2026-08-14.md).
+If this is the kind of portable memory you want agents to have,
+[star Lians](https://github.com/Lians-ai/Lians/stargazers) and try the
+[three-minute memory challenge](https://github.com/Lians-ai/Lians/discussions/122).
 
 ## One product, two ways to run it
 

--- a/docs/assets/cross-tool-memory-flow.svg
+++ b/docs/assets/cross-tool-memory-flow.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title description">
   <title id="title">The Lians cross-tool memory moment</title>
-  <desc id="description">A preference saved in Cursor is recalled in a new Codex or Claude task with an inspectable Lians receipt and correction and forgetting controls.</desc>
+  <desc id="description">The Lians blue lotus marks a flow where a preference saved in Cursor is recalled in a new Codex or Claude task with an inspectable receipt and correction and forgetting controls.</desc>
   <defs>
     <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#05070b"/>
@@ -21,6 +21,19 @@
   <rect width="1200" height="630" rx="30" fill="url(#background)"/>
   <circle cx="1078" cy="42" r="180" fill="#3777ff" opacity="0.08"/>
   <circle cx="92" cy="620" r="210" fill="#7657ff" opacity="0.07"/>
+
+  <g transform="translate(1064 18) scale(0.1328125)" aria-label="Lians blue lotus">
+    <rect width="512" height="512" rx="88" fill="#05070b"/>
+    <g fill="#1b4da1" stroke="#05070b" stroke-width="12" stroke-linejoin="round">
+      <path d="M256 92c-52 55-75 112-75 169 0 53 25 98 75 139 50-41 75-86 75-139 0-57-23-114-75-169z"/>
+      <path d="M172 142c-22-18-45-31-70-39-8 32-6 65 5 98 12 35 38 68 78 98-11-24-17-49-17-75 0-27 2-55 4-82z"/>
+      <path d="M340 142c22-18 45-31 70-39 8 32 6 65-5 98-12 35-38 68-78 98 11-24 17-49 17-75 0-27-2-55-4-82z"/>
+      <path d="M167 188c-45-28-91-40-139-34 4 58 28 107 72 148 38 36 87 55 147 58-54-38-81-96-80-172z"/>
+      <path d="M345 188c45-28 91-40 139-34-4 58-28 107-72 148-38 36-87 55-147 58 54-38 81-96 80-172z"/>
+      <path d="M91 256c-31 2-58 12-81 31 40 66 99 102 177 107 27 2 52-4 69-15-65-8-120-49-165-123z"/>
+      <path d="M421 256c31 2 58 12 81 31-40 66-99 102-177 107-27 2-52-4-69-15 65-8 120-49 165-123z"/>
+    </g>
+  </g>
 
   <g font-family="Segoe UI, Inter, Arial, sans-serif">
     <text x="64" y="67" fill="#4f87ff" font-size="19" font-weight="700" letter-spacing="3">LIANS MEMORY</text>

--- a/docs/assets/cross-tool-memory-flow.svg
+++ b/docs/assets/cross-tool-memory-flow.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title description">
+  <title id="title">The Lians cross-tool memory moment</title>
+  <desc id="description">A preference saved in Cursor is recalled in a new Codex or Claude task with an inspectable Lians receipt and correction and forgetting controls.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#05070b"/>
+      <stop offset="1" stop-color="#0b1324"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#3777ff"/>
+      <stop offset="1" stop-color="#7657ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="18" flood-color="#000000" flood-opacity="0.34"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7798ff"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="630" rx="30" fill="url(#background)"/>
+  <circle cx="1078" cy="42" r="180" fill="#3777ff" opacity="0.08"/>
+  <circle cx="92" cy="620" r="210" fill="#7657ff" opacity="0.07"/>
+
+  <g font-family="Segoe UI, Inter, Arial, sans-serif">
+    <text x="64" y="67" fill="#4f87ff" font-size="19" font-weight="700" letter-spacing="3">LIANS MEMORY</text>
+    <text x="64" y="116" fill="#f5f7fb" font-size="36" font-weight="700">Say it once. Start a new task. It is already there.</text>
+    <text x="64" y="151" fill="#9ba8ba" font-size="19">One encrypted memory layer for the AI tools you already use.</text>
+
+    <g filter="url(#shadow)">
+      <rect x="64" y="204" width="330" height="250" rx="20" fill="#0d1420" stroke="#25334a"/>
+      <rect x="435" y="204" width="330" height="250" rx="20" fill="#0d1420" stroke="#25334a"/>
+      <rect x="806" y="204" width="330" height="250" rx="20" fill="#0d1420" stroke="#25334a"/>
+    </g>
+
+    <circle cx="98" cy="244" r="18" fill="#263451"/>
+    <text x="98" y="251" text-anchor="middle" fill="#dce6ff" font-size="17" font-weight="700">C</text>
+    <text x="128" y="251" fill="#f5f7fb" font-size="19" font-weight="700">Cursor</text>
+    <text x="92" y="297" fill="#8fa0b8" font-size="15" font-weight="600" letter-spacing="1">YOU SAY</text>
+    <rect x="90" y="316" width="278" height="91" rx="14" fill="#131d2d"/>
+    <text x="109" y="345" fill="#dce4ef" font-size="16">
+      <tspan x="109" dy="0">“Remember that we use FastAPI</tspan>
+      <tspan x="109" dy="24">and never write migrations</tspan>
+      <tspan x="109" dy="24">manually.”</tspan>
+    </text>
+    <circle cx="104" cy="429" r="7" fill="#4fe0a0"/>
+    <text x="120" y="435" fill="#9ba8ba" font-size="15">Saved to this project</text>
+
+    <circle cx="469" cy="244" r="18" fill="#263451"/>
+    <path d="M460 245h18M469 236v18" stroke="#dce6ff" stroke-width="2" stroke-linecap="round"/>
+    <text x="499" y="251" fill="#f5f7fb" font-size="19" font-weight="700">Lians Bridge</text>
+    <text x="463" y="297" fill="#8fa0b8" font-size="15" font-weight="600" letter-spacing="1">BOUNDED RECALL</text>
+    <rect x="461" y="316" width="278" height="91" rx="14" fill="#111c31" stroke="#2c4e91"/>
+    <text x="480" y="344" fill="#dce4ef" font-size="16">
+      <tspan x="480" dy="0">Global preferences</tspan>
+      <tspan x="480" dy="25">Project rules</tspan>
+      <tspan x="480" dy="25">Relevant handoff</tspan>
+    </text>
+    <text x="480" y="435" fill="#7798ff" font-size="15">Encrypted • scoped • current</text>
+
+    <circle cx="840" cy="244" r="18" fill="#263451"/>
+    <text x="840" y="251" text-anchor="middle" fill="#dce6ff" font-size="15" font-weight="700">AI</text>
+    <text x="870" y="251" fill="#f5f7fb" font-size="19" font-weight="700">New Codex or Claude task</text>
+    <text x="834" y="297" fill="#8fa0b8" font-size="15" font-weight="600" letter-spacing="1">LIANS RECEIPT</text>
+    <rect x="832" y="316" width="278" height="91" rx="14" fill="#11251f" stroke="#28684f"/>
+    <circle cx="854" cy="342" r="7" fill="#4fe0a0"/>
+    <text x="871" y="348" fill="#dcf8eb" font-size="16" font-weight="700">3 memories used</text>
+    <text x="851" y="378" fill="#a5c4b7" font-size="15">Lians project • inspect why</text>
+    <text x="851" y="432" fill="#9ba8ba" font-size="15">FastAPI • no manual migrations</text>
+
+    <path d="M400 329 H425" stroke="#7798ff" stroke-width="3" marker-end="url(#arrow)"/>
+    <path d="M771 329 H796" stroke="#7798ff" stroke-width="3" marker-end="url(#arrow)"/>
+
+    <rect x="64" y="493" width="1072" height="79" rx="18" fill="#0c1320" stroke="#25334a"/>
+    <rect x="84" y="513" width="246" height="39" rx="19" fill="url(#accent)"/>
+    <text x="207" y="539" text-anchor="middle" fill="#ffffff" font-size="16" font-weight="700">New task. Same rules.</text>
+    <text x="371" y="539" fill="#b1bdcc" font-size="16">Exact source and time</text>
+    <circle cx="351" cy="533" r="4" fill="#4f87ff"/>
+    <text x="589" y="539" fill="#b1bdcc" font-size="16">Why recalled</text>
+    <circle cx="569" cy="533" r="4" fill="#4f87ff"/>
+    <text x="747" y="539" fill="#b1bdcc" font-size="16">Correct</text>
+    <circle cx="727" cy="533" r="4" fill="#4f87ff"/>
+    <text x="857" y="539" fill="#b1bdcc" font-size="16">Pause</text>
+    <circle cx="837" cy="533" r="4" fill="#4f87ff"/>
+    <text x="956" y="539" fill="#b1bdcc" font-size="16">Forget</text>
+    <circle cx="936" cy="533" r="4" fill="#4f87ff"/>
+
+    <text x="64" y="607" fill="#6f7f94" font-size="14">Product flow • receipt values are illustrative; benchmark and live-test claims are documented below.</text>
+  </g>
+</svg>

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -33,6 +33,10 @@ are not directly comparable to LLM-judged answer-accuracy leaderboards.
 
 ## Public retrieval and answer benchmarks
 
+- [Cross-agent memory evidence, August 14, 2026](cross-agent-memory-2026-08-14.md)
+  records a live Cursor-to-Claude handoff, confirmed deletion, a balanced Cursor
+  native-rule comparison, and the exact platform blockers observed during the
+  same test window.
 - [LOCOMO reports](../../agentmem/docs/benchmarks/) preserve the exact protocol,
   embedding configuration, scoring method, and limitations for each published
   run.

--- a/docs/benchmarks/cross-agent-memory-2026-08-14.json
+++ b/docs/benchmarks/cross-agent-memory-2026-08-14.json
@@ -1,0 +1,51 @@
+{
+  "schema": "lians.cross-agent-memory-evidence.v1",
+  "observed_at": "2026-08-14",
+  "evidence_class": "operator_observed_live_clients_and_provider_usage",
+  "cross_agent_handoff": {
+    "writer": "Cursor Agent CLI 2026.08.11-e8db854",
+    "reader": "Claude Code 2.1.210",
+    "synthetic_data_only": true,
+    "separate_cursor_recall_session": true,
+    "separate_claude_recall_session": true,
+    "cursor_exact_recall": true,
+    "claude_exact_recall": true,
+    "confirmed_forget": true,
+    "cursor_post_forget_absent": true,
+    "claude_post_forget_result": "ABSENT",
+    "claude_additional_shell_fallback_denied": true
+  },
+  "cursor_native_rule_baab": {
+    "execution_order": [
+      "candidate",
+      "native",
+      "native",
+      "candidate"
+    ],
+    "model_requested": "auto",
+    "candidate_context_characters": 568,
+    "native_rule_characters": 21166,
+    "native_rule_lines": 201,
+    "candidate_exact_answers": 2,
+    "native_exact_answers": 2,
+    "candidate_provider_input_tokens": 30048,
+    "native_provider_input_tokens": 39914,
+    "provider_input_token_reduction_percent": 24.7181,
+    "same_input_budget_usage_multiplier": 1.3283,
+    "candidate_to_native_mean_latency_ratio": 0.9333,
+    "provider_reported_cost": null
+  },
+  "prior_claude_balanced_evidence": {
+    "bounded_vs_full_history_input_reduction_percent": 97.1564,
+    "bounded_vs_large_native_auto_memory_input_reduction_percent": 86.0779,
+    "exact_answers_across_both_tests": "8/8"
+  },
+  "platform_status": {
+    "cursor": "passed_live_handoff_and_balanced_token_test",
+    "claude": "passed_live_handoff_and_prior_balanced_token_tests",
+    "codex": "hosted_config_installed_but_restart_and_oauth_pending",
+    "copilot": "blocked_by_organization_policy",
+    "gemini": "blocked_by_google_unsupported_client_response"
+  },
+  "claim_boundary": "One live Cursor-to-Claude handoff and workload-scoped Cursor and Claude measurements; not a five-client, typical-workload, provider-quota, or universal-savings claim."
+}

--- a/docs/benchmarks/cross-agent-memory-2026-08-14.md
+++ b/docs/benchmarks/cross-agent-memory-2026-08-14.md
@@ -1,0 +1,85 @@
+# Cross-agent memory evidence
+
+Date: August 14, 2026
+
+Status: live two-client handoff and workload-scoped token evidence
+
+## Outcome
+
+A live hosted-MCP test completed this sequence with synthetic data:
+
+1. Cursor Agent CLI stored one project-scoped memory.
+2. A separate Cursor chat recalled the exact codeword.
+3. A fresh Claude Code session, authenticated to the same hosted Lians account,
+   recalled the same exact codeword.
+4. The memory was permanently forgotten after explicit confirmation.
+5. A fresh Cursor recall returned `ABSENT`.
+6. A fresh Claude check also returned `ABSENT`; Claude attempted an additional
+   shell fallback, which the permission policy denied.
+
+This proves one live Cursor-to-Claude continuity path. It does not prove a
+five-client handoff, typical latency, or installed-MCP token economics.
+
+## Cursor native-rule comparison
+
+Cursor CLI 2026.08.11-e8db854 ran a balanced
+candidate/native/native/candidate sequence on its free-plan `auto` model.
+
+- The native arm loaded a synthetic 201-line, 21,166-character
+  always-applied `.cursor/rules` file.
+- The bounded arm received one 568-character relevant evidence pack.
+- Both arms answered a derived-date question whose gold answer was not copied
+  into either user prompt.
+- Provider input accounting included fresh, cache-read, and cache-write tokens.
+
+| Metric | Bounded context | Cursor rule |
+|---|---:|---:|
+| Runs | 2 | 2 |
+| Exact answers | 2/2 | 2/2 |
+| Pooled provider input tokens | 30,048 | 39,914 |
+| Mean latency ratio | 0.9333x | 1.0000x |
+
+Observed effect: **24.7181% fewer input tokens** and a **1.3283x**
+same-input-budget multiplier, with all four answers exact. Cursor did not report
+cost. The machine-readable aggregate is
+[`cross-agent-memory-2026-08-14.json`](cross-agent-memory-2026-08-14.json).
+
+## Platform matrix
+
+| Client | Live result | Boundary or blocker |
+|---|---|---|
+| Cursor | Authenticated; store and fresh-chat recall exact | Token A/B used bounded prompt delivery, not an installed MCP call |
+| Claude Code | Authenticated; fresh-session recall of Cursor record exact | Installed MCP handoff tested; token economics measured separately |
+| Codex | Hosted MCP configuration installed | Running plugin still used a separate local database; restart and hosted OAuth remained |
+| GitHub Copilot CLI | Hosted MCP configuration recognized | Organization policy disabled third-party MCP and denied the model call |
+| Gemini CLI 0.55.1 | Google OAuth completed for two eligible browser sessions | Google returned `UNSUPPORTED_CLIENT` and directed this CLI client/tier to Antigravity |
+
+## Prior Claude context evidence
+
+Two separate balanced Claude Code tests also retained exact answer quality:
+
+- bounded evidence versus full frozen history: 97.1564% fewer reported input
+  tokens on one LOCOMO workload;
+- bounded evidence versus a synthetic large native auto-memory index: 86.0779%
+  fewer reported input tokens.
+
+Those are high-history stress tests. They are not typical-memory averages or
+provider-quota increases.
+
+## Claim boundary
+
+Allowed:
+
+- A memory stored through Cursor was recalled exactly from a fresh Claude Code
+  session through the same hosted Lians account.
+- Confirmed forgetting made the synthetic record absent from a fresh Cursor
+  recall.
+- In the declared Cursor large-rule workload, bounded context reduced reported
+  input tokens by 24.72% while preserving four of four exact answers.
+
+Not allowed:
+
+- Lians has completed live continuity tests across every packaged client.
+- Lians increases provider plan quotas or saves 24.72% on every prompt.
+- The running Codex local plugin and hosted Lians account are already one store.
+- Copilot and Gemini passed their installed-MCP tests.


### PR DESCRIPTION
## Summary

- adds a live GitHub star badge and a near-top proof section to the README
- adds a 1200x630 cross-tool product-flow visual for the Cursor -> Lians -> Codex/Claude memory moment
- publishes the August 14 Cursor-to-Claude memory handoff, confirmed deletion result, and balanced Cursor token comparison
- records Codex, Copilot, and Gemini blockers explicitly so the public claim stays narrower than the evidence
- includes a machine-readable aggregate for future regression and marketing comparisons

## Why

Recent repository traffic shows meaningful discovery but weak star conversion. This moves the strongest verified product proof close to the first-screen value proposition, makes the cross-tool experience understandable before a visitor reads setup instructions, and gives visitors a concrete next action without claiming universal savings or five-client support.

The visual labels receipt values illustrative; measured and live-test claims remain linked to the evidence below it.

## Verification

- `python -c "import xml.etree.ElementTree as ET; ET.parse('docs/assets/cross-tool-memory-flow.svg')"`
- rendered the SVG at 1200x630 in headless Chrome and visually inspected it
- `python -m json.tool docs/benchmarks/cross-agent-memory-2026-08-14.json`
- `git diff --check`
- `python -m pytest -q agentmem/tests/test_distribution_contract.py agentmem/tests/test_published_release_status.py` - 17 passed

## Claim boundary

This PR claims one live Cursor-to-Claude hosted-memory handoff, confirmed forgetting, and workload-scoped Cursor/Claude token measurements. It does not claim universal token savings, provider quota increases, or successful installed-MCP tests on every listed platform.
