### PR TITLE
fix: harden local project identity

### DIFF
--- a/agentmem/tests/test_consumer_cloud_e2e.py
+++ b/agentmem/tests/test_consumer_cloud_e2e.py
@@ -62,7 +62,7 @@ def _service(store, cloud_url, state_path, device_name):
 
 @pytest.mark.asyncio
 async def test_two_clean_stores_enroll_and_share_corrected_memory_through_real_api(
-    db, tmp_path
+    db, tmp_path, monkeypatch
 ):
     db.add(
         ApiKey(
@@ -101,6 +101,7 @@ async def test_two_clean_stores_enroll_and_share_corrected_memory_through_real_a
         )
         project = tmp_path / "project"
         (project / ".git").mkdir(parents=True)
+        monkeypatch.chdir(project)
         remembered = await asyncio.to_thread(
             call_tool,
             first_store,

--- a/packages/lians-easy/lians_easy/project.py
+++ b/packages/lians-easy/lians_easy/project.py
@@ -9,6 +9,16 @@ import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
+
+
+_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
+_SCP_REMOTE = re.compile(
+    r"^(?:[^@/:\s]+@)?(?P<host>[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?):(?P<path>[^?#\s]+)$"
+)
+_MAX_PATH_CHARS = 32_768
+_MAX_GIT_POINTER_BYTES = 4_096
+_MAX_GIT_CONFIG_BYTES = 1_048_576
 
 
 @dataclass(frozen=True)
@@ -22,43 +32,146 @@ class Project:
         return asdict(self)
 
 
+def _validated_project_path(value: str | Path) -> Path:
+    raw = os.fspath(value)
+    if not raw or len(raw) > _MAX_PATH_CHARS or _CONTROL.search(raw):
+        raise ValueError("project path must be a bounded local path")
+    try:
+        resolved = Path(raw).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("project path must exist and be accessible") from exc
+    if not (resolved.is_dir() or resolved.is_file()):
+        raise ValueError("project path must identify a file or directory")
+    return resolved
+
+
 def _repository_root(start: Path) -> Path:
     candidate = start if start.is_dir() else start.parent
-    candidate = candidate.resolve()
     for parent in (candidate, *candidate.parents):
         if (parent / ".git").exists():
             return parent
     return candidate
 
 
-def _origin(root: Path) -> str | None:
+def _bounded_text(path: Path, *, max_bytes: int) -> str | None:
+    try:
+        if path.is_symlink() or not path.is_file() or path.stat().st_size > max_bytes:
+            return None
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+
+
+def _worktree_config(git_file: Path) -> Path | None:
+    pointer = _bounded_text(git_file, max_bytes=_MAX_GIT_POINTER_BYTES)
+    if pointer is None:
+        return None
+    match = re.fullmatch(r"gitdir:\s*([^\r\n]+)\s*", pointer)
+    if match is None or _CONTROL.search(match.group(1)):
+        return None
+    location = Path(match.group(1).strip())
+    try:
+        git_dir = (location if location.is_absolute() else git_file.parent / location).resolve(
+            strict=True
+        )
+    except (OSError, RuntimeError):
+        return None
+    if not git_dir.is_dir() or git_dir.is_symlink():
+        return None
+
+    common_pointer = _bounded_text(
+        git_dir / "commondir", max_bytes=_MAX_GIT_POINTER_BYTES
+    )
+    if common_pointer is None:
+        return None
+    common_raw = common_pointer.strip()
+    if not common_raw or _CONTROL.search(common_raw) or "\n" in common_raw or "\r" in common_raw:
+        return None
+    common_location = Path(common_raw)
+    try:
+        common_dir = (
+            common_location if common_location.is_absolute() else git_dir / common_location
+        ).resolve(strict=True)
+        worktrees_dir = git_dir.parent.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    if (
+        not common_dir.is_dir()
+        or common_dir.is_symlink()
+        or worktrees_dir.name != "worktrees"
+        or worktrees_dir.parent != common_dir
+    ):
+        return None
+    return common_dir / "config"
+
+
+def _git_config(root: Path) -> Path | None:
     git = root / ".git"
+    if git.is_symlink():
+        return None
     config_path = git / "config" if git.is_dir() else None
     if git.is_file():
-        match = re.search(r"^gitdir:\s*(.+)$", git.read_text(encoding="utf-8"), re.MULTILINE)
-        if match:
-            location = Path(match.group(1).strip())
-            config_path = (location if location.is_absolute() else root / location) / "config"
-    if not config_path or not config_path.is_file():
+        config_path = _worktree_config(git)
+    if config_path is None or config_path.is_symlink() or not config_path.is_file():
+        return None
+    return config_path
+
+
+def _safe_origin(raw: str) -> str | None:
+    value = raw.strip()
+    if not value or len(value) > 4_096 or _CONTROL.search(value):
+        return None
+
+    scp = (
+        _SCP_REMOTE.fullmatch(value)
+        if "://" not in value and not re.match(r"^[A-Za-z]:[\\/]", value)
+        else None
+    )
+    if scp is not None:
+        host = scp.group("host").lower().rstrip(".")
+        path = scp.group("path").strip("/").removesuffix(".git")
+    else:
+        try:
+            parsed = urlsplit(value)
+            port = parsed.port
+        except ValueError:
+            return None
+        if parsed.scheme.lower() not in {"http", "https", "ssh", "git"} or not parsed.hostname:
+            return None
+        host = parsed.hostname.lower().rstrip(".")
+        if port is not None:
+            host = f"{host}:{port}"
+        path = parsed.path.strip("/").removesuffix(".git")
+
+    pieces = path.split("/") if path else []
+    if (
+        not host
+        or not pieces
+        or any(part in {"", ".", ".."} for part in pieces)
+        or any(_CONTROL.search(part) or any(character.isspace() for character in part) for part in pieces)
+    ):
+        return None
+    return f"{host}/{'/'.join(pieces)}".lower().rstrip("/")
+
+
+def _origin(root: Path) -> str | None:
+    config_path = _git_config(root)
+    if config_path is None:
+        return None
+    source = _bounded_text(config_path, max_bytes=_MAX_GIT_CONFIG_BYTES)
+    if source is None:
         return None
     parser = configparser.ConfigParser()
     try:
-        parser.read(config_path, encoding="utf-8")
+        parser.read_string(source)
         raw = parser.get('remote "origin"', "url", fallback="").strip()
-    except (configparser.Error, OSError):
+    except configparser.Error:
         return None
-    if not raw:
-        return None
-    normalized = raw.removesuffix(".git")
-    if normalized.startswith("git@") and ":" in normalized:
-        host, path = normalized[4:].split(":", 1)
-        normalized = f"{host}/{path}"
-    normalized = re.sub(r"^https?://", "", normalized, flags=re.IGNORECASE)
-    return normalized.lower().rstrip("/")
+    return _safe_origin(raw)
 
 
 def detect_project(cwd: str | Path | None = None) -> Project:
-    root = _repository_root(Path(cwd or Path.cwd()).expanduser())
+    root = _repository_root(_validated_project_path(cwd or Path.cwd()))
     origin = _origin(root)
     identity = origin or os.path.normcase(str(root))
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]

--- a/packages/lians-easy/lians_easy/project.py
+++ b/packages/lians-easy/lians_easy/project.py
@@ -32,17 +32,18 @@ class Project:
         return asdict(self)
 
 
-def _validated_project_path(value: str | Path) -> Path:
+def _validate_workspace_hint(value: str | Path, *, root: Path) -> None:
     raw = os.fspath(value)
     if not raw or len(raw) > _MAX_PATH_CHARS or _CONTROL.search(raw):
         raise ValueError("project path must be a bounded local path")
     try:
-        resolved = Path(raw).expanduser().resolve(strict=True)
-    except (OSError, RuntimeError) as exc:
-        raise ValueError("project path must exist and be accessible") from exc
-    if not (resolved.is_dir() or resolved.is_file()):
-        raise ValueError("project path must identify a file or directory")
-    return resolved
+        requested = os.path.normcase(os.path.abspath(os.path.expanduser(raw)))
+        boundary = os.path.normcase(str(root))
+        inside = os.path.commonpath([requested, boundary]) == boundary
+    except (OSError, ValueError):
+        inside = False
+    if not inside:
+        raise ValueError("project path must stay inside the launched workspace")
 
 
 def _repository_root(start: Path) -> Path:
@@ -171,7 +172,13 @@ def _origin(root: Path) -> str | None:
 
 
 def detect_project(cwd: str | Path | None = None) -> Project:
-    root = _repository_root(_validated_project_path(cwd or Path.cwd()))
+    try:
+        current = Path.cwd().resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("launched workspace must exist and be accessible") from exc
+    root = _repository_root(current)
+    if cwd is not None:
+        _validate_workspace_hint(cwd, root=root)
     origin = _origin(root)
     identity = origin or os.path.normcase(str(root))
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]

--- a/packages/lians-easy/tests/test_bridge_memory.py
+++ b/packages/lians-easy/tests/test_bridge_memory.py
@@ -16,7 +16,7 @@ def _canonical(value):
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
 
 
-def test_project_identity_follows_repository_origin_across_nested_paths(tmp_path):
+def test_project_identity_follows_repository_origin_across_nested_paths(tmp_path, monkeypatch):
     root = tmp_path / "checkout-one"
     nested = root / "src" / "api"
     nested.mkdir(parents=True)
@@ -26,6 +26,7 @@ def test_project_identity_follows_repository_origin_across_nested_paths(tmp_path
         encoding="utf-8",
     )
 
+    monkeypatch.chdir(nested)
     project = detect_project(nested)
 
     assert project.name == "fastapi-app"

--- a/packages/lians-easy/tests/test_bridge_service.py
+++ b/packages/lians-easy/tests/test_bridge_service.py
@@ -41,9 +41,10 @@ def _json_request(url, *, cookie, data=None, origin=None):
         return response.status, json.loads(response.read())
 
 
-def test_hook_adapter_and_cursor_rule_use_the_same_context(tmp_path):
+def test_hook_adapter_and_cursor_rule_use_the_same_context(tmp_path, monkeypatch):
     project = tmp_path / "project"
     (project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(project)
     store = MemoryStore(tmp_path / "bridge.sqlite3")
     remembered = call_tool(
         store,
@@ -134,9 +135,10 @@ def test_hook_adapter_and_cursor_rule_use_the_same_context(tmp_path):
     assert context_for_event(event, client="claude", store=store)["context"] == ""
 
 
-def test_cursor_remember_creates_the_first_project_rule(tmp_path):
+def test_cursor_remember_creates_the_first_project_rule(tmp_path, monkeypatch):
     project = tmp_path / "project"
     (project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(project)
     store = MemoryStore(tmp_path / "bridge.sqlite3")
 
     call_tool(
@@ -156,7 +158,8 @@ def test_cursor_remember_creates_the_first_project_rule(tmp_path):
     assert "Never use em dashes." in rule.read_text(encoding="utf-8")
 
 
-def test_hook_context_pulls_cloud_memory_before_building_its_receipt(tmp_path):
+def test_hook_context_pulls_cloud_memory_before_building_its_receipt(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     store = MemoryStore(tmp_path / "bridge.sqlite3")
 
     class PullingCloud:
@@ -191,6 +194,7 @@ def test_hook_context_pulls_cloud_memory_before_building_its_receipt(tmp_path):
 def test_hook_accepts_a_utf8_bom_from_windows_hosts(tmp_path, monkeypatch):
     project = tmp_path / "project"
     (project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(project)
     data = tmp_path / "bridge.sqlite3"
     store = MemoryStore(data)
     detected = call_tool(
@@ -222,6 +226,7 @@ def test_hook_accepts_a_utf8_bom_from_windows_hosts(tmp_path, monkeypatch):
 def test_gemini_before_agent_hook_injects_bounded_context(tmp_path, monkeypatch):
     project = tmp_path / "project"
     (project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(project)
     data = tmp_path / "bridge.sqlite3"
     store = MemoryStore(data)
     call_tool(
@@ -255,6 +260,7 @@ def test_gemini_before_agent_hook_injects_bounded_context(tmp_path, monkeypatch)
 def test_antigravity_hook_injects_once_per_agent_loop(tmp_path, monkeypatch):
     project = tmp_path / "project"
     (project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(project)
     data = tmp_path / "bridge.sqlite3"
     store = MemoryStore(data)
     call_tool(
@@ -296,6 +302,7 @@ def test_antigravity_hook_injects_once_per_agent_loop(tmp_path, monkeypatch):
 def test_antigravity_empty_workspace_injects_global_memory_only(tmp_path, monkeypatch):
     project = tmp_path / "project"
     (project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(project)
     data = tmp_path / "bridge.sqlite3"
     store = MemoryStore(data)
     call_tool(
@@ -334,7 +341,8 @@ def test_antigravity_empty_workspace_injects_global_memory_only(tmp_path, monkey
     assert pack["receipt"]["excluded"]["scope"] == 1
 
 
-def test_loopback_app_uses_http_only_session_and_blocks_cross_origin_writes(tmp_path):
+def test_loopback_app_uses_http_only_session_and_blocks_cross_origin_writes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     store = MemoryStore(tmp_path / "bridge.sqlite3")
     app = BridgeApplication(store, port=0)
     server = ThreadingHTTPServer(("127.0.0.1", 0), app.handler())
@@ -638,7 +646,8 @@ def test_loopback_add_device_routes_are_short_code_only_and_confirmation_guarded
         thread.join(timeout=5)
 
 
-def test_loopback_memory_operations_pull_then_write_through_to_cloud(tmp_path):
+def test_loopback_memory_operations_pull_then_write_through_to_cloud(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     calls = []
 
     class FakeCloudAuth:

--- a/packages/lians-easy/tests/test_cloud_service.py
+++ b/packages/lians-easy/tests/test_cloud_service.py
@@ -271,13 +271,14 @@ def test_short_code_add_device_flow_needs_no_workspace_id_or_key_copy(tmp_path):
     assert "FastAPI" not in json.dumps(cloud.log._workspaces)
 
 
-def test_cursor_memory_reaches_codex_and_claude_with_correction_and_forgetting(tmp_path):
+def test_cursor_memory_reaches_codex_and_claude_with_correction_and_forgetting(tmp_path, monkeypatch):
     """Prove the launch-critical cross-tool sequence across two local devices."""
 
     auth = FakeAuth()
     cloud = HTTPShapeCloud()
     cursor_project = tmp_path / "desktop-project"
     (cursor_project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(cursor_project)
     cursor_store = MemoryStore(tmp_path / "desktop" / "memory.sqlite3")
     cursor_state_path = tmp_path / "desktop" / "sync-state.json"
     cursor_sync = _service(cursor_store, auth, cloud, cursor_state_path, "Main PC")
@@ -543,7 +544,7 @@ def test_backup_recovery_requires_confirmation_and_preserves_unreadable_state(
     assert state_path.read_text(encoding="utf-8") == "existing state"
 
 
-def test_cloud_failure_never_blocks_or_leaks_from_a_local_remember(tmp_path):
+def test_cloud_failure_never_blocks_or_leaks_from_a_local_remember(tmp_path, monkeypatch):
     class FailingCloud:
         def client_factory(self, _base_url, *, bearer_token_provider):
             assert bearer_token_provider() == "short-lived-access-token"
@@ -559,6 +560,7 @@ def test_cloud_failure_never_blocks_or_leaks_from_a_local_remember(tmp_path):
     sync = _service(store, FakeAuth(), cloud, tmp_path / "sync-state.json", "Laptop")
     project = tmp_path / "project"
     (project / ".git").mkdir(parents=True)
+    monkeypatch.chdir(project)
 
     result = call_tool(
         store,

--- a/packages/lians-easy/tests/test_project_security.py
+++ b/packages/lians-easy/tests/test_project_security.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lians_easy.project import detect_project
+
+
+def _repo(tmp_path: Path, remote: str) -> Path:
+    root = tmp_path / "project"
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "config").write_text(
+        f'[remote "origin"]\n\turl = {remote}\n', encoding="utf-8"
+    )
+    return root
+
+
+def test_origin_drops_https_credentials_query_and_fragment(tmp_path):
+    root = _repo(
+        tmp_path,
+        "https://build-user:top-secret@example.com/Team/Project.git?token=hidden#fragment",
+    )
+
+    project = detect_project(root)
+
+    assert project.origin == "example.com/team/project"
+    assert "secret" not in project.id
+    assert "token" not in project.id
+
+
+def test_origin_drops_ssh_user_information(tmp_path):
+    root = _repo(tmp_path, "ssh://deploy-key@example.com:2222/Team/Project.git")
+
+    project = detect_project(root)
+
+    assert project.origin == "example.com:2222/team/project"
+
+
+def test_local_remote_path_is_not_exposed_as_public_origin(tmp_path):
+    root = _repo(tmp_path, str(tmp_path / "private" / "upstream.git"))
+
+    project = detect_project(root)
+
+    assert project.origin is None
+    assert project.name == "project"
+
+
+def test_unverified_gitdir_pointer_is_not_followed(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    outside = tmp_path / "private-metadata"
+    outside.mkdir()
+    (outside / "config").write_text(
+        '[remote "origin"]\n\turl = https://user:secret@example.com/private/repo.git\n',
+        encoding="utf-8",
+    )
+    (root / ".git").write_text(f"gitdir: {outside}\n", encoding="utf-8")
+
+    project = detect_project(root)
+
+    assert project.origin is None
+    assert project.root == str(root)
+
+
+def test_verified_linked_worktree_uses_common_git_config(tmp_path):
+    common = tmp_path / "source" / ".git"
+    git_dir = common / "worktrees" / "preview"
+    git_dir.mkdir(parents=True)
+    (git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (common / "config").write_text(
+        '[remote "origin"]\n\turl = git@github.com:Lians-ai/Lians.git\n',
+        encoding="utf-8",
+    )
+    root = tmp_path / "preview"
+    root.mkdir()
+    (root / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
+
+    project = detect_project(root)
+
+    assert project.origin == "github.com/lians-ai/lians"
+
+
+@pytest.mark.parametrize("value", ["missing", "bad\x00path"])
+def test_invalid_project_paths_fail_closed(tmp_path, value):
+    candidate = tmp_path / value if "\x00" not in value else value
+
+    with pytest.raises(ValueError, match="project path"):
+        detect_project(candidate)

--- a/packages/lians-easy/tests/test_project_security.py
+++ b/packages/lians-easy/tests/test_project_security.py
@@ -16,12 +16,13 @@ def _repo(tmp_path: Path, remote: str) -> Path:
     return root
 
 
-def test_origin_drops_https_credentials_query_and_fragment(tmp_path):
+def test_origin_drops_https_credentials_query_and_fragment(tmp_path, monkeypatch):
     root = _repo(
         tmp_path,
         "https://build-user:top-secret@example.com/Team/Project.git?token=hidden#fragment",
     )
 
+    monkeypatch.chdir(root)
     project = detect_project(root)
 
     assert project.origin == "example.com/team/project"
@@ -29,24 +30,26 @@ def test_origin_drops_https_credentials_query_and_fragment(tmp_path):
     assert "token" not in project.id
 
 
-def test_origin_drops_ssh_user_information(tmp_path):
+def test_origin_drops_ssh_user_information(tmp_path, monkeypatch):
     root = _repo(tmp_path, "ssh://deploy-key@example.com:2222/Team/Project.git")
 
+    monkeypatch.chdir(root)
     project = detect_project(root)
 
     assert project.origin == "example.com:2222/team/project"
 
 
-def test_local_remote_path_is_not_exposed_as_public_origin(tmp_path):
+def test_local_remote_path_is_not_exposed_as_public_origin(tmp_path, monkeypatch):
     root = _repo(tmp_path, str(tmp_path / "private" / "upstream.git"))
 
+    monkeypatch.chdir(root)
     project = detect_project(root)
 
     assert project.origin is None
     assert project.name == "project"
 
 
-def test_unverified_gitdir_pointer_is_not_followed(tmp_path):
+def test_unverified_gitdir_pointer_is_not_followed(tmp_path, monkeypatch):
     root = tmp_path / "project"
     root.mkdir()
     outside = tmp_path / "private-metadata"
@@ -57,13 +60,14 @@ def test_unverified_gitdir_pointer_is_not_followed(tmp_path):
     )
     (root / ".git").write_text(f"gitdir: {outside}\n", encoding="utf-8")
 
+    monkeypatch.chdir(root)
     project = detect_project(root)
 
     assert project.origin is None
     assert project.root == str(root)
 
 
-def test_verified_linked_worktree_uses_common_git_config(tmp_path):
+def test_verified_linked_worktree_uses_common_git_config(tmp_path, monkeypatch):
     common = tmp_path / "source" / ".git"
     git_dir = common / "worktrees" / "preview"
     git_dir.mkdir(parents=True)
@@ -76,14 +80,29 @@ def test_verified_linked_worktree_uses_common_git_config(tmp_path):
     root.mkdir()
     (root / ".git").write_text(f"gitdir: {git_dir}\n", encoding="utf-8")
 
+    monkeypatch.chdir(root)
     project = detect_project(root)
 
     assert project.origin == "github.com/lians-ai/lians"
 
 
-@pytest.mark.parametrize("value", ["missing", "bad\x00path"])
-def test_invalid_project_paths_fail_closed(tmp_path, value):
-    candidate = tmp_path / value if "\x00" not in value else value
+@pytest.mark.parametrize("value", ["../outside", "bad\x00path"])
+def test_project_hints_outside_the_launched_workspace_fail_closed(tmp_path, monkeypatch, value):
+    root = tmp_path / "project"
+    root.mkdir()
+    monkeypatch.chdir(root)
+    candidate = root / value if "\x00" not in value else value
 
-    with pytest.raises(ValueError, match="project path"):
+    with pytest.raises(ValueError, match="project path must"):
         detect_project(candidate)
+
+
+def test_project_hint_inside_workspace_never_changes_the_trusted_root(tmp_path, monkeypatch):
+    root = tmp_path / "project"
+    nested = root / "src" / "api"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(root)
+
+    project = detect_project(nested)
+
+    assert project.root == str(root)


### PR DESCRIPTION
## Summary
- confine project identity to the workspace that launched Lians; model or browser path hints cannot select an arbitrary filesystem location
- require bounded path hints and reject hints outside the launched workspace
- follow only verified linked-worktree Git metadata and bound Git pointer/config reads
- normalize repository origins without usernames, passwords, tokens, query strings, fragments, or local paths
- add regression coverage for credential stripping, unsafe .git pointers, linked worktrees, workspace confinement, and invalid paths

## Verification
- local lians-easy suite: 154 passed, 1 skipped
- real consumer cloud regression: passed
- GitHub Python 3.11 and 3.12 matrices: passed
- CodeQL, Gitleaks, dependency review, release contracts, memory safety, SDK, container, and public package checks: passed
- python -m compileall -q packages/lians-easy/lians_easy
- git diff --check