### PR TITLE
docs: remove the README flow graphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ model, editor, and normal workflow.
   the estimated repeated memory context avoided.
 - **Portable:** one local store can support multiple compatible AI tools.
 
-<p align="center">
-  <img src="docs/assets/cross-tool-memory-flow.svg" width="100%" alt="A saved project preference is reused as bounded context in a later Cursor, Codex, or Claude task.">
-</p>
-
 ## Try Lians in two chats
 
 Choose the AI tool you already use:


### PR DESCRIPTION
## What changed

Removed the large `docs/assets/cross-tool-memory-flow.svg` graphic from the public README.

## Why

The graphic still appeared on the default branch even though it had been removed from the dependent product PR. This small independent change removes it without waiting for that PR chain.

## User impact

The live README becomes shorter and no longer displays the large "Say it once" product-flow image. The approved Lotus and Lians wordmark remain unchanged.

## Validation

- `python -m pytest agentmem/tests/test_distribution_contract.py -q` (10 passed)
- `git diff --check`
- exact diff is four deleted README lines