### PR TITLE
feat: add verified Antigravity plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ exposes the basic loop plus the controls needed to trust it:
 
 Use the exact setup guide for
 [Cursor](integrations/cursor),
+[Antigravity CLI](integrations/antigravity),
 [Gemini CLI](integrations/gemini),
 [Claude Code](integrations/lians-plugin), or
 [OpenCode](integrations/opencode), or

--- a/agentmem/tests/test_distribution_contract.py
+++ b/agentmem/tests/test_distribution_contract.py
@@ -30,6 +30,22 @@ def test_gemini_extension_uses_the_published_bounded_server():
     assert server["timeout"] == 300000
 
 
+def test_antigravity_starter_uses_current_global_mcp_shape():
+    server = _json("integrations/antigravity/mcp_config.example.json")["mcpServers"]["lians"]
+    guide = (ROOT / "integrations/antigravity/README.md").read_text(encoding="utf-8")
+
+    assert server["command"] == "uvx"
+    assert server["args"] == ["--from", "lians-sdk[mcp]", "lians-mcp"]
+    assert server["env"] == {
+        "LIANS_MCP_ENABLED_TOOLS": (
+            "remember,recall,list_memories,correct_memory,forget_memory"
+        )
+    }
+    assert server["disabled"] is False
+    assert "~/.gemini/config/mcp_config.json" in guide
+    assert "consumer Google-login access" in guide
+
+
 def test_cursor_starter_profile_is_local_bounded_stdio():
     server = _json("integrations/cursor/mcp.example.json")["mcpServers"]["lians"]
 

--- a/docs/benchmarks/antigravity-cli-2026-08-14.md
+++ b/docs/benchmarks/antigravity-cli-2026-08-14.md
@@ -1,0 +1,54 @@
+# Antigravity CLI compatibility check — 2026-08-14
+
+This check used Antigravity CLI 1.1.13 on Windows with a fresh empty project,
+the Lians Easy local MCP runtime, a disposable database, and narrowly scoped
+MCP permissions. No dangerous global auto-approval was used.
+
+## Result
+
+The global `~/.gemini/config/mcp_config.json` route discovered Lians schemas but
+did not expose an invocable Lians tool in a fresh safe session. Packaging the
+same MCP server as an Antigravity plugin exposed `call_mcp_tool` and completed
+the memory lifecycle across new conversations:
+
+1. `remember` stored a disposable memory in 0.045 seconds.
+2. A fresh conversation recalled it in 0.071 seconds.
+3. `forget_memory` erased its content in 0.096 seconds.
+4. A final fresh conversation returned `No relevant memories found` in 0.055
+   seconds. The disposable database was then removed.
+
+Antigravity changed the explicitly supplied memory payload to the single word
+`Synthetic` before calling the tool. The lifecycle passed for the value the
+host actually sent, but exact argument preservation did not pass. This is a
+host-agent reliability boundary and should remain visible in compatibility
+claims.
+
+## Host token baseline
+
+| Fresh Antigravity turn | Total tokens | Lians tool time |
+| --- | ---: | ---: |
+| Write | 45,485 | 0.045 s |
+| Recall | 20,983 | 0.071 s |
+| Forget | 22,883 | 0.096 s |
+| Recall after forgetting | 21,942 | 0.055 s |
+
+These totals are Antigravity host usage, not Lians context size. This run does
+not prove token reduction. It shows that the MCP operations were fast while the
+host's fixed prompt and reasoning overhead dominated the end-to-end token bill.
+Future token claims should compare the same task with and without recalled
+context under the same host, model, permissions, and prompt.
+
+## Reproducibility boundary
+
+- Host: Antigravity CLI 1.1.13
+- OS: Windows
+- Transport: local stdio MCP through an Antigravity plugin
+- Memory runtime: Lians Easy local SQLite
+- Isolation: fresh conversations in an empty project
+- Cleanup: memory content erased, post-delete recall verified empty, disposable
+  database removed
+
+The plugin route is a compatibility workaround for Google's open
+[Antigravity CLI issue #71](https://github.com/google-antigravity/antigravity-cli/issues/71),
+which tracks custom MCP servers whose schemas are discovered but whose tools are
+not invocable through the ordinary configuration path.

--- a/docs/easy-install.md
+++ b/docs/easy-install.md
@@ -56,6 +56,11 @@ subscriptions, API keys, and Vertex AI configurations after Google's June 18,
 connectors use a hosted HTTP connection rather than a local stdio process. Use
 a hosted Lians connector when that distribution is available.
 
+Antigravity is configured through its plugin loader, not the ordinary global
+MCP file. This is the route verified to expose invocable custom MCP tools on
+Antigravity CLI 1.1.13; see the
+[compatibility evidence](benchmarks/antigravity-cli-2026-08-14.md).
+
 ## IT and enterprise deployment
 
 The same artifact supports non-interactive deployment. Review detected paths:

--- a/docs/easy-install.md
+++ b/docs/easy-install.md
@@ -48,10 +48,13 @@ The core tools are intentionally understandable:
 
 ## Supported clients
 
-The first desktop release configures Claude Desktop, Cursor, Windsurf, Gemini
-CLI, and Codex. It does not modify ChatGPT because ChatGPT connectors use a
-hosted HTTP connection rather than a local stdio process. Use a hosted Lians
-connector when that distribution is available.
+The first desktop release configures Claude Desktop, Cursor, Windsurf,
+Antigravity CLI, Gemini CLI, and Codex. Choose Antigravity for a consumer Google
+account. The Gemini CLI target is for supported Standard or Enterprise
+subscriptions, API keys, and Vertex AI configurations after Google's June 18,
+2026 consumer-login retirement. It does not modify ChatGPT because ChatGPT
+connectors use a hosted HTTP connection rather than a local stdio process. Use
+a hosted Lians connector when that distribution is available.
 
 ## IT and enterprise deployment
 
@@ -64,19 +67,19 @@ LiansMemory doctor --json
 Preview an exact install without writing anything:
 
 ```bash
-LiansMemory install --clients claude,cursor,codex --plan --json
+LiansMemory install --clients claude,cursor,antigravity,codex --plan --json
 ```
 
 Install for selected clients:
 
 ```bash
-LiansMemory install --clients claude,cursor,codex --yes --json
+LiansMemory install --clients claude,cursor,antigravity,codex --yes --json
 ```
 
 Remove the managed client entries while preserving the user's memory database:
 
 ```bash
-LiansMemory uninstall --clients claude,cursor,codex --yes --json
+LiansMemory uninstall --clients claude,cursor,antigravity,codex --yes --json
 ```
 
 Every write is idempotent and creates a timestamped backup when a configuration

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,8 @@ self-hosted Lians server.
 ## Existing AI client: use MCP
 
 This is the recommended path for Claude Desktop, Cursor, Windsurf, VS Code,
-Gemini CLI, and other MCP-compatible agents.
+Antigravity CLI, supported Gemini CLI deployments, and other MCP-compatible
+agents.
 
 Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then add
 this server to your client's MCP configuration:
@@ -44,6 +45,7 @@ reconstruction, lineage, conflict, and backtest tools.
 Client-specific examples:
 
 - [Cursor](../integrations/cursor)
+- [Antigravity CLI](../integrations/antigravity)
 - [Gemini CLI](../integrations/gemini)
 - [Claude Code](../integrations/lians-plugin)
 - [Codex](../plugins/lians-memory)

--- a/integrations/antigravity/README.md
+++ b/integrations/antigravity/README.md
@@ -4,6 +4,13 @@ Antigravity CLI is Google's supported consumer successor to Gemini CLI. Lians
 adds durable local memory through MCP, so useful context can survive a new
 conversation or a switch to another Lians-enabled client.
 
+> **Verified route:** Antigravity CLI 1.1.13 exposed and invoked Lians tools
+> when Lians was packaged as an Antigravity plugin. The global
+> `~/.gemini/config/mcp_config.json` route discovered schemas but did not expose
+> a usable tool in a fresh agent session, matching Google's open
+> [MCP invocation issue #71](https://github.com/google-antigravity/antigravity-cli/issues/71).
+> Lians Easy therefore installs the plugin route.
+
 ## Install with Lians Easy
 
 Select **Antigravity CLI** in Lians Easy, or run:
@@ -12,16 +19,25 @@ Select **Antigravity CLI** in Lians Easy, or run:
 LiansMemory install --clients antigravity --yes --json
 ```
 
-Restart Antigravity CLI and run `/mcp` to confirm that `lians` is available.
-The installer backs up and safely merges the global configuration at
-`~/.gemini/config/mcp_config.json`.
+Restart Antigravity CLI, then run `agy plugin list`. The `lians-memory` entry
+should report `mcpServers` in its components. The installer backs up and safely
+merges these files:
+
+- `~/.gemini/config/plugins/lians-memory/plugin.json`
+- `~/.gemini/config/plugins/lians-memory/mcp_config.json`
+- `~/.gemini/config/plugins.json`
 
 ## Manual setup
 
 1. Install [`uv`](https://docs.astral.sh/uv/).
-2. Merge [`mcp_config.example.json`](mcp_config.example.json) into
-   `~/.gemini/config/mcp_config.json`.
-3. Restart Antigravity CLI and run `/mcp`.
+2. Create `~/.gemini/config/plugins/lians-memory/`.
+3. Copy [`plugin.example.json`](plugin.example.json) to `plugin.json` and
+   [`mcp_config.example.json`](mcp_config.example.json) to `mcp_config.json`
+   inside that directory.
+4. Add the absolute `~/.gemini/config/plugins` path to
+   `~/.gemini/config/plugins.json`, with `lians-memory` in `include_only`.
+   Antigravity rejects `~` in this registry path; it must be absolute.
+5. Restart Antigravity CLI and run `agy plugin list`.
 
 The starter exposes the memory lifecycle through `remember`, `recall`,
 `list_memories`, `correct_memory`, and explicitly confirmed `forget_memory`.
@@ -42,3 +58,5 @@ for the current boundary.
 Lians can reduce repeated input context when a workflow repeatedly needs facts
 that fit in a smaller recall result. It does not enlarge a model's context
 window, increase Google quotas, or guarantee lower token use on every task.
+The verified lifecycle and host-token measurements are recorded in
+[`docs/benchmarks/antigravity-cli-2026-08-14.md`](../../docs/benchmarks/antigravity-cli-2026-08-14.md).

--- a/integrations/antigravity/README.md
+++ b/integrations/antigravity/README.md
@@ -1,0 +1,44 @@
+# Lians Memory for Antigravity CLI
+
+Antigravity CLI is Google's supported consumer successor to Gemini CLI. Lians
+adds durable local memory through MCP, so useful context can survive a new
+conversation or a switch to another Lians-enabled client.
+
+## Install with Lians Easy
+
+Select **Antigravity CLI** in Lians Easy, or run:
+
+```bash
+LiansMemory install --clients antigravity --yes --json
+```
+
+Restart Antigravity CLI and run `/mcp` to confirm that `lians` is available.
+The installer backs up and safely merges the global configuration at
+`~/.gemini/config/mcp_config.json`.
+
+## Manual setup
+
+1. Install [`uv`](https://docs.astral.sh/uv/).
+2. Merge [`mcp_config.example.json`](mcp_config.example.json) into
+   `~/.gemini/config/mcp_config.json`.
+3. Restart Antigravity CLI and run `/mcp`.
+
+The starter exposes the memory lifecycle through `remember`, `recall`,
+`list_memories`, `correct_memory`, and explicitly confirmed `forget_memory`.
+Local mode needs no Lians account or API key. The same local database can be
+used by other MCP clients configured through Lians Easy.
+
+## Gemini CLI users
+
+Google ended consumer Google-login access to Gemini CLI on June 18, 2026. Use
+Antigravity CLI for a consumer Google account. Gemini CLI remains a separate
+Lians target for supported Standard or Enterprise subscriptions, API keys, and
+Vertex AI configurations. See Google's
+[consumer-account deprecation notice](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals)
+for the current boundary.
+
+## Claim boundary
+
+Lians can reduce repeated input context when a workflow repeatedly needs facts
+that fit in a smaller recall result. It does not enlarge a model's context
+window, increase Google quotas, or guarantee lower token use on every task.

--- a/integrations/antigravity/mcp_config.example.json
+++ b/integrations/antigravity/mcp_config.example.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "lians": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "lians-sdk[mcp]",
+        "lians-mcp"
+      ],
+      "env": {
+        "LIANS_MCP_ENABLED_TOOLS": "remember,recall,list_memories,correct_memory,forget_memory"
+      },
+      "disabled": false
+    }
+  }
+}

--- a/integrations/antigravity/plugin.example.json
+++ b/integrations/antigravity/plugin.example.json
@@ -1,0 +1,3 @@
+{
+  "name": "lians-memory"
+}

--- a/integrations/gemini/README.md
+++ b/integrations/gemini/README.md
@@ -4,6 +4,13 @@ This starter profile gives Gemini CLI durable local memory through MCP. It is
 provider-neutral: the same local Lians store can support other MCP clients, so
 memory is not locked to Gemini or its model provider.
 
+> **Consumer account notice:** Google ended consumer Google-login access to
+> Gemini CLI on June 18, 2026. Consumer users should follow the
+> [Antigravity CLI integration](../antigravity/). This Gemini CLI path remains
+> applicable to supported Standard or Enterprise subscriptions, Gemini API
+> keys, and Vertex AI configurations. See Google's
+> [deprecation notice](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals).
+
 ## Install
 
 1. Install [`uv`](https://docs.astral.sh/uv/).

--- a/packages/lians-easy/README.md
+++ b/packages/lians-easy/README.md
@@ -8,7 +8,7 @@ Normal users should download the standalone app from GitHub Releases and
 double-click it. Developers and IT teams can run the same installer from source:
 
 ```bash
-python -m lians_easy install --clients claude,cursor --yes
+python -m lians_easy install --clients claude,cursor,antigravity --yes
 python -m lians_easy doctor --json
 ```
 

--- a/packages/lians-easy/lians_easy/cli.py
+++ b/packages/lians-easy/lians_easy/cli.py
@@ -46,7 +46,10 @@ def parser() -> argparse.ArgumentParser:
         command.add_argument(
             "--clients",
             default="detected",
-            help="Comma-separated claude,cursor,windsurf,gemini,codex; or detected/all",
+            help=(
+                "Comma-separated claude,cursor,windsurf,antigravity,gemini,codex; "
+                "or detected/all"
+            ),
         )
         command.add_argument("--yes", action="store_true", help="Confirm a non-interactive change")
         command.add_argument("--plan", action="store_true", help="Show exact targets without changing them")

--- a/packages/lians-easy/lians_easy/installer.py
+++ b/packages/lians-easy/lians_easy/installer.py
@@ -14,6 +14,7 @@ from typing import Any
 
 MANAGED_START = "# >>> Lians Memory (managed by Lians Easy)"
 MANAGED_END = "# <<< Lians Memory (managed by Lians Easy)"
+ANTIGRAVITY_PLUGIN_NAME = "lians-memory"
 
 
 @dataclass(frozen=True)
@@ -44,6 +45,14 @@ def user_data_dir() -> Path:
 
 def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
     home = home or Path.home()
+    antigravity_config = (
+        home
+        / ".gemini"
+        / "config"
+        / "plugins"
+        / ANTIGRAVITY_PLUGIN_NAME
+        / "mcp_config.json"
+    )
     if sys.platform == "win32":
         roaming = Path(os.environ.get("APPDATA", home / "AppData" / "Roaming"))
         paths = {
@@ -52,7 +61,7 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
             "windsurf": ("Windsurf", home / ".codeium" / "windsurf" / "mcp_config.json"),
             "antigravity": (
                 "Antigravity CLI",
-                home / ".gemini" / "config" / "mcp_config.json",
+                antigravity_config,
             ),
             "gemini": ("Gemini CLI", home / ".gemini" / "settings.json"),
             "codex": ("Codex", home / ".codex" / "config.toml"),
@@ -67,7 +76,7 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
             "windsurf": ("Windsurf", home / ".codeium" / "windsurf" / "mcp_config.json"),
             "antigravity": (
                 "Antigravity CLI",
-                home / ".gemini" / "config" / "mcp_config.json",
+                antigravity_config,
             ),
             "gemini": ("Gemini CLI", home / ".gemini" / "settings.json"),
             "codex": ("Codex", home / ".codex" / "config.toml"),
@@ -80,7 +89,7 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
             "windsurf": ("Windsurf", home / ".codeium" / "windsurf" / "mcp_config.json"),
             "antigravity": (
                 "Antigravity CLI",
-                home / ".gemini" / "config" / "mcp_config.json",
+                antigravity_config,
             ),
             "gemini": ("Gemini CLI", home / ".gemini" / "settings.json"),
             "codex": ("Codex", home / ".codex" / "config.toml"),
@@ -103,13 +112,21 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
                     configured = isinstance(existing.get("mcpServers"), dict) and (
                         "lians" in existing["mcpServers"]
                     )
+                    if key == "antigravity" and configured:
+                        configured = _antigravity_plugin_registered(home, path.parent.parent)
             except (AttributeError, json.JSONDecodeError, UnicodeDecodeError):
                 configured = False
         targets[key] = ClientTarget(
             key=key,
             label=label,
             config_path=path,
-            kind="toml" if key == "codex" else "json",
+            kind=(
+                "toml"
+                if key == "codex"
+                else "antigravity_plugin"
+                if key == "antigravity"
+                else "json"
+            ),
             detected=detected,
             configured=configured,
         )
@@ -185,6 +202,208 @@ def _json_config(path: Path, command: str, args: list[str]) -> Path | None:
     return backup
 
 
+def _read_json_object(path: Path, *, description: str) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ValueError(f"Cannot safely update invalid JSON {description}: {path}") from exc
+    if not isinstance(document, dict):
+        raise TypeError(f"Cannot safely update non-object JSON {description}: {path}")
+    return document
+
+
+def _antigravity_registry_path(home: Path) -> Path:
+    return home / ".gemini" / "config" / "plugins.json"
+
+
+def _antigravity_plugin_registered(home: Path, plugin_root: Path) -> bool:
+    registry_path = _antigravity_registry_path(home)
+    if not registry_path.exists():
+        return False
+    try:
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return False
+    entries = registry.get("entries") if isinstance(registry, dict) else None
+    if not isinstance(entries, list):
+        return False
+    expected = plugin_root.resolve()
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            continue
+        try:
+            registered = Path(entry["path"]).expanduser().resolve()
+        except (OSError, RuntimeError):
+            continue
+        if registered != expected:
+            continue
+        include_only = entry.get("include_only")
+        return include_only is None or (
+            isinstance(include_only, list) and ANTIGRAVITY_PLUGIN_NAME in include_only
+        )
+    return False
+
+
+def _antigravity_plugin_config(
+    home: Path,
+    command: str,
+    args: list[str],
+) -> list[Path]:
+    """Install through Antigravity's plugin loader, which exposes MCP tools to agents."""
+
+    plugin_dir = (
+        home / ".gemini" / "config" / "plugins" / ANTIGRAVITY_PLUGIN_NAME
+    )
+    manifest_path = plugin_dir / "plugin.json"
+    mcp_path = plugin_dir / "mcp_config.json"
+    registry_path = _antigravity_registry_path(home)
+    manifest = _read_json_object(manifest_path, description="Antigravity plugin manifest")
+    manifest["name"] = ANTIGRAVITY_PLUGIN_NAME
+    mcp_document = _read_json_object(mcp_path, description="Antigravity MCP configuration")
+    servers = mcp_document.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise TypeError(f"mcpServers must be an object in {mcp_path}")
+    servers["lians"] = {"command": command, "args": args}
+
+    registry = _read_json_object(registry_path, description="Antigravity plugin registry")
+    entries = registry.setdefault("entries", [])
+    if not isinstance(entries, list):
+        raise TypeError(f"entries must be an array in {registry_path}")
+    plugin_root = str(plugin_dir.parent.resolve()).replace("\\", "/")
+    matching = [
+        entry
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("path") == plugin_root
+    ]
+    if matching:
+        entry = matching[0]
+        include_only = entry.get("include_only")
+        if include_only is not None:
+            if not isinstance(include_only, list) or not all(
+                isinstance(value, str) for value in include_only
+            ):
+                raise TypeError(f"include_only must be a string array in {registry_path}")
+            if ANTIGRAVITY_PLUGIN_NAME not in include_only:
+                include_only.append(ANTIGRAVITY_PLUGIN_NAME)
+    else:
+        entries.append(
+            {"path": plugin_root, "include_only": [ANTIGRAVITY_PLUGIN_NAME]}
+        )
+
+    backups = [
+        candidate
+        for candidate in (
+            _backup(manifest_path),
+            _backup(mcp_path),
+            _backup(registry_path),
+        )
+        if candidate is not None
+    ]
+    _write_text(manifest_path, json.dumps(manifest, indent=2) + "\n")
+    _write_text(mcp_path, json.dumps(mcp_document, indent=2) + "\n")
+    _write_text(registry_path, json.dumps(registry, indent=2) + "\n")
+    return backups
+
+
+def _remove_antigravity_plugin(home: Path) -> list[Path]:
+    plugin_dir = (
+        home / ".gemini" / "config" / "plugins" / ANTIGRAVITY_PLUGIN_NAME
+    )
+    manifest_path = plugin_dir / "plugin.json"
+    mcp_path = plugin_dir / "mcp_config.json"
+    registry_path = _antigravity_registry_path(home)
+
+    manifest = (
+        _read_json_object(manifest_path, description="Antigravity plugin manifest")
+        if manifest_path.exists()
+        else None
+    )
+    mcp_document = (
+        _read_json_object(mcp_path, description="Antigravity MCP configuration")
+        if mcp_path.exists()
+        else None
+    )
+    registry = (
+        _read_json_object(registry_path, description="Antigravity plugin registry")
+        if registry_path.exists()
+        else None
+    )
+    if registry is not None:
+        entries = registry.get("entries")
+        if not isinstance(entries, list):
+            raise TypeError(f"entries must be an array in {registry_path}")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            include_only = entry.get("include_only")
+            if include_only is not None and (
+                not isinstance(include_only, list)
+                or not all(isinstance(value, str) for value in include_only)
+            ):
+                raise TypeError(f"include_only must be a string array in {registry_path}")
+    backups = [
+        candidate
+        for candidate in (
+            _backup(manifest_path),
+            _backup(mcp_path),
+            _backup(registry_path),
+        )
+        if candidate is not None
+    ]
+
+    if mcp_document is not None:
+        servers = mcp_document.get("mcpServers")
+        if isinstance(servers, dict):
+            servers.pop("lians", None)
+        if mcp_document == {"mcpServers": {}}:
+            mcp_path.unlink()
+        else:
+            _write_text(mcp_path, json.dumps(mcp_document, indent=2) + "\n")
+
+    if registry is not None:
+        entries = registry.get("entries")
+        if not isinstance(entries, list):
+            raise TypeError(f"entries must be an array in {registry_path}")
+        plugin_root = str(plugin_dir.parent.resolve()).replace("\\", "/")
+        updated_entries = []
+        for entry in entries:
+            if not isinstance(entry, dict) or entry.get("path") != plugin_root:
+                updated_entries.append(entry)
+                continue
+            include_only = entry.get("include_only")
+            if include_only is None:
+                # A broad user-managed root registration should keep loading other plugins.
+                updated_entries.append(entry)
+                continue
+            if not isinstance(include_only, list) or not all(
+                isinstance(value, str) for value in include_only
+            ):
+                raise TypeError(f"include_only must be a string array in {registry_path}")
+            remaining = [
+                value for value in include_only if value != ANTIGRAVITY_PLUGIN_NAME
+            ]
+            if remaining:
+                updated = dict(entry)
+                updated["include_only"] = remaining
+                updated_entries.append(updated)
+        registry["entries"] = updated_entries
+        _write_text(registry_path, json.dumps(registry, indent=2) + "\n")
+
+    if manifest is not None and manifest.get("name") == ANTIGRAVITY_PLUGIN_NAME:
+        remaining_components = [
+            path
+            for path in plugin_dir.iterdir()
+            if path.name != manifest_path.name and ".lians-backup-" not in path.name
+        ]
+        if not remaining_components:
+            manifest_path.unlink()
+    if plugin_dir.exists() and not any(plugin_dir.iterdir()):
+        plugin_dir.rmdir()
+    return backups
+
+
 def _managed_toml(command: str, args: list[str]) -> str:
     rendered_args = ", ".join(json.dumps(value) for value in args)
     return (
@@ -218,6 +437,7 @@ def _toml_config(path: Path, command: str, args: list[str]) -> Path | None:
 
 
 def install(keys: list[str], *, home: Path | None = None) -> dict[str, Any]:
+    home = home or Path.home()
     targets = client_targets(home)
     unknown = sorted(set(keys) - set(targets))
     if unknown:
@@ -227,17 +447,19 @@ def install(keys: list[str], *, home: Path | None = None) -> dict[str, Any]:
     results = []
     for key in keys:
         target = targets[key]
-        backup = (
-            _toml_config(target.config_path, command, args)
-            if target.kind == "toml"
-            else _json_config(target.config_path, command, args)
-        )
+        if target.kind == "toml":
+            backups = [backup] if (backup := _toml_config(target.config_path, command, args)) else []
+        elif target.kind == "antigravity_plugin":
+            backups = _antigravity_plugin_config(home, command, args)
+        else:
+            backups = [backup] if (backup := _json_config(target.config_path, command, args)) else []
         results.append(
             {
                 "client": key,
                 "label": target.label,
                 "config": str(target.config_path),
-                "backup": str(backup) if backup else None,
+                "backup": str(backups[0]) if backups else None,
+                "backups": [str(backup) for backup in backups],
                 "status": "installed",
             }
         )
@@ -250,6 +472,7 @@ def install(keys: list[str], *, home: Path | None = None) -> dict[str, Any]:
 
 
 def plan(keys: list[str], *, action: str, home: Path | None = None) -> dict[str, Any]:
+    home = home or Path.home()
     targets = client_targets(home)
     unknown = sorted(set(keys) - set(targets))
     if unknown:
@@ -267,6 +490,7 @@ def plan(keys: list[str], *, action: str, home: Path | None = None) -> dict[str,
 
 
 def uninstall(keys: list[str], *, home: Path | None = None) -> dict[str, Any]:
+    home = home or Path.home()
     targets = client_targets(home)
     unknown = sorted(set(keys) - set(targets))
     if unknown:
@@ -274,6 +498,17 @@ def uninstall(keys: list[str], *, home: Path | None = None) -> dict[str, Any]:
     results = []
     for key in keys:
         target = targets[key]
+        if target.kind == "antigravity_plugin":
+            backups = _remove_antigravity_plugin(home)
+            results.append(
+                {
+                    "client": key,
+                    "status": "removed" if backups else "not_configured",
+                    "backup": str(backups[0]) if backups else None,
+                    "backups": [str(backup) for backup in backups],
+                }
+            )
+            continue
         if not target.config_path.exists():
             results.append({"client": key, "status": "not_configured"})
             continue

--- a/packages/lians-easy/lians_easy/installer.py
+++ b/packages/lians-easy/lians_easy/installer.py
@@ -50,6 +50,10 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
             "claude": ("Claude Desktop", roaming / "Claude" / "claude_desktop_config.json"),
             "cursor": ("Cursor", home / ".cursor" / "mcp.json"),
             "windsurf": ("Windsurf", home / ".codeium" / "windsurf" / "mcp_config.json"),
+            "antigravity": (
+                "Antigravity CLI",
+                home / ".gemini" / "config" / "mcp_config.json",
+            ),
             "gemini": ("Gemini CLI", home / ".gemini" / "settings.json"),
             "codex": ("Codex", home / ".codex" / "config.toml"),
         }
@@ -61,6 +65,10 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
             ),
             "cursor": ("Cursor", home / ".cursor" / "mcp.json"),
             "windsurf": ("Windsurf", home / ".codeium" / "windsurf" / "mcp_config.json"),
+            "antigravity": (
+                "Antigravity CLI",
+                home / ".gemini" / "config" / "mcp_config.json",
+            ),
             "gemini": ("Gemini CLI", home / ".gemini" / "settings.json"),
             "codex": ("Codex", home / ".codex" / "config.toml"),
         }
@@ -70,12 +78,21 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
             "claude": ("Claude Desktop", config / "Claude" / "claude_desktop_config.json"),
             "cursor": ("Cursor", home / ".cursor" / "mcp.json"),
             "windsurf": ("Windsurf", home / ".codeium" / "windsurf" / "mcp_config.json"),
+            "antigravity": (
+                "Antigravity CLI",
+                home / ".gemini" / "config" / "mcp_config.json",
+            ),
             "gemini": ("Gemini CLI", home / ".gemini" / "settings.json"),
             "codex": ("Codex", home / ".codex" / "config.toml"),
         }
     targets: dict[str, ClientTarget] = {}
     for key, (label, path) in paths.items():
-        detected = path.exists() or path.parent.exists()
+        if key == "antigravity":
+            detected = path.exists() or shutil.which("agy") is not None
+        elif key == "gemini":
+            detected = path.exists() or shutil.which("gemini") is not None
+        else:
+            detected = path.exists() or path.parent.exists()
         configured = False
         if path.exists():
             try:

--- a/packages/lians-easy/tests/test_installer.py
+++ b/packages/lians-easy/tests/test_installer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from lians_easy.installer import (
     MANAGED_END,
     MANAGED_START,
@@ -61,7 +62,7 @@ def test_plan_reports_targets_without_writing(tmp_path, monkeypatch):
     assert not (home / ".codex" / "config.toml").exists()
 
 
-def test_antigravity_uses_current_global_mcp_path_on_every_platform(tmp_path, monkeypatch):
+def test_antigravity_uses_plugin_mcp_path_on_every_platform(tmp_path, monkeypatch):
     home = tmp_path / "home"
     monkeypatch.setattr("lians_easy.installer.shutil.which", lambda _name: None)
 
@@ -70,13 +71,25 @@ def test_antigravity_uses_current_global_mcp_path_on_every_platform(tmp_path, mo
         target = client_targets(home)["antigravity"]
 
         assert target.label == "Antigravity CLI"
-        assert target.config_path == home / ".gemini" / "config" / "mcp_config.json"
+        assert target.config_path == (
+            home
+            / ".gemini"
+            / "config"
+            / "plugins"
+            / "lians-memory"
+            / "mcp_config.json"
+        )
+        assert target.kind == "antigravity_plugin"
         assert target.detected is False
 
 
-def test_antigravity_install_round_trips_without_touching_other_servers(tmp_path, monkeypatch):
+def test_antigravity_plugin_round_trip_preserves_other_components(tmp_path, monkeypatch):
     home = tmp_path / "home"
-    config = home / ".gemini" / "config" / "mcp_config.json"
+    plugin_root = home / ".gemini" / "config" / "plugins"
+    plugin_dir = plugin_root / "lians-memory"
+    config = plugin_dir / "mcp_config.json"
+    manifest = plugin_dir / "plugin.json"
+    registry = home / ".gemini" / "config" / "plugins.json"
     config.parent.mkdir(parents=True)
     config.write_text(
         json.dumps(
@@ -88,21 +101,85 @@ def test_antigravity_install_round_trips_without_touching_other_servers(tmp_path
             }
         )
     )
+    manifest.write_text(json.dumps({"name": "lians-memory", "channel": "test"}))
+    registry.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "path": str(plugin_root.resolve()).replace("\\", "/"),
+                        "include_only": ["other-plugin"],
+                    },
+                    {"path": "C:/shared/plugins", "include_only": ["shared-plugin"]},
+                ]
+            }
+        )
+    )
     monkeypatch.setenv("LIANS_EASY_HOME", str(tmp_path / "lians"))
 
     first = install(["antigravity"], home=home)
     install(["antigravity"], home=home)
     updated = json.loads(config.read_text())
+    updated_manifest = json.loads(manifest.read_text())
+    updated_registry = json.loads(registry.read_text())
 
     assert updated["theme"] == "dark"
     assert updated["mcpServers"]["other"] == {"serverUrl": "https://example.test/mcp"}
     assert updated["mcpServers"]["lians"]["args"][-1] == "mcp"
+    assert updated_manifest == {"name": "lians-memory", "channel": "test"}
+    assert updated_registry["entries"][0]["include_only"] == [
+        "other-plugin",
+        "lians-memory",
+    ]
+    assert client_targets(home)["antigravity"].configured is True
     assert first["clients"][0]["config"] == str(config)
     assert first["clients"][0]["backup"]
 
     removed = uninstall(["antigravity"], home=home)
     final = json.loads(config.read_text())
+    final_registry = json.loads(registry.read_text())
 
     assert "lians" not in final["mcpServers"]
     assert final["mcpServers"]["other"] == {"serverUrl": "https://example.test/mcp"}
+    assert final_registry["entries"][0]["include_only"] == ["other-plugin"]
+    assert final_registry["entries"][1] == {
+        "path": "C:/shared/plugins",
+        "include_only": ["shared-plugin"],
+    }
+    assert client_targets(home)["antigravity"].configured is False
     assert removed["data_preserved"].endswith("memory.sqlite3")
+
+
+def test_antigravity_plugin_fresh_install_uninstalls_to_inert_backups(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("LIANS_EASY_HOME", str(tmp_path / "lians"))
+
+    install(["antigravity"], home=home)
+    removed = uninstall(["antigravity"], home=home)
+
+    plugin_dir = home / ".gemini" / "config" / "plugins" / "lians-memory"
+    registry = json.loads(
+        (home / ".gemini" / "config" / "plugins.json").read_text()
+    )
+    active_files = [
+        path.name for path in plugin_dir.iterdir() if ".lians-backup-" not in path.name
+    ]
+
+    assert active_files == []
+    assert registry["entries"] == []
+    assert removed["clients"][0]["status"] == "removed"
+
+
+def test_antigravity_invalid_registry_fails_before_writing_plugin(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    registry = home / ".gemini" / "config" / "plugins.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(json.dumps({"entries": "not-an-array"}))
+    monkeypatch.setenv("LIANS_EASY_HOME", str(tmp_path / "lians"))
+
+    with pytest.raises(TypeError, match="entries must be an array"):
+        install(["antigravity"], home=home)
+
+    plugin_dir = home / ".gemini" / "config" / "plugins" / "lians-memory"
+    assert not plugin_dir.exists()
+    assert json.loads(registry.read_text()) == {"entries": "not-an-array"}

--- a/packages/lians-easy/tests/test_installer.py
+++ b/packages/lians-easy/tests/test_installer.py
@@ -19,6 +19,7 @@ def test_installer_preserves_json_and_creates_backup(tmp_path, monkeypatch):
     config.parent.mkdir(parents=True)
     config.write_text(json.dumps({"theme": "dark", "mcpServers": {"other": {"command": "x"}}}))
     monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("lians_easy.installer.shutil.which", lambda _name: None)
     monkeypatch.setenv("APPDATA", str(roaming))
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
 

--- a/packages/lians-easy/tests/test_installer.py
+++ b/packages/lians-easy/tests/test_installer.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import json
 
-from lians_easy.installer import MANAGED_END, MANAGED_START, install, plan, uninstall
+from lians_easy.installer import (
+    MANAGED_END,
+    MANAGED_START,
+    client_targets,
+    install,
+    plan,
+    uninstall,
+)
 
 
 def test_installer_preserves_json_and_creates_backup(tmp_path, monkeypatch):
@@ -51,3 +58,50 @@ def test_plan_reports_targets_without_writing(tmp_path, monkeypatch):
     assert result["changes_made"] is False
     assert result["clients"][0]["key"] == "codex"
     assert not (home / ".codex" / "config.toml").exists()
+
+
+def test_antigravity_uses_current_global_mcp_path_on_every_platform(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr("lians_easy.installer.shutil.which", lambda _name: None)
+
+    for platform in ("win32", "darwin", "linux"):
+        monkeypatch.setattr("sys.platform", platform)
+        target = client_targets(home)["antigravity"]
+
+        assert target.label == "Antigravity CLI"
+        assert target.config_path == home / ".gemini" / "config" / "mcp_config.json"
+        assert target.detected is False
+
+
+def test_antigravity_install_round_trips_without_touching_other_servers(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    config = home / ".gemini" / "config" / "mcp_config.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "theme": "dark",
+                "mcpServers": {
+                    "other": {"serverUrl": "https://example.test/mcp"},
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("LIANS_EASY_HOME", str(tmp_path / "lians"))
+
+    first = install(["antigravity"], home=home)
+    install(["antigravity"], home=home)
+    updated = json.loads(config.read_text())
+
+    assert updated["theme"] == "dark"
+    assert updated["mcpServers"]["other"] == {"serverUrl": "https://example.test/mcp"}
+    assert updated["mcpServers"]["lians"]["args"][-1] == "mcp"
+    assert first["clients"][0]["config"] == str(config)
+    assert first["clients"][0]["backup"]
+
+    removed = uninstall(["antigravity"], home=home)
+    final = json.loads(config.read_text())
+
+    assert "lians" not in final["mcpServers"]
+    assert final["mcpServers"]["other"] == {"serverUrl": "https://example.test/mcp"}
+    assert removed["data_preserved"].endswith("memory.sqlite3")

--- a/packages/lians-easy/tests/test_installer.py
+++ b/packages/lians-easy/tests/test_installer.py
@@ -56,6 +56,7 @@ def test_codex_managed_block_is_idempotent(tmp_path, monkeypatch):
 @pytest.mark.parametrize("platform", ["win32", "darwin", "linux"])
 def test_cline_cli_target_uses_supplied_home_on_every_platform(platform, tmp_path, monkeypatch):
     home = tmp_path / platform
+    monkeypatch.setattr("lians_easy.installer.shutil.which", lambda _name: None)
     monkeypatch.setattr("sys.platform", platform)
 
     target = client_targets(home)["cline"]
@@ -241,6 +242,7 @@ def test_antigravity_invalid_registry_fails_before_writing_plugin(tmp_path, monk
 @pytest.mark.parametrize("platform", ["win32", "darwin", "linux"])
 def test_opencode_target_uses_documented_global_path(platform, tmp_path, monkeypatch):
     home = tmp_path / platform
+    monkeypatch.setattr("lians_easy.installer.shutil.which", lambda _name: None)
     monkeypatch.setattr("sys.platform", platform)
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
 


### PR DESCRIPTION
## Why

Google ended consumer Google-login access to Gemini CLI on June 18, 2026, but Antigravity CLI's ordinary global MCP route did not expose an invocable Lians tool in a fresh agent session. A live test found that packaging the same server as an Antigravity plugin does expose and invoke the tools.

## What changed

- add Antigravity CLI as a first-class Lians Easy target
- install through `~/.gemini/config/plugins/lians-memory/` and safely register that plugin in `~/.gemini/config/plugins.json`
- preserve unrelated plugin components and registry entries during install/uninstall
- refuse malformed registries before writing a partial plugin
- report Antigravity as configured only when both the Lians MCP entry and plugin registration are active
- preserve Gemini CLI for supported Standard/Enterprise, API-key, and Vertex AI users
- document the verified route, upstream boundary, manual package shape, and measured evidence

## Verification

- 11 Lians Easy tests passed
- 24 distribution and release contract tests passed
- Ruff passed
- both Antigravity JSON examples parsed and `git diff --check` passed
- Antigravity CLI 1.1.13 on Windows completed `remember` -> fresh-session `recall` -> confirmed `forget_memory` -> fresh-session empty recall through the plugin route
- the disposable database and test plugin/permissions were removed after verification

## Evidence and claim boundary

The Lians tool calls completed in 0.045-0.096 seconds, but Antigravity used 20,983-45,485 total tokens per fresh host turn. Antigravity also reduced the explicitly supplied write payload to `Synthetic` before invoking Lians. The lifecycle passed for the value the host actually sent, but exact argument preservation did not pass. This PR therefore does not claim token reduction on Antigravity.

The ordinary global MCP path remains affected by Google's open custom-tool invocation issue: https://github.com/google-antigravity/antigravity-cli/issues/71

Full reproducible evidence is in `docs/benchmarks/antigravity-cli-2026-08-14.md`.