### PR TITLE
test: classify MCP mutation approval hints

### DIFF
--- a/agentmem/sdk/python/tests/test_mcp_local.py
+++ b/agentmem/sdk/python/tests/test_mcp_local.py
@@ -206,7 +206,7 @@ def test_local_query_routes_parse_query_strings(monkeypatch):
     assert history == {"ticker": "NVDA", "items": []}
 
 
-def test_mcp_tools_advertise_safe_approval_hints():
+def test_mcp_tools_advertise_accurate_approval_hints():
     server = mcp_server._build_server()
     handler = next(
         callback
@@ -220,9 +220,16 @@ def test_mcp_tools_advertise_safe_approval_hints():
     recall_schema = tools["recall"].inputSchema["properties"]
     assert recall_schema["k"]["default"] == 50
     assert recall_schema["max_tokens"]["default"] == 2650
-    assert tools["remember"].annotations.readOnlyHint is False
-    assert tools["remember"].annotations.idempotentHint is False
-    for name in set(tools) - {"remember"}:
+    for name in ("remember", "correct_memory"):
+        assert tools[name].annotations.readOnlyHint is False
+        assert tools[name].annotations.destructiveHint is False
+        assert tools[name].annotations.idempotentHint is False
+
+    assert tools["forget_memory"].annotations.readOnlyHint is False
+    assert tools["forget_memory"].annotations.destructiveHint is True
+    assert tools["forget_memory"].annotations.idempotentHint is True
+
+    for name in set(tools) - {"remember", "correct_memory", "forget_memory"}:
         assert tools[name].annotations.readOnlyHint is True
         assert tools[name].annotations.destructiveHint is False
         assert tools[name].annotations.idempotentHint is True


### PR DESCRIPTION
## Summary

- updates the local MCP approval-hints test to distinguish read-only tools from mutating tools
- protects `correct_memory` as a non-destructive, non-idempotent write
- protects `forget_memory` as a destructive, idempotent write
- leaves the production tool annotations unchanged because they were already correct

## Why

The old test assumed every tool except `remember` was read-only. That became stale when correction and confirmed forgetting were added, causing the focused local MCP suite to fail even though the runtime advertised the safe annotations correctly.

## Verification

- `agentmem/sdk/python/tests/test_mcp_local.py` — 46 passed
- Ruff — passed
- distribution/release contract tests — 17 passed
- `git diff --check`

## Product behavior

Protects the existing user-control and confirmed-deletion contract; no runtime behavior changes.