### PR TITLE
Clarify Lians positioning and first-run experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/first_run_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/first_run_feedback.yml
@@ -1,0 +1,50 @@
+name: First-run feedback
+description: Tell us where installation or the first memory test became unclear.
+title: "first run: "
+labels: [documentation]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for trying Lians. Do not include project secrets, credentials, personal data, or confidential memory values.
+  - type: dropdown
+    id: client
+    attributes:
+      label: AI tool
+      options:
+        - Codex
+        - Claude Code
+        - Cursor
+        - Another MCP client
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: What were you trying to do?
+      placeholder: Install Lians, save one test fact, and recall it in a fresh chat.
+    validations:
+      required: true
+  - type: textarea
+    id: blocker
+    attributes:
+      label: Where did you get stuck?
+      description: Include the step, what you expected, and what happened instead. Use synthetic values in examples.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Lians version or commit
+      placeholder: Package version or commit SHA, if known
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: macOS, Windows, or Linux; AI tool version if known
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety check
+      options:
+        - label: I removed credentials, personal data, and confidential project information.
+          required: true

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 <p align="center">
   <a href="https://github.com/Lians-ai/Lians">
-    <img src="docs/images/favicon.png" width="88" alt="Lians Lotus">
-  </a>
-</p>
-
-<p align="center">
-  <a href="https://github.com/Lians-ai/Lians">
     <img src="docs/images/logo.png" width="320" alt="Lians">
   </a>
 </p>
 
+<p align="center"><strong>Persistent project memory for Claude Code, Codex, and Cursor.</strong></p>
+
 <p align="center">
+  <a href="docs/quickstart.md"><strong>Quickstart</strong></a> ·
   <a href="docs/install.md">Install</a> ·
-  <a href="docs/easy-install.md">Desktop preview</a> ·
   <a href="docs/">Docs</a> ·
   <a href="https://github.com/Lians-ai/Lians/issues">Issues</a>
 </p>
@@ -22,43 +18,71 @@
   <a href="https://www.npmjs.com/package/@lians-ai/lians"><img src="https://img.shields.io/npm/v/%40lians-ai%2Flians?label=npm" alt="npm version"></a>
   <a href="https://registry.modelcontextprotocol.io/?q=io.github.ebeirne%2Flians"><img src="https://img.shields.io/badge/MCP-Official%20Registry-blueviolet" alt="MCP Official Registry"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 license"></a>
-  <a href="https://github.com/Lians-ai/Lians/stargazers"><img src="https://img.shields.io/github/stars/Lians-ai/Lians?style=social" alt="Star Lians on GitHub"></a>
 </p>
 
-# Start a new AI coding session without re-explaining your project.
+## Stop re-explaining your project to AI
 
-**Use less context. Get more AI.**
+Save a project decision once. Lians recalls the relevant part in a later
+session—even when you switch supported AI tools—without replaying your entire
+chat history.
 
-Lians gives Claude Code, Codex, Cursor, and other AI tools the current project
-state they need to pick up where another session stopped. It keeps completed
-work, open work, decisions, constraints, and changed facts separate so the next
-agent can continue without repeating or reversing prior work.
+- **Continue across sessions.** Carry completed work, open work, decisions, and
+  constraints into a fresh task.
+- **Keep memory current.** Correct or supersede stale facts instead of letting
+  an agent revive an old decision.
+- **Stay in control.** Inspect, export, or permanently delete anything Lians
+  stores.
+- **Run locally.** The starter setup needs no Lians account, AI password, or
+  provider API key.
 
-Keep your current AI account, editor, and normal workflow. Lians runs locally
-between your work history and your AI tool.
+Lians works with your existing AI account and editor. It does not replace your
+model, enlarge its context window, or change its subscription quota.
 
-- Resume a project with what is complete, what is open, and what should happen next.
-- Stop agents from redoing completed work or reviving a superseded decision.
-- Give each new session a small, project-scoped handoff instead of a transcript dump.
-- Bind repository changes to the original task and produce a signed review receipt.
-- Turn thousands of research posts or browser events into one bounded brief.
-- Inspect, correct, export, or delete anything Lians saves.
-- Use one local memory store with multiple compatible AI tools.
+## See it in two chats
 
-Lians does not ask for your Claude, Cursor, or Codex password or provider API
-key. It does not enlarge a provider context window or change a subscription
-quota.
+In one chat:
 
-> **Cross-agent continuity beta:** the included Claude-to-Codex fixture recovers
-> **10/10 expected continuity facts**, presents **0 stale facts as current**, and
-> produces a **231-token handoff**. A live Windows Claude session also completed
-> the automatic `SessionEnd` to fresh Codex-hook path. These are bounded beta
-> results, not a claim that every live coding session extracts perfectly.
-> [Run the experiment](experiments/cross-agent-continuity/README.md).
+```text
+You: Remember that this project uses PostgreSQL, not SQLite.
+Lians: Saved for this project.
+```
 
-## See the handoff
+Open a new chat—or switch to another supported AI tool:
 
-A fresh agent receives a bounded continuation view like this:
+```text
+You: Which database should this feature use?
+Lians: PostgreSQL. The project explicitly excludes SQLite.
+```
+
+If that decision changes, correct it once and future current-state recall uses
+the replacement. [Watch the 33-second remember, reuse, and delete proof](https://github.com/Lians-ai/Lians/releases/download/lians-memory-openai-demo-v1.0.0/Lians-Memory-OpenAI-submission-demo-v1.0.0.mp4).
+
+## Try it in two minutes
+
+Choose the AI tool you already use:
+
+| Tool | Fastest setup |
+|---|---|
+| Codex app, CLI, or IDE | [One command](integrations/codex) |
+| Claude Code | [Two plugin commands](integrations/lians-plugin) |
+| Cursor | [One-click MCP install](integrations/cursor) |
+| Other MCP clients | [Minimal MCP setup](docs/install.md#existing-ai-client-use-mcp) |
+
+For example, after [installing `uv`](https://docs.astral.sh/uv/getting-started/installation/), connect Codex with:
+
+```bash
+codex mcp add lians --env LIANS_MCP_ENABLED_TOOLS=remember,recall,list_memories,correct_memory,forget_memory -- uvx --from "lians-sdk[mcp]" lians-mcp
+```
+
+Restart Codex, then try the two-chat example above. Local memory is stored in
+`~/.lians/mcp.db` by default.
+
+[Follow the complete quickstart](docs/quickstart.md) for setup, verification,
+correction, deletion, and troubleshooting.
+
+## What a fresh coding agent receives
+
+Lians can generate a bounded project handoff instead of replaying a transcript:
 
 ```text
 Completed:
@@ -74,163 +98,49 @@ Decisions:
 Changed:
 - /v1/orders is stale; use /v2/orders
 
-Do NOT:
-- redo the migration
-- replace pytest with unittest
-
 Next:
 - update documentation before touching unrelated UI
 ```
 
-The handoff is derived from current Lians state. It is not a manually maintained
-summary and it does not expose the full session transcript.
+The handoff is derived from current Lians state, not a manually maintained
+summary.
 
-## Try saved memory in two chats
+## Project status
 
-Choose the AI tool you already use:
-
-| Tool | Fastest setup |
-|---|---|
-| Cursor | [One-click MCP install](integrations/cursor) |
-| Claude Code | [Two plugin commands](integrations/lians-plugin) |
-| Codex app, CLI, or IDE | [One-command MCP setup](integrations/codex) |
-| Other MCP clients | [Minimal local MCP configuration](#minimal-local-mcp-setup) |
-
-Then tell the AI tool:
-
-```text
-Remember that this project uses Python 3.12 and pytest.
-```
-
-Open a new chat in the same project and ask:
-
-```text
-What Python version and test runner does this project use?
-```
-
-Lians can supply the saved detail without replaying the previous chat.
-
-If that saved detail later changes, Lians can mark dependent memories and work
-for review, keep stale memory out of normal recall, and give every connected AI
-the same current replacement state.
-
-[Watch the 33-second remember, reuse, and delete proof](https://github.com/Lians-ai/Lians/releases/download/lians-memory-openai-demo-v1.0.0/Lians-Memory-OpenAI-submission-demo-v1.0.0.mp4).
-
-## Verify agent work before you ship it
-
-For repository work, a connected agent can create a task contract, restrict the
-approved file scope, map changed files back to success criteria, and request a
-signed Lians verification receipt before claiming completion. Lians checks the
-actual Git diff, whitespace integrity, current-state invalidations, recorded
-task evidence, required check attestations, credential patterns, and common
-high-risk code patterns.
-
-The receipt binds those measured facts to the base commit and exact diff hash.
-It does not ask a model to grade its own work, run arbitrary project commands,
-or claim that semantic correctness has been formally proven. Test output
-provided by an agent is labeled caller-attested, and every passing result still
-requires a human ship decision.
-
-For bounded critical logic, Lians can also exhaustively prove a declared finite
-model, reject vacuous assumptions, return a concrete counterexample, and bind
-the proof plus source hashes into the same receipt. A second backend proves an
-actual restricted pure Python function across every declared finite input
-without importing or executing it. These are bounded proofs, not a claim that
-an arbitrary application is completely correct. [Read the formal verification
-boundary and manifest format](docs/formal-verification.md).
-
-## Compress a large workday
-
-Compile a JSON or JSON Lines export locally before giving it to Claude or
-Codex:
-
-```bash
-lians brief research posts.jsonl --output research-brief.json
-lians brief browser browser-events.jsonl --output browser-brief.json
-```
-
-Lians removes repeated research text and superseded browser states, preserves
-representative evidence, and writes a hash receipt. Raw records are not sent to
-an AI provider. Credential-like records are refused.
-
-The brief compiler is currently available from a source checkout while the
-consumer package is being tested.
-
-## What is available
+Lians is under active development. Start with local memory; preview features
+are clearly labeled so you can choose the appropriate risk level.
 
 | Capability | Status |
 |---|---|
-| Free local memory through MCP and Python | Available |
-| Cursor, Claude Code, Codex, Gemini, Antigravity, Windsurf, Cline, and OpenCode setup | Available |
-| Local research and browser brief compiler | Available from source |
-| Automatic project-scoped Claude-to-Codex continuity | Beta, live hook and fixture tested |
+| Local memory through MCP and Python | Available |
+| Codex, Claude Code, and Cursor setup paths | Available |
+| Inspect, correct, and confirmed permanent deletion | Available |
 | Bounded context and signed selection receipts | Available |
-| State-change blast radius and bounded repair briefs | Beta candidate |
-| Git-scoped task verification and signed review receipts | Beta candidate |
-| Exhaustive finite-model proofs with counterexamples | Beta candidate |
-| Bounded proofs over actual restricted Python functions | Beta candidate |
+| Automatic Claude-to-Codex project handoff | Beta |
 | Guided desktop installer and local control center | Release candidate |
 | Managed cross-device continuity | Technical preview |
 
-The Windows and macOS desktop builds are tested release candidates. General
-consumer promotion remains gated on Windows publisher signing and Apple
-Developer ID signing and notarization. Read the
-[desktop preview boundary](docs/easy-install.md).
+The macOS and Windows desktop builds remain release candidates pending platform
+signing and notarization. See the [desktop preview boundary](docs/easy-install.md).
 
-## Measured results
+## Evidence
 
-The cross-agent continuity fixture captured current project truth, work state,
-decisions, constraints, and one superseded route. A fresh Codex handoff selected
-11 useful items in an estimated 231 tokens, recovered all 10 expected facts, and
-excluded the stale route from current state. The evaluator and fixture are
-[included in the repository](experiments/cross-agent-continuity/README.md).
+The included Claude-to-Codex continuity fixture recovered **10/10 expected
+facts**, exposed **0 stale facts as current**, and produced a **231-token
+handoff**. These are bounded beta results, not a promise that every live coding
+session extracts perfectly. [Run the experiment](experiments/cross-agent-continuity/README.md).
 
-The installed Claude integration now captures a compact continuity checkpoint at
-`SessionEnd`; it reads a bounded transcript tail as evidence and never stores the
-transcript as memory. A live Windows gate carried completed work, an unfinished
-README update, the pytest decision, and the current v2 route into the candidate
-Codex hook while marking v1 stale. Repeated multi-repository behavior testing
-remains necessary before any general-availability claim.
+A separate live test saved a synthetic project fact through Cursor, recalled it
+in a new Cursor chat and a fresh Claude Code session, and confirmed it was gone
+after deletion. [Read the test method](docs/benchmarks/cross-agent-memory-2026-08-14.md).
 
-In four bounded paired synthetic workloads, signed-in Claude Code and Codex
-returned the exact expected answer while Lians used **79.9% to 96.7% fewer
-provider-reported input tokens**. That equals **4.96x to 30.21x work per input
-token** on the tested social-research and browser-history fixtures.
+Four paired synthetic workloads also returned the exact expected answer while
+using **79.9% to 96.7% fewer provider-reported input tokens**. Results depend on
+the workload and do not guarantee lower usage or cost. [Read the benchmark](docs/benchmarks/work-per-token-2026-08-16.md).
 
-Separate compiled-only checks processed 10,000 posts and 2,400 browser events.
-These are bounded synthetic results, not a promise that every workflow, plan,
-quota, or bill will improve by the same amount.
+## Build with Lians
 
-[Read the method and machine-readable reports](docs/benchmarks/work-per-token-2026-08-16.md).
-
-A separate live test saved one synthetic project fact through Cursor, recalled
-it in a new Cursor chat and a fresh Claude Code session, then confirmed it was
-gone after deletion. [Read the cross-agent test](docs/benchmarks/cross-agent-memory-2026-08-14.md).
-
-## Minimal local MCP setup
-
-Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then add
-this server to an MCP-compatible AI tool:
-
-```json
-{
-  "mcpServers": {
-    "lians": {
-      "command": "uvx",
-      "args": ["--from", "lians-sdk[mcp]", "lians-mcp"],
-      "env": {
-        "LIANS_MCP_ENABLED_TOOLS": "remember,recall,list_memories,correct_memory,forget_memory"
-      }
-    }
-  }
-}
-```
-
-Restart the AI tool. Local memory is stored in `~/.lians/mcp.db`. No Lians
-account, Docker service, or provider API key is required. The first use may
-download the local semantic model.
-
-## Use Lians inside an application
+Use the local Python SDK inside an application:
 
 ```bash
 pip install "lians-sdk[local]"
@@ -253,27 +163,29 @@ result = memory.recall(
 )
 ```
 
-See the [full install guide](docs/install.md) for TypeScript, Go, Java, C,
-framework integrations, and self-hosting.
+See the [install guide](docs/install.md) for TypeScript, Go, Java, C, framework
+integrations, and self-hosting.
 
 Running a class, club, hackathon, or campus developer group? Use the
-[student and community kit](docs/student-community-kit.md). If you cloned the
-monorepo and need to identify the current packages, start with
+[student and community kit](docs/student-community-kit.md). Contributors and
+package integrators can start with
 [Supported paths and repository status](docs/supported-paths.md).
 
 <details>
-<summary><strong>Advanced memory and governance</strong></summary>
+<summary><strong>Advanced capabilities</strong></summary>
 
-Lians can supersede stale facts, reconstruct point-in-time state, inspect
-lineage and conflicts, maintain tamper-evident audit history, enforce
-information barriers, and perform confirmed erasure. Encrypted backups and
-opaque device sync preserve the dependency graph as well as the memories, so
-stale-work protections survive a move to another machine.
+Lians also includes tools for project-scoped agent handoffs, signed selection
+and review receipts, local research and browser briefs, temporal reconstruction,
+lineage, information barriers, confirmed erasure, and bounded formal checks.
+These capabilities are useful for advanced or governed deployments but are not
+required for the starter memory workflow.
 
 - [Memory engine](docs/memory-engine.md)
-- [Decision evidence](docs/decision-evidence.md)
+- [Cross-agent continuity experiment](experiments/cross-agent-continuity/README.md)
+- [Agent-work verification](docs/formal-verification.md)
 - [Security model](docs/security-whitepaper.md)
 - [Community and managed product boundary](docs/community-cloud-boundary.md)
+- [Supported paths and repository status](docs/supported-paths.md)
 
 </details>
 
@@ -286,8 +198,8 @@ python -m pip install -e ".[dev]"
 python scripts/test_all.py
 ```
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) for focused test commands and project
-conventions. Ask questions or report problems in
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Feature
+ideas, integration requests, and reproducible bugs are welcome in
 [GitHub Issues](https://github.com/Lians-ai/Lians/issues).
 
 If Lians helps your workflow, [star the repository](https://github.com/Lians-ai/Lians/stargazers)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,23 +1,25 @@
 # Lians product roadmap
 
-Lians is the memory tool for any AI agent. The near-term product goal is simple:
-a normal person should be able to install it, understand what was remembered,
-and carry useful context between supported AI clients.
+Lians provides persistent project memory for AI coding tools. The near-term
+product goal is simple: a developer should be able to install it in minutes,
+understand what was remembered, and carry current project context between
+supported AI clients.
 
 This roadmap communicates priorities, not contractual release dates.
 
 ## Now
 
-- Ship the guided Lians Easy installer for Windows, macOS, and Linux.
+- Make the Codex, Claude Code, and Cursor quickstarts reliable on clean machines.
+- Ship signed and notarized Lians Easy installers for Windows and macOS.
 - Keep `remember`, `recall`, `list`, `correct`, and confirmed `forget`
   consistent across the desktop runtime, MCP, HTTP, Python, and TypeScript.
 - Prove that two different AI clients can use one local memory profile.
-- Make the README, demos, package metadata, and release artifacts tell one
-  product story.
+- Keep the README, demos, package metadata, and releases focused on persistent
+  project memory before introducing advanced capabilities.
 
 ## Next
 
-- Add a visual memory manager for people who do not want to ask an agent to
+- Add a visual memory manager for developers who do not want to ask an agent to
   inspect or correct saved information.
 - Publish a hosted connector for clients such as ChatGPT and for multi-device
   continuity.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,97 @@
+# Lians quickstart
+
+Give an AI coding tool one project fact, open a fresh chat, and confirm that the
+fact is recalled. The local setup requires no Lians account or provider API key.
+
+## 1. Choose a client
+
+### Codex
+
+Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then run:
+
+```bash
+codex mcp add lians --env LIANS_MCP_ENABLED_TOOLS=remember,recall,list_memories,correct_memory,forget_memory -- uvx --from "lians-sdk[mcp]" lians-mcp
+```
+
+Restart Codex. Run `codex mcp list` or type `/mcp` in the terminal UI to confirm
+that `lians` is connected.
+
+### Claude Code
+
+Run these commands inside Claude Code:
+
+```text
+/plugin marketplace add Lians-ai/Lians
+/plugin install lians@lians-plugins
+```
+
+Restart Claude Code after installation.
+
+### Cursor
+
+Use the [one-click Cursor installer](../integrations/cursor), review the local
+MCP configuration, and approve it in Cursor.
+
+For another MCP client, follow the [generic MCP setup](install.md#existing-ai-client-use-mcp).
+
+## 2. Save one safe project fact
+
+In a project chat, say:
+
+```text
+Remember that this project uses Python 3.12 and pytest.
+```
+
+Approve the `remember` tool if your client asks. Do not use passwords, API keys,
+personal data, or other secrets as test values.
+
+## 3. Recall it in a fresh chat
+
+Open a new chat in the same project and ask:
+
+```text
+What Python version and test runner does this project use?
+```
+
+Approve the `recall` tool if prompted. The answer should mention Python 3.12
+and pytest without requiring the previous transcript.
+
+## 4. Correct the memory
+
+Say:
+
+```text
+Correct that memory: this project now uses Python 3.13 and pytest.
+```
+
+Open another fresh chat and ask the same question. Current-state recall should
+use Python 3.13 rather than presenting Python 3.12 as current.
+
+## 5. Inspect or delete saved memory
+
+Ask your AI tool to list the project's Lians memories. To remove the test fact,
+ask it to permanently forget that memory and confirm the deletion when prompted.
+
+Deletion is intentionally explicit. Confirm that the correct memory reference
+is selected before approving it.
+
+## Where local data is stored
+
+The basic MCP setup stores local memory in `~/.lians/mcp.db`. Set
+`LIANS_LOCAL_DB` in the MCP server environment to choose another location.
+
+Lians does not ask for your Claude, Cursor, or Codex password or provider API
+key. The first use may download a local semantic model.
+
+## Troubleshooting
+
+- Confirm that `uvx` runs in a terminal.
+- Restart the AI client after changing its MCP configuration.
+- Confirm that the `lians` or `lians-memory` server is connected in the client.
+- Allow extra time during the first run while the local model initializes.
+- If a write times out during initialization, retry it after the server is ready;
+  the timed-out write is not queued.
+
+For client-specific details, see the [Codex](../integrations/codex),
+[Claude Code](../integrations/lians-plugin), and
+[Cursor](../integrations/cursor) guides.

--- a/product-manifest.json
+++ b/product-manifest.json
@@ -1,26 +1,26 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-14",
+  "updatedAt": "2026-08-18",
   "source": {
     "repository": "Lians-ai/Lians",
     "branch": "master"
   },
   "product": {
     "name": "Lians",
-    "category": "AI efficiency for the tools you already use",
-    "summary": "Lians helps Claude, Cursor, Codex, and other AI tools avoid rereading the same project context. Connect an existing app, keep working normally, and Lians reuses a small amount of relevant saved context while leaving the rest out. Local mode is free, encrypted on the device, and does not require an AI account password or provider API key.",
+    "category": "Persistent project memory for AI coding tools",
+    "summary": "Lians gives Claude Code, Codex, Cursor, and other compatible AI tools current project memory across sessions. Save a useful fact, decision, constraint, or work state once; Lians recalls a small relevant subset later and keeps superseded facts out of current-state answers. Local mode is free and does not require an AI account password or provider API key.",
     "workflow": [
       {
-        "label": "Optimize",
-        "detail": "Lians detects supported AI apps and adds its local context connection without replacing the user's model, editor, or workflow."
+        "label": "Connect",
+        "detail": "Connect Lians to a supported AI coding tool without replacing the user's model, editor, or workflow."
       },
       {
         "label": "Work normally",
         "detail": "The user saves a useful preference, fact, constraint, or decision once and continues working in the AI tools they already use."
       },
       {
-        "label": "Reuse less",
-        "detail": "For a later task, Lians selects a bounded set of relevant current context instead of replaying the full saved history."
+        "label": "Continue",
+        "detail": "In a later session or compatible AI tool, Lians selects a bounded set of relevant current project context instead of replaying the full history."
       },
       {
         "label": "See the proof",


### PR DESCRIPTION
## What changed

- focuses the README on persistent project memory for Claude Code, Codex, and Cursor
- adds a two-minute quickstart covering install, recall, correction, deletion, and troubleshooting
- separates available, beta, release-candidate, and technical-preview capabilities
- aligns the roadmap and product manifest with the same developer-first positioning
- adds a structured first-run feedback issue template
- updates the public repository description for clearer GitHub discovery

## Why

The repository exposed several valuable capabilities at once, which made the primary job harder to understand. This change gives first-time visitors one customer, one problem, one demonstration, and one path to activation while retaining advanced technical material behind links.

## User impact

A developer can now understand Lians quickly, connect a supported AI coding tool, complete the first memory loop, and know which capabilities are production-ready versus preview.

## Validation

- `git diff --check`
- local Markdown link resolution
- JSON parsing for `product-manifest.json`
- 11 focused product-manifest and distribution contract checks
- GitHub rendered-preview inspection on the branch

## Product record

- [x] Updated `product-manifest.json` for the positioning and workflow change
