### PR TITLE
Make AI efficiency the primary Lians product

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 <p align="center">
   <a href="https://github.com/Lians-ai/Lians">
-    <img src="docs/assets/logo-blue.png" width="420" alt="Lians">
+    <img src="docs/assets/logo-blue.png" width="420" alt="Lians lotus logo">
   </a>
 </p>
 
 <p align="center">
-  <a href="https://www.lians.ai/">Website</a> ·
   <a href="docs/install.md">Install</a> ·
+  <a href="docs/easy-install.md">Desktop preview</a> ·
   <a href="https://github.com/Lians-ai/Lians/tree/master/docs">Docs</a> ·
-  <a href="https://www.lians.ai/pricing">Pricing</a> ·
   <a href="https://github.com/Lians-ai/Lians/issues">Issues</a>
 </p>
 
@@ -16,93 +15,122 @@
   <a href="https://pypi.org/project/lians-sdk"><img src="https://img.shields.io/pypi/v/lians-sdk?label=PyPI" alt="PyPI version"></a>
   <a href="https://www.npmjs.com/package/@lians-ai/lians"><img src="https://img.shields.io/npm/v/%40lians-ai%2Flians?label=npm" alt="npm version"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians"><img src="https://img.shields.io/badge/MCP-Official%20Registry-blueviolet" alt="MCP Official Registry"></a>
-  <a href="https://glama.ai/mcp/servers/Lians-ai/Lians"><img src="https://glama.ai/mcp/servers/Lians-ai/Lians/badges/score.svg" alt="Glama MCP quality score"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 license"></a>
   <a href="https://github.com/Lians-ai/Lians/stargazers"><img src="https://img.shields.io/github/stars/Lians-ai/Lians?style=social" alt="Star Lians on GitHub"></a>
 </p>
 
-# Portable memory for the AI tools you already use.
+# Use less context. Get more AI.
 
-Lians keeps useful project facts, decisions, research constraints, and
-preferences available when you start a new chat or switch tools. It is a
-memory layer, not another assistant: your model stays the same.
+Lians helps Claude, Cursor, Codex, and other AI tools stop rereading the same
+project context.
 
-The product loop is deliberately small:
+Save a useful preference, fact, constraint, or decision once. In a later task,
+Lians reuses only a small relevant slice and leaves the rest out. You keep your
+model, editor, and normal workflow.
 
-1. **Remember** something worth keeping.
-2. **Recall** a few relevant current facts in a later session.
-3. **Inspect, correct, or forget** the memory when it changes.
-
-Lians works through MCP, plugins, and SDKs. Local mode stores memory in SQLite,
-needs no Lians account or API key, and does not lock memory to one model vendor.
+- **Local by default:** encrypted saved context stays on your device.
+- **No AI credentials:** Lians does not ask for your Claude, Cursor, or Codex
+  password or provider API key.
+- **Measured:** signed receipts record what was reused, what was excluded, and
+  the estimated repeated memory context avoided.
+- **Portable:** one local store can support multiple compatible AI tools.
 
 <p align="center">
-  <img src="docs/assets/cross-tool-memory-flow.svg" width="100%" alt="A project preference saved in Cursor flows through the encrypted Lians Bridge into a new Codex or Claude task with an inspectable receipt and controls to correct, pause, or forget it.">
+  <img src="docs/assets/cross-tool-memory-flow.svg" width="100%" alt="A saved project preference is reused as bounded context in a later Cursor, Codex, or Claude task.">
 </p>
 
-## Tested across real AI clients
+## Try Lians in two chats
 
-On August 14, 2026, a live hosted-MCP test stored one synthetic project memory
-through Cursor, recalled it in a separate Cursor chat, and then recalled the
-same exact codeword in a fresh Claude Code session. After confirmed deletion,
-Cursor returned no matching memory.
+Choose the AI tool you already use:
 
-In a separate balanced Cursor CLI stress test, bounded Lians-style context used
+| Tool | Fastest current setup |
+|---|---|
+| Cursor | [One-click MCP install](integrations/cursor) |
+| Claude Code | [Two plugin commands](integrations/lians-plugin) |
+| Codex app, CLI, or IDE | [One-command MCP setup](integrations/codex) |
+| Other MCP clients | [Minimal local MCP configuration](#minimal-local-mcp-setup) |
+
+Then try:
+
+```text
+Remember that this project uses Python 3.12 and pytest.
+```
+
+Open a new chat in the same project and ask:
+
+```text
+What Python version and test runner does this project use?
+```
+
+Lians can reuse the saved detail without replaying the whole previous chat.
+
+<p align="center">
+  <a href="https://github.com/Lians-ai/Lians/releases/download/lians-memory-openai-demo-v1.0.0/Lians-Memory-OpenAI-submission-demo-v1.0.0.mp4"><strong>▶ Watch the 33-second remember, reuse, and delete proof</strong></a>
+</p>
+
+## The product
+
+```text
+Open Lians → choose your AI apps → keep working normally
+                                      ↓
+                         relevant saved context only
+                                      ↓
+                         visible efficiency receipt
+```
+
+The desktop product detects supported AI apps and connects the ones a user
+selects. Claude, Codex, Gemini CLI, and Antigravity can receive bounded context
+through prompt hooks. Cursor uses its MCP connection and a generated project
+rule. The underlying memory, correction, backup, and deletion controls remain
+available when someone wants them; they are not the main job to be done.
+
+From a source checkout, developers can exercise that flow today:
+
+```bash
+python -m pip install -e packages/lians-easy
+lians optimize --clients detected --plan
+lians optimize --clients detected --yes
+lians status
+```
+
+Running `lians` with no subcommand opens guided setup. The Windows and macOS
+desktop artifacts are tested release candidates, not yet trusted consumer
+downloads: general promotion remains gated on Windows publisher signing and
+Apple Developer ID signing/notarization. See the
+[desktop preview boundary](docs/easy-install.md).
+
+## What is real today
+
+| Capability | Status |
+|---|---|
+| Free local memory through MCP and Python | Available |
+| Cursor, Claude Code, Codex, Gemini, Antigravity, Windsurf, Cline, and OpenCode setup paths | Available |
+| Guided desktop installer and local control center | Release candidate; source/CI evaluation only until signing |
+| Bounded context and signed selection receipts | Available |
+| Estimated repeated memory tokens avoided | Available in receipts, `lians status`, and the local status API |
+| Managed cross-device continuity | Technical preview; not a general-availability claim |
+
+## Evidence, not magic
+
+In a balanced Cursor CLI stress test, bounded Lians-style context used
 **24.72% fewer provider-reported input tokens** than a 201-line always-applied
-Cursor rule while preserving all four exact answers. This is one synthetic
-large-rule workload, not a promise of universal token savings.
+rule while preserving all four exact answers. This is one synthetic workload,
+not a promise of universal token savings.
 
-[Read the methodology, raw aggregate evidence, and current platform blockers](docs/benchmarks/cross-agent-memory-2026-08-14.md).
-If this is the kind of portable memory you want agents to have,
-[star Lians](https://github.com/Lians-ai/Lians/stargazers) and try the
-[three-minute memory challenge](https://github.com/Lians-ai/Lians/discussions/122).
+A separate live test stored one synthetic project fact through Cursor, recalled
+it in a new Cursor chat and a fresh Claude Code session, then confirmed that it
+was gone after deletion. Read the
+[methodology and raw aggregate evidence](docs/benchmarks/cross-agent-memory-2026-08-14.md).
 
-## One product, two ways to run it
+Lians does not enlarge a provider context window or guarantee that every plan,
+quota, or bill lasts longer. It measures the narrower claim it controls: how
+much active saved memory could have been replayed, how much was selected, and
+the estimated repeated memory content left out.
 
-| | **Lians Local** | **Lians Personal** |
-|---|---|---|
-| Best for | Developers, students, and self-managed projects | One person who wants Lians operated for them |
-| Runs | On your device or infrastructure | In a private Lians-managed workspace |
-| Includes | The complete local memory loop through MCP or Python | 100,000 writes, 50,000 recalls, export and deletion controls, and email setup support |
-| Price | **Free** under Apache 2.0 | **$10/month**, cancel anytime |
-| Start | [Install local Lians](#free-local-setup-add-memory-through-mcp) | [Choose Lians Personal](https://www.lians.ai/upgrade?plan=starter&utm_source=github&utm_medium=readme&utm_campaign=product_modes) |
-
-Both modes provide the same basic experience: remember, recall, inspect,
-correct, and forget. Choose Local when you are comfortable running a package;
-choose Personal when setup and operation are the part you want handled.
-
-The first genuine Personal customer also gets a 30-minute founder-led setup
-session at no extra cost. Purchase only when managed memory solves a real
-problem for you.
-
-## Connect the AI tool you already use
-
-- **Cursor:** use the [one-click MCP installer](integrations/cursor).
-- **Claude Code:** paste the [two plugin commands](integrations/lians-plugin).
-- **Codex app, CLI, or IDE:** run the [one-command MCP setup](integrations/codex).
-
-All three routes use the same free local memory by default. After setup, try the
-[three-minute, two-chat memory challenge](https://github.com/Lians-ai/Lians/discussions/122).
-
-Running a club, hackathon, class, or campus developer community? Use the
-[student and community kit](docs/student-community-kit.md) for a ready-made
-workshop, project track, judging rubric, and shareable announcement.
-
-Lians does not change the underlying model or promise fewer tokens on every
-task. It can avoid resending old conversation when a small relevant recall is
-enough; verify the result on your own workflow.
-
-<p align="center">
-  <a href="https://github.com/Lians-ai/Lians/releases/download/lians-memory-openai-demo-v1.0.0/Lians-Memory-OpenAI-submission-demo-v1.0.0.mp4"><strong>▶ Watch the 33-second demo: remember, recall, and confirmed deletion</strong></a>
-</p>
-
-## Free local setup: add memory through MCP
-
-Use this path when you prefer a package-managed MCP server or want the full
-temporal and governance engine.
+## Minimal local MCP setup
 
 Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then add
-this server to your agent's MCP configuration:
+this server to an MCP-compatible AI tool:
 
 ```json
 {
@@ -118,60 +146,11 @@ this server to your agent's MCP configuration:
 }
 ```
 
-Restart your agent and try two prompts in separate chats:
+Restart the AI tool. Local memory is stored in `~/.lians/mcp.db`; no Lians
+account, Docker service, or provider API key is required. The first use may
+download the local semantic model.
 
-```text
-Remember that this project uses Python 3.12 and pytest.
-```
-
-```text
-What Python version and test runner does this project use?
-```
-
-On a clean machine, the first memory tool may download and initialize the local
-semantic model. Lians reports that warmup to MCP clients that support progress.
-If it is still running after 90 seconds, the tool returns a retryable error and
-does not queue the write; keep the MCP server running and retry shortly. Model
-files use the Hugging Face cache controlled by `HF_HOME`.
-
-Local MCP memory is stored in `~/.lians/mcp.db`. The starter configuration
-exposes the basic loop plus the controls needed to trust it:
-
-| Tool | What it does |
-|---|---|
-| `remember` | Store one durable fact, preference, constraint, or decision. |
-| `recall` | Retrieve a small set of relevant, current memories. |
-| `list_memories` | Inspect what Lians currently knows. |
-| `correct_memory` | Replace a stale fact without hiding its history. |
-| `forget_memory` | Permanently erase one memory after explicit confirmation. |
-
-Use the exact setup guide for
-[Cursor](integrations/cursor),
-[Antigravity CLI](integrations/antigravity),
-[Gemini CLI](integrations/gemini),
-[Claude Code](integrations/lians-plugin), or
-[OpenCode](integrations/opencode), or
-[Codex](integrations/codex). Remove `LIANS_MCP_ENABLED_TOOLS` when you want
-the advanced temporal and audit tools too.
-
-## How it works
-
-```text
-you → your AI agent → remember / recall → Lians → local SQLite
-```
-
-1. You or your agent explicitly saves something worth keeping.
-2. A later session asks Lians for memory related to the current task.
-3. Lians returns bounded context instead of replaying every old conversation.
-4. When a fact changes, Lians can supersede the stale version instead of
-   sending both versions back to the model.
-
-No model provider owns the memory. You can point another compatible agent at
-the same Lians store and continue from the same context.
-
-## Use Lians in Python
-
-For an application, notebook, or agent loop that needs in-process memory:
+## Use Lians inside an application
 
 ```bash
 pip install "lians-sdk[local]"
@@ -182,79 +161,42 @@ from datetime import datetime, timezone
 from lians import LocalLiansClient
 
 memory = LocalLiansClient(db_path=".lians/memory.db")
-
 memory.add(
     agent_id="my-agent",
     content="The project uses Python 3.12 and pytest.",
     event_time=datetime.now(timezone.utc),
-    metadata={"project": "demo", "topic": "tooling"},
 )
 
 result = memory.recall(
     agent_id="my-agent",
     query="Which Python version and test runner should I use?",
 )
-
-for item in result["memories"]:
-    print(item["content"])
 ```
 
-Local mode needs no server, Docker container, or API key. The first run may
-download the local embedding model.
+See the [full install guide](docs/install.md) for TypeScript, Go, Java, C,
+framework integrations, and self-hosting.
 
-## Install from this repository
+Running a class, club, hackathon, or campus developer group? The
+[student and community kit](docs/student-community-kit.md) contains a small
+workshop and project track. If you cloned the monorepo and are deciding which
+package is current, start with
+[Supported paths and repository status](docs/supported-paths.md).
 
-```bash
-git clone https://github.com/Lians-ai/Lians.git
-cd Lians
-python -m pip install -e "agentmem/sdk/python[local,mcp]"
-```
-
-That editable install includes the local Python client and the `lians-mcp`
-entry point. See the [full install guide](docs/install.md) for TypeScript, Go,
-Java, C, framework adapters, and self-hosting.
-
-## Choose the interface that fits
-
-| You want to... | Start with |
-|---|---|
-| Use managed private memory without running a server | [Lians Personal — $10/month](https://www.lians.ai/upgrade?plan=starter) |
-| Give an existing AI client free local memory | [MCP setup](#free-local-setup-add-memory-through-mcp) |
-| Add local memory inside Python | [`LocalLiansClient`](agentmem/sdk/python) |
-| Evaluate encrypted cross-tool memory from source | [Lians Bridge preview](docs/easy-install.md) |
-| Connect Python or TypeScript to a Lians server | [Language SDKs](docs/install.md#language-sdks) |
-| Use Pydantic AI or LangGraph | [Pydantic AI example](integrations/pydantic-ai/python) · [LangGraph example](integrations/langgraph/python) |
-| Use LangChain, CrewAI, OpenAI Agents, or AutoGen | [Framework integrations](docs/install.md#framework-integrations) |
-| Run the full service yourself | [Self-host Lians](docs/install.md#self-host-lians) |
-
-Cloned the repository and unsure which package or folder is current? Read
-[Supported paths and repository status](docs/supported-paths.md) before choosing
-an SDK, plugin, preview, or legacy tree.
-
-## Why Lians
-
-Most memory demos store text and run vector search. Lians also handles the
-problems that appear when an agent keeps memory for more than a few sessions:
-
-- **Current over stale:** corrected facts can supersede earlier versions.
-- **Small over noisy:** recall is bounded so the model gets useful context.
-- **Local over locked-in:** local mode keeps data on your machine.
-- **Portable over provider-specific:** MCP and SDKs work across agent stacks.
-- **Inspectable over opaque:** memories can retain timestamps, sources, and
-  lineage.
+The short [product direction](docs/product-direction.md) defines the customer,
+default experience, claims boundary, build order, and success metrics.
 
 <details>
-<summary><strong>Advanced capabilities</strong></summary>
+<summary><strong>Advanced memory and governance capabilities</strong></summary>
 
-Lians also supports point-in-time recall, conflict inspection, memory lineage,
-tamper-evident audit history, governed erasure, information barriers, and
-decision reconstruction. These capabilities are available when a project needs
-them; they are not required to get started.
+Lians can supersede stale facts, reconstruct point-in-time state, inspect
+lineage and conflicts, maintain tamper-evident audit history, enforce
+information barriers, and perform confirmed erasure. These capabilities are
+available for applications and teams that need them; they are not required to
+get started.
 
 - [Memory engine](docs/memory-engine.md)
 - [Decision evidence](docs/decision-evidence.md)
 - [Security model](docs/security-whitepaper.md)
-- [Benchmarks and reproducible evidence](docs/benchmarks/README.md)
 - [Community and managed product boundary](docs/community-cloud-boundary.md)
 
 </details>
@@ -262,13 +204,12 @@ them; they are not required to get started.
 ## Repository map
 
 ```text
-agentmem/src/lians/          Core engine and HTTP service
+packages/lians-easy/        Desktop runtime, installer, control center, and receipts
 agentmem/sdk/python/        Python SDK, local client, and MCP server
-agentmem/sdk/typescript/    TypeScript SDK
-packages/lians-easy/        Lians Bridge package source and installer preview
-integrations/               Agent and framework integrations
+agentmem/src/lians/         Core engine and HTTP service
+integrations/               AI-client and framework connections
 plugins/                    Installable agent plugins
-docs/                       Setup, architecture, security, and operations
+docs/                       Setup, evidence, security, and operations
 ```
 
 ## Development
@@ -280,23 +221,15 @@ python -m pip install -e ".[dev]"
 python scripts/test_all.py
 ```
 
-Focused test runs and development conventions are in
-[CONTRIBUTING.md](CONTRIBUTING.md). Published package and registry
-versions are tracked in
-[docs/published-release-status.json](docs/published-release-status.json).
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for focused test commands and project
+conventions. Ask questions or report problems in
+[GitHub Issues](https://github.com/Lians-ai/Lians/issues).
 
-## Community
-
-- Ask a question or report a bug in [GitHub Issues](https://github.com/Lians-ai/Lians/issues).
-- Request a new agent or framework integration with the
-  [integration template](https://github.com/Lians-ai/Lians/issues/new?template=integration_request.yml).
-- Read the [security policy](docs/SECURITY.md) before reporting a vulnerability.
-
-If Lians is useful to you, [star the repository](https://github.com/Lians-ai/Lians/stargazers).
-It helps other agent developers find the project.
+If Lians helps your workflow, [star the repository](https://github.com/Lians-ai/Lians/stargazers)
+so other AI-tool users can find it.
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE).
+Apache 2.0 - see [LICENSE](LICENSE).
 
 <!-- mcp-name: io.github.ebeirne/lians -->

--- a/docs/consumer-installer.md
+++ b/docs/consumer-installer.md
@@ -1,9 +1,29 @@
-# Lians consumer installer contract
+# Lians consumer product and installer contract
 
 The consumer package is one Lians installer per operating system, not a separate
 installer for every AI client. The installer places one local Lians Bridge on
 the device, detects compatible AI apps, and lets the user connect any of them
 from one screen.
+
+The consumer promise is **Use less context. Get more AI.** Memory is the local
+engine that makes this possible, not the job the user should have to manage.
+The default experience should help someone optimize the AI tools they already
+use, keep working normally, and see evidence that irrelevant saved context was
+left out. Memory directories, lineage, receipts, backup, and deployment remain
+available as controls and technical detail.
+
+Product language must stay within the measured boundary:
+
+- Say that Lians reduces repeated saved context and measures an estimate of what
+  it leaves out.
+- Say that this can help users get more useful work from the AI tools they
+  already pay for.
+- Do not promise that Lians extends every provider's plan, message cap, or
+  billing quota. That requires provider-reported measurement in the installed
+  product.
+- Never ask for a Claude, Cursor, Codex, or other AI account password. Connect
+  supported local clients through their documented plugin, hook, rule, or MCP
+  configuration surfaces.
 
 The reference implementation in
 [`codefl0w/mtkclient-windows-installer`](https://github.com/codefl0w/mtkclient-windows-installer)
@@ -86,27 +106,27 @@ successfully.
 
 The setup sequence has four moments:
 
-1. **Promise and trust.** Explain that Lians carries preferences and useful
-   project context across the user's existing AI apps. State that memory is
-   encrypted locally, existing settings are backed up, and no provider API key
-   is required.
+1. **Promise and trust.** Lead with **Use less context. Get more AI.** Explain
+   that Lians gives later tasks only useful saved context. State that saved
+   context is encrypted locally, existing settings are backed up, and no AI
+   account password or provider API key is required.
 2. **Choose apps.** Detect installed clients, select them by default, and keep
-   unsupported or absent clients behind **Add another AI app**. Encourage two
-   connections because the cross-app handoff is the activation event.
+   unsupported or absent clients behind **Add another AI app**. One connected
+   app provides value; a second also demonstrates portability.
 3. **Set up.** Show one progress bar and three plain-language states:
-   **Protect your existing settings**, **Connect your AI apps**, and **Check
-   that memory is ready**.
+   **Protect your existing settings**, **Optimize your AI apps**, and **Check
+   that Lians is ready**.
 4. **Prove value.** Copy a ready-made `remember` prompt, tell the user to open a
-   new task in another app, and show the expected context receipt. Do not end on
-   a generic "installation complete" message.
+   new task in the same or another app, and show the estimated context reused
+   and left out. Do not end on a generic "installation complete" message.
 
 The user should see the outcome, not the implementation:
 
 | Internal operation | Consumer copy |
 |---|---|
 | Back up and atomically update client configuration | Protect your existing settings |
-| Register MCP server, hook, plugin, or project rule | Connect Cursor / Claude / Codex |
-| Start Bridge and validate the client contract | Check that memory is ready |
+| Register MCP server, hook, plugin, or project rule | Optimize Cursor / Claude / Codex |
+| Start Bridge and validate the client contract | Check that Lians is ready |
 | Display configuration paths, commands, and exceptions | Technical details |
 | Create diagnostic archive | Save support report |
 

--- a/docs/easy-install.md
+++ b/docs/easy-install.md
@@ -1,13 +1,15 @@
-# Lians Bridge desktop preview
+# Lians desktop preview
 
 The intended generally available package and nontechnical first-run contract
 are defined in [the consumer installer contract](consumer-installer.md). The
 current preview exercises the same Bridge and client configuration engine but
 does not yet satisfy its signing and release gates.
 
-Lians Bridge is a technical preview for carrying private, local memory across
-supported AI clients. It is deliberately smaller than the full Lians engine.
-There is no account, API key, database server, or embedding-model download.
+Lians is a technical preview for reducing repeated saved context across
+supported AI clients. The local Bridge is the memory engine underneath that
+experience; users keep their existing AI tools and models. There is no Lians
+account, provider password, API key, database server, or embedding-model
+download.
 
 There are currently no Authenticode-signed Windows, notarized macOS, or Linux
 `LiansMemory` assets in [GitHub Releases](https://github.com/Lians-ai/Lians/releases).
@@ -64,8 +66,9 @@ pipx install lians-bridge
 # or: uv tool install lians-bridge
 
 lians doctor --json
-lians install --clients detected --plan --json
-lians install --clients detected --yes --json
+lians optimize --clients detected --plan --json
+lians optimize --clients detected --yes --json
+lians status --json
 lians app
 ```
 
@@ -75,10 +78,10 @@ Python wheel removes the repository checkout for developers; it does not
 replace Authenticode, Developer ID, notarization, or clean-device testing for
 the consumer desktop packages.
 
-Choose the clients to configure, select **Install Lians**, restart those
-clients, then ask Cursor to remember a useful project rule. Start a new Codex
-or Claude task in the same repository and inspect the receipt attached to the
-recalled context.
+Choose the clients to configure, select **Optimize my AI apps**, restart those
+clients, then ask any connected app to remember a useful project rule. Start a
+new task in the same or another connected app and inspect how much saved context
+was reused and left out.
 
 For Gemini CLI, an install can succeed while `lians` remains disabled or
 disconnected in an untrusted folder. Review the folder and run `gemini trust`

--- a/docs/product-direction.md
+++ b/docs/product-direction.md
@@ -1,0 +1,88 @@
+# Lians product direction
+
+## One sentence
+
+**Use less context. Get more AI.**
+
+Lians helps people get more useful work from the AI tools they already use by
+reusing less context.
+
+The memory engine is how Lians delivers that result. It is not the job the
+ordinary user should have to manage.
+
+## The first customer
+
+Start with an individual who uses Claude, Cursor, or Codex across long-running
+work and repeatedly explains preferences, project rules, research constraints,
+or prior decisions. Developers are the first distribution wedge because GitHub,
+MCP, plugins, and source installs reach them today. Students, researchers, and
+other knowledge workers should receive the same simple product after signed
+desktop installers remove operating-system trust warnings.
+
+## The product loop
+
+1. **Open Lians.** It detects supported AI apps already on the device.
+2. **Optimize.** The user chooses apps and clicks one button. Lians connects
+   through documented local plugin, hook, rule, or MCP surfaces; it never asks
+   for an AI account password.
+3. **Work normally.** The user can say `Remember that...` when a detail should
+   survive a chat. Connected clients automatically request bounded recall when
+   their supported hook or integration allows it.
+4. **See the result.** Lians shows connected apps, context events, useful saved
+   details reused, and estimated repeated memory tokens left out.
+5. **Stay in control.** Inspect, correct, pause, export, or permanently forget
+   saved context without learning the underlying memory architecture.
+
+## What the default screen should show
+
+- detected and connected AI apps;
+- one **Optimize my AI apps** action;
+- a simple active/inactive status;
+- repeated memory context avoided, clearly labeled as an estimate;
+- a short two-chat proof; and
+- privacy and disconnect controls.
+
+Memory directories, source lineage, signed receipts, point-in-time recall,
+cloud protocol details, and enterprise governance belong behind progressive
+disclosure.
+
+## Claims boundary
+
+Lians can claim that it selects bounded relevant saved context, leaves other
+active in-scope memory out, and records an inspectable estimate. The repository
+also contains a provider-reported Cursor benchmark for one synthetic workload.
+
+Lians must not claim that every user receives a specific token reduction or
+that it extends every provider's message cap, context window, subscription
+quota, or billing balance. Those outcomes depend on the provider and workflow
+and require installed-product measurement.
+
+## Build order
+
+1. **One coherent product surface:** outcome-led README, `lians optimize`,
+   `lians status`, guided setup language, and measured efficiency receipts.
+2. **Trusted consumer distribution:** obtain Windows publisher and Apple
+   Developer ID credentials, publish signed/notarized installers, and pass
+   clean-device usability tests with nontechnical users.
+3. **Make memory quieter:** improve client guidance so durable facts are saved
+   naturally, add reviewable memory suggestions where client permissions allow,
+   and avoid silent capture of whole conversations.
+4. **Close the proof loop:** show per-client and per-project efficiency trends
+   in the desktop app, then validate them against provider-reported usage where
+   providers expose it.
+5. **Add paid value:** cross-device continuity, team sharing, administration,
+   support, and enterprise controls only after the free local activation loop is
+   reliable.
+
+## Product success metrics
+
+- installation completion rate;
+- percentage of installs with at least one connected AI app;
+- percentage reaching a successful second-chat reuse event;
+- weekly active users with genuine context events;
+- estimated repeated memory tokens avoided, with the measurement basis shown;
+- 7-day and 30-day retention; and
+- conversion to managed continuity or team use.
+
+Stars, directory listings, and traffic are useful distribution signals. They do
+not replace activation, retention, or revenue.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,7 +1,8 @@
-# Lians Memory for Codex
+# Lians for Codex
 
-Give the Codex app, CLI, and IDE extension durable local memory. They share the
-same MCP configuration, so you only need to add Lians once.
+Help the Codex app, CLI, and IDE extension reuse useful project context instead
+of asking you to repeat it. They share one local MCP configuration, so you
+only need to add Lians once.
 
 ## Install in one command
 

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -1,8 +1,8 @@
-# Lians Memory for Cursor
+# Lians for Cursor
 
-Give Cursor a durable local memory without changing your model or editor. The
-starter profile remembers important project facts and recalls a small relevant
-slice in a later chat.
+Help Cursor avoid rereading the same project context without changing your
+model or editor. Save a useful detail once; Lians reuses a small relevant slice
+in a later chat and leaves the rest out.
 
 ## Install for one project
 

--- a/integrations/lians-plugin/README.md
+++ b/integrations/lians-plugin/README.md
@@ -1,6 +1,8 @@
-# Lians plugin for Claude Code
+# Lians for Claude Code
 
-This plugin gives Claude Code commands and an agent for working with Lians memory.
+This plugin helps Claude Code reuse useful project context without asking you to
+repeat it. It adds simple remember and recall commands while keeping the
+advanced memory and evidence tools available when a project needs them.
 
 ## Install from GitHub
 

--- a/packages/lians-easy/README.md
+++ b/packages/lians-easy/README.md
@@ -1,11 +1,23 @@
-# Lians Bridge (technical preview)
+# Lians desktop runtime (technical preview)
 
-Lians Bridge is the local service behind the guided Lians installer. It keeps
-one encrypted memory store for supported AI clients and exposes a small MCP
-surface, automatic bounded recall, project handoffs, and signed context
-receipts. The same package now carries the React Lians App for Memory, Activity,
-Review, Integrations, and Settings; normal users do not install or locate a
-separate web bundle.
+**Use less context. Get more AI.**
+
+This is the local runtime behind the guided Lians installer. It detects the AI
+apps already on a device, connects the selected apps, and gives later tasks a
+small set of relevant saved context instead of replaying the full history. The
+same package carries the encrypted local control center; users do not install a
+separate dashboard or hand Lians their Claude, Cursor, or Codex credentials.
+
+The product surface is intentionally small:
+
+1. Open Lians and choose the AI apps to optimize.
+2. Keep using those apps normally. Say `Remember that...` when a detail should
+   survive the current chat.
+3. Run `lians status` to see connected apps and the estimated repeated memory
+   context left out of later tasks.
+
+Memory controls, receipts, backup, cloud-sync preview, and deployment options
+remain available as progressive technical disclosure.
 
 The current desktop artifacts are development builds and are not yet published
 with trusted operating-system signatures. Context receipts are Ed25519-signed,
@@ -14,7 +26,8 @@ notarization. Until a signed release is published, developers and IT teams
 should evaluate the Bridge from source:
 
 ```bash
-python -m lians_easy install --clients antigravity,claude,cursor,gemini,codex,cline,opencode --yes
+python -m lians_easy optimize --clients antigravity,claude,cursor,gemini,codex,cline,opencode --yes
+python -m lians_easy status
 python -m lians_easy doctor --json
 python -m lians_easy app
 ```
@@ -32,8 +45,9 @@ pipx install lians-bridge
 
 lians doctor --json
 lians --version
-lians install --clients detected --plan --json
-lians install --clients detected --yes --json
+lians optimize --clients detected --plan --json
+lians optimize --clients detected --yes --json
+lians status --json
 lians app
 ```
 

--- a/packages/lians-easy/lians_easy/cli.py
+++ b/packages/lians-easy/lians_easy/cli.py
@@ -36,19 +36,72 @@ def _show(result: dict[str, Any], *, as_json: bool) -> None:
     if as_json:
         print(json.dumps(result, indent=2))
         return
-    print(result.get("status", "Lians Memory"))
+    print(result.get("headline") or result.get("status", "Lians"))
     for item in result.get("clients", []):
         if isinstance(item, dict):
             print(
                 f"- {item.get('label') or item.get('key') or item.get('client')}: "
                 f"{item.get('status') or item.get('config_path')}"
             )
+    efficiency = result.get("efficiency")
+    if isinstance(efficiency, dict):
+        avoided = int(efficiency.get("repeated_memory_tokens_avoided_estimate") or 0)
+        events = int(efficiency.get("context_events") or 0)
+        print(f"- Repeated memory context left out: ~{avoided} tokens across {events} tasks")
     if result.get("next_step"):
         print(result["next_step"])
 
 
+def product_status(
+    *, data_path: str | Path | None = None, home: Path | None = None
+) -> dict[str, Any]:
+    """Return the small ordinary-user view of Lians configuration and impact."""
+    targets = client_targets(home)
+    configured = [target for target in targets.values() if target.configured]
+    detected = [target for target in targets.values() if target.detected]
+    memory = MemoryStore(data_path or default_data_path()).stats()
+    return {
+        "status": "optimized" if configured else "not_configured",
+        "headline": (
+            f"Lians is active in {len(configured)} AI app"
+            f"{'s' if len(configured) != 1 else ''}."
+            if configured
+            else "Lians is ready to optimize your AI apps."
+        ),
+        "clients": [
+            {
+                **target.public(),
+                "status": (
+                    "connected"
+                    if target.configured
+                    else "found"
+                    if target.detected
+                    else "not found"
+                ),
+            }
+            for target in targets.values()
+            if target.detected or target.configured
+        ],
+        "configured_clients": len(configured),
+        "detected_clients": len(detected),
+        "efficiency": memory["efficiency"],
+        "privacy": {
+            "local": True,
+            "encrypted": memory["encrypted"],
+            "ai_account_credentials_required": False,
+        },
+        "next_step": (
+            "Keep using your connected apps normally. Lians adds only relevant saved context."
+            if configured
+            else "Open Lians for guided setup, or run `lians optimize --clients detected --yes`."
+        ),
+    }
+
+
 def parser() -> argparse.ArgumentParser:
-    result = argparse.ArgumentParser(prog="lians", description="Local memory for your AI")
+    result = argparse.ArgumentParser(
+        prog="lians", description="Use less repeated context in the AI tools you already use"
+    )
     result.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     commands = result.add_subparsers(dest="command")
     mcp = commands.add_parser("mcp", help="Run the local MCP memory server")
@@ -65,6 +118,10 @@ def parser() -> argparse.ArgumentParser:
     app.add_argument("--data", type=Path)
     app.add_argument("--host", default="127.0.0.1")
     app.add_argument("--port", type=int, default=7317)
+
+    status = commands.add_parser("status", help="Show connected apps and measured context reuse")
+    status.add_argument("--data", type=Path)
+    status.add_argument("--json", action="store_true")
 
     hook = commands.add_parser("hook", help="Inject bounded memory into an AI prompt")
     hook.add_argument(
@@ -88,8 +145,13 @@ def parser() -> argparse.ArgumentParser:
     cursor_rule.add_argument("--data", type=Path)
     cursor_rule.add_argument("--json", action="store_true")
 
-    for name in ("install", "uninstall"):
-        command = commands.add_parser(name, help=f"{name.title()} supported AI client settings")
+    for name in ("optimize", "install", "uninstall"):
+        help_text = (
+            "Connect supported AI apps to Lians"
+            if name == "optimize"
+            else f"{name.title()} supported AI client settings"
+        )
+        command = commands.add_parser(name, help=help_text)
         command.add_argument(
             "--clients",
             default="detected",
@@ -180,6 +242,9 @@ def main(argv: list[str] | None = None) -> None:
             port=args.port,
         ).serve(open_browser=True)
         return
+    if args.command == "status":
+        _show(product_status(data_path=args.data), as_json=args.json)
+        return
     if args.command == "hook":
         raise SystemExit(run_hook(client=args.client, data_path=args.data))
     if args.command == "context":
@@ -236,16 +301,17 @@ def main(argv: list[str] | None = None) -> None:
             )
         _show(result, as_json=args.json)
         return
-    if args.command in {"install", "uninstall"}:
+    if args.command in {"optimize", "install", "uninstall"}:
         keys = _keys(args.clients)
         if not keys:
             raise SystemExit("No supported AI clients were detected. Use --clients to choose one.")
         if args.plan:
-            _show(plan(keys, action=args.command), as_json=args.json)
+            action = "install" if args.command == "optimize" else args.command
+            _show(plan(keys, action=action), as_json=args.json)
             return
         if not args.yes:
             raise SystemExit("Review the selected clients, then rerun with --yes (or use the GUI).")
-        operation = install if args.command == "install" else uninstall
+        operation = install if args.command in {"optimize", "install"} else uninstall
         _show(operation(keys), as_json=args.json)
         return
     if sys.platform == "win32":

--- a/packages/lians-easy/lians_easy/gui.py
+++ b/packages/lians-easy/lians_easy/gui.py
@@ -45,7 +45,7 @@ class SetupApp:
         self.other_visible = False
         self.open_requested = False
 
-        self.root.title("Lians — AI Efficiency")
+        self.root.title("Lians AI Efficiency")
         self.root.geometry("780x720")
         self.root.minsize(680, 620)
         self.root.configure(background=BACKGROUND)

--- a/packages/lians-easy/lians_easy/gui.py
+++ b/packages/lians-easy/lians_easy/gui.py
@@ -45,7 +45,7 @@ class SetupApp:
         self.other_visible = False
         self.open_requested = False
 
-        self.root.title("Lians Setup")
+        self.root.title("Lians — AI Efficiency")
         self.root.geometry("780x720")
         self.root.minsize(680, 620)
         self.root.configure(background=BACKGROUND)
@@ -90,7 +90,7 @@ class SetupApp:
 
         self._label(
             self.shell,
-            "Your AI apps, one memory.",
+            "Use less context. Get more AI.",
             foreground=TEXT,
             font=("Segoe UI", 22, "bold"),
             anchor="w",
@@ -98,8 +98,9 @@ class SetupApp:
         self._label(
             self.shell,
             (
-                "Lians carries your preferences and useful project context between the AI "
-                "apps you already use. No account or API key required."
+                "Lians gives each new task only the useful context it needs, so your AI apps "
+                "do not have to reread everything. Keep using them normally. No AI account "
+                "password or API key required."
             ),
             foreground=MUTED,
             font=("Segoe UI", 11),
@@ -122,7 +123,7 @@ class SetupApp:
         detected_text = (
             f"We found {len(detected)} AI app{'s' if len(detected) != 1 else ''}"
             if detected
-            else "Choose the AI apps you use"
+            else "Choose the AI apps you want to optimize"
         )
         self._label(
             self.card,
@@ -134,7 +135,7 @@ class SetupApp:
         ).pack(fill="x")
         self._label(
             self.card,
-            "Connect at least two to experience memory moving between them.",
+            "Connect one or more. Lians works quietly in the apps you already use.",
             background=PANEL,
             foreground=MUTED,
             anchor="w",
@@ -179,9 +180,9 @@ class SetupApp:
         self._label(
             trust,
             (
-                "✓  Memory stays encrypted on this computer\n"
-                "✓  Existing settings are backed up before Lians changes them\n"
-                "✓  Pause, correct, or permanently forget a memory whenever you want"
+                "✓  No Claude, Cursor, or Codex password is requested\n"
+                "✓  Saved context is encrypted; existing settings are backed up\n"
+                "✓  Only a small, relevant context pack is added to a task"
             ),
             background=PANEL_SOFT,
             foreground=MUTED,
@@ -200,8 +201,8 @@ class SetupApp:
         self.progress_bar.pack(fill="x", pady=(0, 12))
         steps = (
             ("protecting", "Protect your existing settings"),
-            ("connecting", "Connect your AI apps"),
-            ("verifying", "Check that memory is ready"),
+            ("connecting", "Optimize your AI apps"),
+            ("verifying", "Check that Lians is ready"),
         )
         for key, copy in steps:
             label = self._label(
@@ -214,7 +215,7 @@ class SetupApp:
             label.pack(fill="x", pady=2)
             self.step_labels[key] = label
 
-        self.status = tk.StringVar(value="Ready to connect")
+        self.status = tk.StringVar(value="Ready to optimize")
         self.status_label = self._label(
             self.card,
             textvariable=self.status,
@@ -228,7 +229,7 @@ class SetupApp:
         actions.pack(fill="x")
         self.install_button = tk.Button(
             actions,
-            text="Set up Lians",
+            text="Optimize my AI apps",
             command=self._start_install,
             background=BLUE,
             foreground="white",
@@ -349,8 +350,9 @@ class SetupApp:
         detected = "\n".join(paths) if paths else "No supported app settings found yet."
         return (
             "What setup changes\n"
-            "Lians adds a local memory connection only to the apps you select. It does not "
-            "install Git, Python, build tools, or a model. Existing files are backed up first.\n\n"
+            "Lians adds a local context connection only to the apps you select. It does not "
+            "ask for an AI account password, install Git, build tools, or a model. Existing "
+            "files are backed up first.\n\n"
             f"Encrypted memory: {user_data_dir() / 'memory.sqlite3'}\n"
             f"Detected settings:\n{detected}"
         )
@@ -363,7 +365,7 @@ class SetupApp:
             self.status.set("Choose at least one AI app to continue.")
             return
 
-        self.install_button.configure(state="disabled", text="Setting up...")
+        self.install_button.configure(state="disabled", text="Optimizing...")
         self.progress_frame.pack(fill="x", pady=(0, 10), before=self.status_label)
         self._update_progress("protecting", "Protecting your existing settings")
 
@@ -474,7 +476,7 @@ class SetupApp:
         connected = ", ".join(self.connected_labels)
         self._label(
             self.card,
-            "Memory is ready.",
+            "Your AI apps are optimized.",
             background=PANEL,
             foreground=GREEN,
             font=("Segoe UI", 22, "bold"),
@@ -482,7 +484,7 @@ class SetupApp:
         ).pack(fill="x")
         self._label(
             self.card,
-            f"Lians connected {connected}.",
+            f"Lians is active in {connected}. Keep using the apps normally.",
             background=PANEL,
             foreground=TEXT,
             font=("Segoe UI", 11),
@@ -494,7 +496,7 @@ class SetupApp:
         try_card.pack(fill="x")
         self._label(
             try_card,
-            "Try the cross-app memory moment",
+            "Try it in two chats",
             background=BLUE_SOFT,
             foreground=TEXT,
             font=("Segoe UI", 12, "bold"),
@@ -504,8 +506,8 @@ class SetupApp:
             try_card,
             (
                 "1. Restart the connected AI apps.\n"
-                "2. In one app, say: Remember that we use FastAPI and never write migrations manually.\n"
-                "3. Start a new task in another app and ask: What are our project rules?"
+                "2. Say: Remember that this project uses FastAPI and pytest.\n"
+                "3. Start a new chat in the same or another app and ask: What does this project use?"
             ),
             background=BLUE_SOFT,
             foreground=MUTED,
@@ -517,7 +519,7 @@ class SetupApp:
             try_card,
             text="Copy the first prompt",
             command=lambda: self._copy(
-                "Remember that we use FastAPI and never write migrations manually."
+                "Remember that this project uses FastAPI and pytest."
             ),
             background=BLUE,
             foreground="white",
@@ -533,8 +535,8 @@ class SetupApp:
         self._label(
             self.card,
             (
-                "When a memory appears, Lians shows a small receipt with what was used, "
-                "why it was selected, the project, and its estimated token cost."
+                "Lians adds only the saved details relevant to the new task. Its receipt shows "
+                "what was reused, what was left out, and the estimated context size."
             ),
             background=PANEL,
             foreground=MUTED,

--- a/packages/lians-easy/lians_easy/installer.py
+++ b/packages/lians-easy/lians_easy/installer.py
@@ -1173,7 +1173,7 @@ def _install_unlocked(
                 item["cleanup_errors"] = cleanup_errors
         results.append(item)
 
-    progress("verifying", "Checking that memory is ready")
+    progress("verifying", "Checking that Lians is ready")
     installed = [item for item in results if item["status"] == "installed"]
     failed = [item for item in results if item["status"] == "failed"]
     status = "installed" if not failed else "partial" if installed else "failed"
@@ -1192,7 +1192,7 @@ def _install_unlocked(
         "requires_trust": [item["client"] for item in installed if item["client"] == "codex"],
         "next_step": (
             "Restart each selected AI client. In Codex, review and trust the Lians hooks in "
-            "/hooks. Then ask Cursor to remember one project preference."
+            "/hooks. Then say 'Remember that...' in any connected app and reuse it in a new chat."
             if status == "installed"
             else "Retry only the failed AI apps. Successful connections were not repeated."
         ),

--- a/packages/lians-easy/lians_easy/store.py
+++ b/packages/lians-easy/lians_easy/store.py
@@ -132,6 +132,8 @@ class MemoryStore:
                     client TEXT NOT NULL,
                     token_estimate INTEGER NOT NULL,
                     memory_count INTEGER NOT NULL,
+                    available_memory_token_estimate INTEGER NOT NULL DEFAULT 0,
+                    avoided_memory_token_estimate INTEGER NOT NULL DEFAULT 0,
                     receipt_json TEXT NOT NULL,
                     created_at TEXT NOT NULL
                 );
@@ -153,6 +155,19 @@ class MemoryStore:
             for name, declaration in additions.items():
                 if name not in existing:
                     db.execute(f"ALTER TABLE memories ADD COLUMN {name} {declaration}")
+
+            existing_receipt_columns = {
+                row[1] for row in db.execute("PRAGMA table_info(context_receipts)")
+            }
+            receipt_additions = {
+                "available_memory_token_estimate": "INTEGER NOT NULL DEFAULT 0",
+                "avoided_memory_token_estimate": "INTEGER NOT NULL DEFAULT 0",
+            }
+            for name, declaration in receipt_additions.items():
+                if name not in existing_receipt_columns:
+                    db.execute(
+                        f"ALTER TABLE context_receipts ADD COLUMN {name} {declaration}"
+                    )
 
             legacy = db.execute(
                 "SELECT id, profile, content FROM memories "
@@ -400,6 +415,21 @@ class MemoryStore:
             used += item_size
         return result
 
+    def _available_memory_totals(self, *, project_id: str | None) -> tuple[int, int]:
+        """Count active memory that a full in-scope replay would have included."""
+        with self._connect() as db:
+            row = db.execute(
+                """SELECT COUNT(*), COALESCE(SUM(token_estimate), 0)
+                   FROM memories
+                   WHERE profile = ?
+                     AND forgotten_at IS NULL
+                     AND superseded_by_id IS NULL
+                     AND paused_at IS NULL
+                     AND (scope != 'project' OR project_id = ?)""",
+                (self.profile, project_id),
+            ).fetchone()
+        return int(row[0] or 0), int(row[1] or 0)
+
     def context_pack(
         self,
         query: str,
@@ -412,6 +442,9 @@ class MemoryStore:
     ) -> dict[str, Any]:
         project_id = project.id if project is not None else None
         project_name = project.name if project is not None else "global"
+        available_memory_count, available_memory_tokens = self._available_memory_totals(
+            project_id=project_id
+        )
         ranked, exclusions = self._ranked(
             query,
             project_id=project_id,
@@ -463,6 +496,23 @@ class MemoryStore:
             token_count = corrected_count
             context = render(token_count)
 
+        selected_memory_tokens = sum(int(item["token_estimate"] or 0) for item in selected)
+        avoided_memory_tokens = max(0, available_memory_tokens - selected_memory_tokens)
+        reduction_percent = (
+            round((avoided_memory_tokens / available_memory_tokens) * 100, 1)
+            if available_memory_tokens
+            else 0.0
+        )
+        efficiency = {
+            "basis": "active in-scope memory content compared with full replay",
+            "available_memory_count": available_memory_count,
+            "available_memory_token_estimate": available_memory_tokens,
+            "selected_memory_count": len(selected),
+            "selected_memory_token_estimate": selected_memory_tokens,
+            "repeated_memory_tokens_avoided_estimate": avoided_memory_tokens,
+            "reduction_percent_estimate": reduction_percent,
+        }
+
         receipt_id = str(uuid.uuid4())
         created_at = _now()
         receipt: dict[str, Any] = {
@@ -480,6 +530,7 @@ class MemoryStore:
             "memory_count": len(selected),
             "token_estimate": token_count,
             "limits": {"max_memories": limit, "max_tokens": max_tokens},
+            "efficiency": efficiency,
             "memories": [
                 {
                     "id": item["id"],
@@ -503,7 +554,8 @@ class MemoryStore:
             db.execute(
                 """INSERT INTO context_receipts
                    (id, profile, project_id, client, token_estimate, memory_count,
-                    receipt_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    available_memory_token_estimate, avoided_memory_token_estimate,
+                    receipt_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     receipt_id,
                     self.profile,
@@ -511,6 +563,8 @@ class MemoryStore:
                     client,
                     token_count,
                     len(selected),
+                    available_memory_tokens,
+                    avoided_memory_tokens,
                     json.dumps(receipt, ensure_ascii=False, sort_keys=True),
                     created_at,
                 ),
@@ -524,6 +578,7 @@ class MemoryStore:
                     "receipt_id": receipt_id,
                     "memory_count": len(selected),
                     "token_estimate": token_count,
+                    "repeated_memory_tokens_avoided_estimate": avoided_memory_tokens,
                 },
             )
         return {
@@ -533,6 +588,7 @@ class MemoryStore:
             ),
             "memories": selected,
             "receipt": receipt,
+            "efficiency": efficiency,
         }
 
     def list(self, *, state: str = "current", limit: int = 50) -> list[dict[str, Any]]:
@@ -857,6 +913,15 @@ class MemoryStore:
                    FROM memories WHERE profile = ?""",
                 (self.profile,),
             ).fetchone()
+            efficiency = db.execute(
+                """SELECT COUNT(*), COALESCE(SUM(memory_count), 0),
+                          COALESCE(SUM(token_estimate), 0),
+                          COALESCE(SUM(available_memory_token_estimate), 0),
+                          COALESCE(SUM(avoided_memory_token_estimate), 0),
+                          COUNT(DISTINCT client)
+                   FROM context_receipts WHERE profile = ?""",
+                (self.profile,),
+            ).fetchone()
         return {
             "current": row[0] or 0,
             "superseded": row[1] or 0,
@@ -867,4 +932,13 @@ class MemoryStore:
             "encrypted": True,
             "key_protection": self.cipher.protection,
             "key_fingerprint": self.cipher.fingerprint,
+            "efficiency": {
+                "context_events": efficiency[0] or 0,
+                "memories_reused": efficiency[1] or 0,
+                "context_tokens_sent_estimate": efficiency[2] or 0,
+                "available_memory_tokens_estimate": efficiency[3] or 0,
+                "repeated_memory_tokens_avoided_estimate": efficiency[4] or 0,
+                "clients_used": efficiency[5] or 0,
+                "basis": "active in-scope memory content compared with full replay",
+            },
         }

--- a/packages/lians-easy/manifest.json
+++ b/packages/lians-easy/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": "0.4",
   "name": "lians-memory",
-  "display_name": "Lians Memory",
+  "display_name": "Lians",
   "version": "0.5.0",
-  "description": "Encrypted local memory shared by Cursor, Claude, Codex, and other AI agents.",
-  "long_description": "Remember project facts, preferences, decisions, and handoffs once, then recall only the relevant context in any supported AI agent. Lians runs locally by default, encrypts memory on your device, and needs no account or API key.",
+  "description": "Use less repeated context in Cursor, Claude, Codex, and other AI tools.",
+  "long_description": "Save a useful preference, fact, or decision once. Lians reuses only the relevant context in later tasks instead of replaying everything. It runs locally by default, encrypts saved context on your device, and needs no AI account password or provider API key.",
   "author": {
     "name": "Lians",
     "email": "info@lians.ai",

--- a/packages/lians-easy/pyproject.toml
+++ b/packages/lians-easy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "lians-bridge"
 version = "0.5.0"
-description = "Private cross-tool memory for AI clients"
+description = "Less repeated context for the AI tools you already use"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 readme = "README.md"

--- a/packages/lians-easy/tests/test_bridge_memory.py
+++ b/packages/lians-easy/tests/test_bridge_memory.py
@@ -124,6 +124,11 @@ def test_encrypted_cross_tool_context_receipt_and_immediate_correction(tmp_path)
     assert pack["receipt"]["excluded"]["scope"] == 1
     assert pack["receipt"]["excluded"]["paused"] == 1
     assert all(item["reason"] for item in pack["receipt"]["memories"])
+    efficiency = pack["receipt"]["efficiency"]
+    assert efficiency["available_memory_count"] == 3
+    assert efficiency["selected_memory_count"] == 3
+    assert efficiency["repeated_memory_tokens_avoided_estimate"] == 0
+    assert efficiency["basis"] == "active in-scope memory content compared with full replay"
 
     signature = pack["receipt"]["signature"]
     protected = {key: value for key, value in pack["receipt"].items() if key != "signature"}
@@ -142,6 +147,11 @@ def test_encrypted_cross_tool_context_receipt_and_immediate_correction(tmp_path)
     )
     assert corrected["content"] in corrected_pack["context"]
     assert stack["content"] not in corrected_pack["context"]
+
+    totals = codex.stats()["efficiency"]
+    assert totals["context_events"] == 2
+    assert totals["memories_reused"] == 6
+    assert totals["clients_used"] == 2
 
     erased = cursor.forget(corrected["id"], confirmed=True)
     forgotten_pack = codex.context_pack(

--- a/packages/lians-easy/tests/test_cli_product.py
+++ b/packages/lians-easy/tests/test_cli_product.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+from lians_easy import cli
+from lians_easy.installer import ClientTarget
+from lians_easy.store import MemoryStore
+
+
+def test_product_status_keeps_setup_and_measured_impact_simple(tmp_path, monkeypatch) -> None:
+    data = tmp_path / "memory.sqlite3"
+    store = MemoryStore(data)
+    store.remember("Use Python 3.12 for this project.", kind="preference")
+    store.remember("Run tests with pytest.", kind="preference")
+    store.context_pack("Which Python version?", project=None, client="claude", limit=1)
+
+    targets = {
+        "claude": ClientTarget(
+            key="claude",
+            label="Claude Desktop",
+            config_path=tmp_path / "claude.json",
+            kind="json",
+            detected=True,
+            configured=True,
+        ),
+        "cursor": ClientTarget(
+            key="cursor",
+            label="Cursor",
+            config_path=tmp_path / "cursor.json",
+            kind="json",
+            detected=True,
+            configured=False,
+        ),
+    }
+    monkeypatch.setattr(cli, "client_targets", lambda _home=None: targets)
+
+    result = cli.product_status(data_path=data)
+
+    assert result["status"] == "optimized"
+    assert result["headline"] == "Lians is active in 1 AI app."
+    assert result["configured_clients"] == 1
+    assert result["detected_clients"] == 2
+    assert result["privacy"]["ai_account_credentials_required"] is False
+    assert result["efficiency"]["context_events"] == 1
+    assert result["efficiency"]["repeated_memory_tokens_avoided_estimate"] > 0
+
+
+def test_status_command_outputs_machine_readable_product_state(tmp_path, monkeypatch, capsys) -> None:
+    data = tmp_path / "memory.sqlite3"
+    monkeypatch.setattr(cli, "listen_for_windows_installer_shutdown", lambda: None)
+    monkeypatch.setattr(cli, "client_targets", lambda _home=None: {})
+
+    cli.main(["status", "--data", str(data), "--json"])
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "not_configured"
+    assert result["efficiency"]["context_events"] == 0
+
+
+def test_optimize_is_the_plain_language_install_path() -> None:
+    parsed = cli.parser().parse_args(
+        ["optimize", "--clients", "claude,cursor", "--plan", "--json"]
+    )
+
+    assert parsed.command == "optimize"
+    assert parsed.clients == "claude,cursor"
+    assert parsed.plan is True

--- a/packages/lians-easy/tests/test_product_positioning.py
+++ b/packages/lians-easy/tests/test_product_positioning.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_ROOT = REPOSITORY_ROOT / "packages" / "lians-easy"
+
+
+def test_primary_github_and_desktop_surfaces_share_one_product_promise() -> None:
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+    direction = (REPOSITORY_ROOT / "docs" / "product-direction.md").read_text(
+        encoding="utf-8"
+    )
+    consumer_contract = (
+        REPOSITORY_ROOT / "docs" / "consumer-installer.md"
+    ).read_text(encoding="utf-8")
+    gui = (PACKAGE_ROOT / "lians_easy" / "gui.py").read_text(encoding="utf-8")
+    manifest = json.loads((REPOSITORY_ROOT / "product-manifest.json").read_text())
+
+    for surface in (readme, direction, consumer_contract, gui):
+        assert "Use less context. Get more AI." in surface
+    assert manifest["product"]["category"] == "AI efficiency for the tools you already use"
+    assert "Optimize my AI apps" in gui
+    assert "provider API key" in readme
+
+
+def test_public_copy_does_not_promise_provider_quota_extension() -> None:
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8").lower()
+    direction = (REPOSITORY_ROOT / "docs" / "product-direction.md").read_text(
+        encoding="utf-8"
+    ).lower()
+
+    for unsupported_claim in (
+        "guaranteed token savings",
+        "double your usage",
+        "extend your claude plan",
+        "extend your cursor plan",
+        "extend your codex plan",
+    ):
+        assert unsupported_claim not in readme
+        assert unsupported_claim not in direction

--- a/packages/lians-easy/tests/test_release_contract.py
+++ b/packages/lians-easy/tests/test_release_contract.py
@@ -22,7 +22,7 @@ def test_public_python_package_has_product_aligned_commands() -> None:
 
     assert 'requires = ["hatchling==1.32.0"]' in pyproject
     assert 'name = "lians-bridge"' in pyproject
-    assert 'description = "Private cross-tool memory for AI clients"' in pyproject
+    assert 'description = "Less repeated context for the AI tools you already use"' in pyproject
     assert 'lians = "lians_easy.cli:main"' in pyproject
     assert 'lians-bridge = "lians_easy.cli:main"' in pyproject
     assert 'lians-easy = "lians_easy.cli:main"' in pyproject

--- a/packages/lians-easy/tests/test_store.py
+++ b/packages/lians-easy/tests/test_store.py
@@ -116,6 +116,33 @@ def test_every_operation_closes_its_sqlite_connection(tmp_path, monkeypatch):
     assert all(connection.closed for connection in connections)
 
 
+def test_existing_receipt_table_is_upgraded_for_efficiency_measurement(tmp_path):
+    data = tmp_path / "memory.sqlite3"
+    with sqlite3.connect(data) as db:
+        db.execute(
+            """CREATE TABLE context_receipts (
+               id TEXT PRIMARY KEY,
+               profile TEXT NOT NULL,
+               project_id TEXT,
+               client TEXT NOT NULL,
+               token_estimate INTEGER NOT NULL,
+               memory_count INTEGER NOT NULL,
+               receipt_json TEXT NOT NULL,
+               created_at TEXT NOT NULL
+            )"""
+        )
+
+    store = MemoryStore(data)
+    memory = store.remember("Use Python 3.12.", kind="preference")
+    pack = store.context_pack("Which Python version?", project=None, client="codex")
+
+    assert pack["memories"][0]["id"] == memory["id"]
+    with sqlite3.connect(data) as db:
+        columns = {row[1] for row in db.execute("PRAGMA table_info(context_receipts)")}
+    assert "available_memory_token_estimate" in columns
+    assert "avoided_memory_token_estimate" in columns
+
+
 def test_confirmed_profile_erasure_clears_history_and_keeps_store_usable(tmp_path):
     data = tmp_path / "memory.sqlite3"
     store = MemoryStore(data)

--- a/product-manifest.json
+++ b/product-manifest.json
@@ -7,36 +7,41 @@
   },
   "product": {
     "name": "Lians",
-    "category": "Memory for any AI agent",
-    "summary": "Lians gives AI agents durable memory across chats, sessions, tools, and models. It runs locally by default, connects through MCP or SDKs, and lets an agent remember useful facts and recall relevant current context without locking that memory to one model provider.",
+    "category": "AI efficiency for the tools you already use",
+    "summary": "Lians helps Claude, Cursor, Codex, and other AI tools avoid rereading the same project context. Connect an existing app, keep working normally, and Lians reuses a small amount of relevant saved context while leaving the rest out. Local mode is free, encrypted on the device, and does not require an AI account password or provider API key.",
     "workflow": [
       {
-        "label": "Remember",
-        "detail": "Store one useful fact, preference, constraint, or decision that should survive the current chat."
+        "label": "Optimize",
+        "detail": "Lians detects supported AI apps and adds its local context connection without replacing the user's model, editor, or workflow."
       },
       {
-        "label": "Recall",
-        "detail": "Retrieve a small, relevant set of current memories when a later task needs them."
+        "label": "Work normally",
+        "detail": "The user saves a useful preference, fact, constraint, or decision once and continues working in the AI tools they already use."
       },
       {
-        "label": "Continue",
-        "detail": "Point another compatible agent or model at the same memory store and continue with the same context."
+        "label": "Reuse less",
+        "detail": "For a later task, Lians selects a bounded set of relevant current context instead of replaying the full saved history."
       },
       {
-        "label": "Control",
-        "detail": "Supersede stale facts, inspect where a memory came from, and use confirmed erasure where the integration exposes it."
+        "label": "See the proof",
+        "detail": "Status and signed receipts show what context was reused, what was left out, and the estimated repeated memory tokens avoided."
       }
     ],
     "surfaces": [
       {
-        "label": "Lians Easy desktop installer",
+        "label": "Lians desktop app",
         "status": "Release candidate",
-        "detail": "Guided, dependency-free local setup for Claude Desktop, Cursor, Windsurf, Gemini CLI, Codex, Cline CLI, and OpenCode, with cross-client memory and managed deployment flags."
+        "detail": "Guided local setup detects supported AI apps, lets the user optimize them from one screen, and opens the encrypted local control center. Consumer publication remains gated on trusted Windows and Apple signing."
       },
       {
-        "label": "MCP memory server",
+        "label": "Bounded context engine",
         "status": "Available",
-        "detail": "Local memory for MCP-compatible agents with remember, recall, inspect, correct, and confirmed forget."
+        "detail": "Stores useful context once, selects a small current subset for each task, and measures the estimated repeated memory context left out."
+      },
+      {
+        "label": "Claude, Cursor, and Codex connections",
+        "status": "Available",
+        "detail": "Connects through supported plugins, hooks, rules, and MCP settings without asking for the user's AI account password or changing the underlying model."
       },
       {
         "label": "Python local library",
@@ -44,19 +49,9 @@
         "detail": "SQLite-backed memory inside Python applications with no server, Docker container, or API key."
       },
       {
-        "label": "Pydantic AI integration",
+        "label": "Developer and framework integrations",
         "status": "Available",
-        "detail": "A tested local example that exposes current and point-in-time Lians recall as ordinary Pydantic AI function tools."
-      },
-      {
-        "label": "LangGraph integration",
-        "status": "Available",
-        "detail": "A tested credential-free graph that remembers a fact locally and recalls it in a later invocation."
-      },
-      {
-        "label": "Language SDKs",
-        "status": "Available",
-        "detail": "Python, TypeScript, Go, Java, and C clients for connecting applications to a Lians service."
+        "detail": "MCP, Python, TypeScript, Go, Java, C, Pydantic AI, LangGraph, and other integration paths remain available behind the simple end-user product."
       },
       {
         "label": "Self-hosted service",


### PR DESCRIPTION
## Summary

- reframe Lians around one ordinary-user promise: **Use less context. Get more AI.**
- add `lians optimize` for plain-language client setup and `lians status` for connected-app and efficiency visibility
- extend signed context receipts with an inspectable estimate of active in-scope memory, selected memory, and repeated memory context left out
- simplify the desktop setup copy and the main GitHub/Claude/Cursor/Codex entry points
- add a concise product-direction contract covering the customer, default experience, claims boundary, build order, and success metrics
- preserve the signing gate: unsigned Windows/macOS artifacts remain technical previews, not consumer downloads
- leave the website unchanged

## Measurement boundary

The new metric compares active, in-scope saved memory content with the subset selected for a task. It is labeled as an estimate and does **not** claim to extend provider quotas, message caps, context windows, or every user's subscription.

## Validation

- `python -m pytest packages/lians-easy/tests -q` - 146 passed, 1 skipped
- `python scripts/test_all.py` - 1,125 passed, 11 skipped
- `python -m ruff check ...` on all touched Python files - passed
- `git diff --check` - passed