### PR TITLE
fix: pin Lians Easy shared database path

### DIFF
--- a/packages/lians-easy/lians_easy/installer.py
+++ b/packages/lians-easy/lians_easy/installer.py
@@ -100,10 +100,11 @@ def client_targets(home: Path | None = None) -> dict[str, ClientTarget]:
 
 
 def runtime_command() -> tuple[str, list[str]]:
+    data_path = str(user_data_dir() / "memory.sqlite3")
     if getattr(sys, "frozen", False):
         installed = user_data_dir() / ("LiansMemory.exe" if sys.platform == "win32" else "lians-memory")
-        return str(installed), ["mcp"]
-    return sys.executable, ["-m", "lians_easy", "mcp"]
+        return str(installed), ["mcp", "--data", data_path]
+    return sys.executable, ["-m", "lians_easy", "mcp", "--data", data_path]
 
 
 def _backup(path: Path) -> Path | None:

--- a/packages/lians-easy/tests/test_installer.py
+++ b/packages/lians-easy/tests/test_installer.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import json
 
-from lians_easy.installer import MANAGED_END, MANAGED_START, install, plan, uninstall
+from lians_easy.installer import (
+    MANAGED_END,
+    MANAGED_START,
+    install,
+    plan,
+    runtime_command,
+    uninstall,
+)
 
 
 def test_installer_preserves_json_and_creates_backup(tmp_path, monkeypatch):
@@ -19,7 +26,12 @@ def test_installer_preserves_json_and_creates_backup(tmp_path, monkeypatch):
     updated = json.loads(config.read_text())
     assert updated["theme"] == "dark"
     assert "other" in updated["mcpServers"]
-    assert updated["mcpServers"]["lians"]["args"][-1] == "mcp"
+    expected_database = tmp_path / "local" / "Lians" / "memory.sqlite3"
+    assert updated["mcpServers"]["lians"]["args"][-2:] == [
+        "--data",
+        str(expected_database),
+    ]
+    assert result["database"] == str(expected_database)
     assert result["clients"][0]["backup"]
 
     removed = uninstall(["claude"], home=home)
@@ -40,6 +52,8 @@ def test_codex_managed_block_is_idempotent(tmp_path, monkeypatch):
     assert content.count(MANAGED_START) == 1
     assert content.count(MANAGED_END) == 1
     assert 'model = "gpt-5"' in content
+    assert json.dumps("--data") in content
+    assert json.dumps(str(tmp_path / "lians" / "memory.sqlite3")) in content
 
 
 def test_plan_reports_targets_without_writing(tmp_path, monkeypatch):
@@ -50,4 +64,19 @@ def test_plan_reports_targets_without_writing(tmp_path, monkeypatch):
 
     assert result["changes_made"] is False
     assert result["clients"][0]["key"] == "codex"
+    assert result["runtime"]["args"][-2:] == [
+        "--data",
+        str(tmp_path / "lians" / "memory.sqlite3"),
+    ]
     assert not (home / ".codex" / "config.toml").exists()
+
+
+def test_runtime_command_pins_the_reported_database(tmp_path, monkeypatch):
+    data_home = tmp_path / "portable-lians-data"
+    monkeypatch.setenv("LIANS_EASY_HOME", str(data_home))
+
+    _command, args = runtime_command()
+    result = plan(["codex"], action="install", home=tmp_path / "home")
+
+    assert args[-3:] == ["mcp", "--data", str(data_home / "memory.sqlite3")]
+    assert result["runtime"]["args"] == args


### PR DESCRIPTION
## Summary

Pin the Lians Easy database path in every generated client runtime command.

## Root cause

`LIANS_EASY_HOME` is an installer-time override. The installer reported `<LIANS_EASY_HOME>/memory.sqlite3`, but generated MCP commands launched `lians_easy mcp` without `--data`. A client started later without that environment variable could therefore write to the platform default database instead of the database shown by install/doctor.

This made the reported storage location and the actual client storage location diverge, and it could split memory across AI clients.

## Fix

Both source and frozen runtime commands now include:

```
mcp --data <user_data_dir>/memory.sqlite3
```

The resolved path is persisted into each client configuration at install time, so later launches do not depend on inheriting `LIANS_EASY_HOME`.

## Automated verification

- `uvx ruff check packages/lians-easy/lians_easy/installer.py packages/lians-easy/tests/test_installer.py`
- Lians Easy: 8 passed
- Distribution/release contracts: 23 passed
- `git diff --check`

## Live OpenCode verification

Validated this branch composed locally with the OpenCode adapter from #153 using OpenCode 1.18.18 and the credential-free `opencode/deepseek-v4-flash-free` model.

- Generated command contained the explicit isolated database path.
- Removed `LIANS_EASY_HOME` before launching OpenCode.
- `opencode mcp list` reported Lians connected with the explicit `--data` path.
- The isolated database was created; the default global database timestamp did not change.
- Remembered marker in one session: ID `b8591fb5-ddcf-4458-9a8d-65ac70840014` (tool: 17 ms).
- Recalled the same ID and exact content in a fresh session (tool: 18 ms).
- Confirmed deletion in another fresh session (tool: 19 ms).
- Final fresh-session recall returned `No relevant memories found.` (tool: 21 ms).
- Strict cleanup hard-deleted the remaining synthetic tombstone only; remaining rows for the ID: 0.

The synthetic test environment was removed after validation.

## Relationship to #153

#153 exposes this pre-existing installer/runtime mismatch during a real OpenCode lifecycle. This PR keeps the shared database-path correction independent so it can be reviewed and landed separately.