### PR TITLE
docs: explain Gemini workspace trust

### DIFF
--- a/docs/easy-install.md
+++ b/docs/easy-install.md
@@ -22,6 +22,16 @@ python -m lians_easy
 Choose the clients to configure, select **Install Lians**, restart those
 clients, then ask one to remember a useful fact and recall it in another chat.
 
+For Gemini CLI, an install can succeed while `lians` remains disabled or
+disconnected in an untrusted folder. Review the folder and run `gemini trust`
+to trust the intended workspace interactively, then check `/mcp list` or
+`gemini mcp list` again. `--skip-trust` and
+`GEMINI_CLI_TRUST_WORKSPACE=true` are available for a single session or a
+disposable test environment, but they bypass the folder trust check and should
+not replace reviewing the workspace. See the
+[Gemini integration guide](../integrations/gemini/README.md#workspace-trust)
+for details.
+
 Existing client configuration files are backed up before every change. Memory
 is stored in a local SQLite file under the operating system's per-user Lians
 data directory. Selected clients use the same `personal` profile, so a fact

--- a/integrations/gemini/README.md
+++ b/integrations/gemini/README.md
@@ -18,6 +18,20 @@ memory is not locked to Gemini or its model provider.
 For a manual setup, merge [`settings.example.json`](settings.example.json)
 into `~/.gemini/settings.json`.
 
+### Workspace trust
+
+Gemini CLI intentionally does not start user-level stdio MCP servers from an
+untrusted folder. If `/mcp list` or `gemini mcp list` shows `lians` as disabled
+or disconnected after installation, review the current folder and run
+`gemini trust` to trust that workspace interactively, then check the list again.
+
+For a single session or a disposable test environment, Gemini also supports
+`--skip-trust` and `GEMINI_CLI_TRUST_WORKSPACE=true`. These options bypass the
+folder trust check, so do not use them as a blanket replacement for reviewing
+and trusting the intended workspace. See Gemini CLI's
+[MCP server documentation](https://geminicli.com/docs/tools/mcp-server/#listing-servers-gemini-mcp-list)
+and [configuration reference](https://github.com/google-gemini/gemini-cli/blob/main/docs/reference/configuration.md#environment-variables-and-env-files).
+
 The Community starter profile exposes only two tools:
 
 - `remember` stores durable information that should survive future sessions.


### PR DESCRIPTION
## Summary

- explain Gemini CLI's workspace-trust gate in the Gemini integration guide
- add the same first-run troubleshooting guidance to the Lians Easy guide
- recommend reviewing and trusting the intended workspace interactively
- limit `--skip-trust` and `GEMINI_CLI_TRUST_WORKSPACE=true` guidance to session or disposable-test use

## Why

Lians Easy can successfully install the user-level stdio MCP configuration while Gemini CLI keeps it disabled in an untrusted folder. The new notes explain why `lians` can appear disabled or disconnected and give users a security-conscious recovery path.

## Validation

- `/private/tmp/lians-168-venv/bin/python -m pytest agentmem/tests/test_distribution_contract.py -q` (`9 passed`)
- `git diff --check`
- verified both linked Gemini CLI documentation pages return HTTP 200

Closes #168

AI assistance disclosure: I used OpenAI Codex to inspect the documentation, prepare the patch, and run validation. I reviewed the final wording and diff before submission.
